### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.1.1] - 2026-06-20\n\n### Added\n- add changelog automation with GitHub Actions\n- add changelog automation with GitHub Actions\n- add version command (version, --version, -v) (#4)\n\n### Fixed\n- delete existing branch before creating new one\n- restructure release-prep workflow YAML and use PAT_TOKEN\n- resolve YAML syntax error in release-prep workflow and fix script for Linux compatibility\n- list command now includes project-scoped skills (#3)\n\n### Other\n- Update README
 ## [v0.1.0] - 2025-01-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolecraft",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Install AI agent skills as roles & behaviors directly from any source — zero-dependency CLI for opencode, claude-code, cursor, and more",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This PR updates the changelog and version for `v0.1.1`.

## Changes
- Updated CHANGELOG.md with changes since the previous tag
- Updated package.json version to `v0.1.1`

> Auto-generated by the release-prep workflow.
