### PR TITLE
docs: add contributing guide and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Only the repository owner can approve and merge PRs
+* @sametcelikbicak

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to RoleCraft
+
+Thanks for your interest in contributing! Here's how you can help.
+
+## How to Contribute
+
+### 1. Fork & Branch
+
+- Fork the repo and create your branch from `main`
+- Use a descriptive branch name: `feat/my-feature`, `fix/my-bug`, `docs/my-update`
+
+### 2. Make Changes
+
+- Keep changes focused on a single concern
+- Follow existing code style (no semicolons, ES modules)
+- Add or update tests for any new functionality
+
+### 3. Test
+
+```bash
+npm test
+```
+
+Make sure all tests pass before submitting.
+
+### 4. Commit
+
+Use conventional commit messages:
+
+```
+feat: add new feature
+fix: correct bug in parser
+docs: update installation guide
+chore: bump dependencies
+```
+
+### 5. Pull Request
+
+- Push your branch and open a PR against `main`
+- Write a clear title and description explaining what and why
+- Link any related issues
+
+### 6. Review & Merge
+
+- Only the repository owner (`sametcelikbicak`) can review and merge PRs
+- PRs are squash-merged to keep history clean
+- After merge, CI automatically publishes to npm if a new version tag exists
+
+## Release Process
+
+Only maintainers can create releases:
+
+1. Ensure all desired changes are merged to `main`
+2. Create and push a version tag: `git tag v0.X.Y && git push origin v0.X.Y`
+3. GitHub Actions handles the rest:
+   - Changelog is generated automatically
+   - A release PR is created
+   - After PR merge, the package is published to npm
+
+## Code of Conduct
+
+Be respectful and constructive. Keep discussions focused on the code.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 
 # RoleCraft — Simple Skill Installer for AI
 
- [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
- [![npm](https://img.shields.io/npm/v/rolecraft)](https://www.npmjs.com/package/rolecraft)
- [![GitHub Stars](https://img.shields.io/github/stars/sametcelikbicak/rolecraft?style=social)](https://github.com/sametcelikbicak/rolecraft)
- [![Changelog](https://img.shields.io/badge/📜-Changelog-blue)](CHANGELOG.md)
+[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+[![npm](https://img.shields.io/npm/v/rolecraft)](https://www.npmjs.com/package/rolecraft)
+[![GitHub Stars](https://img.shields.io/github/stars/sametcelikbicak/rolecraft?style=social)](https://github.com/sametcelikbicak/rolecraft)
+[![Changelog](https://img.shields.io/badge/📜-Changelog-blue)](CHANGELOG.md)
+[![Contributing](https://img.shields.io/badge/🤝-Contributing-green)](CONTRIBUTING.md)
 
  </div>
 
@@ -106,7 +107,7 @@ The CLI clones with `--depth 1`, finds `SKILL.md` recursively, installs it, and 
 | `rolecraft list`             | Show all installed skills         |
 | `rolecraft remove <slug>`    | Uninstall a skill                 |
 | `rolecraft help`             | Show this help                    |
-| `rolecraft version`          | Show version (`--version`, `-v`) |
+| `rolecraft version`          | Show version (`--version`, `-v`)  |
 
 ## Project structure
 
@@ -123,9 +124,14 @@ rolecraft/
 │       ├── installer.js      # copy files to target dirs
 │       └── lockfile.js       # read/write .skill-lock.json
 ├── package.json
-├── CHANGELOG.md               # Release history
+├── CHANGELOG.md              # Release history
+├── CONTRIBUTING.md           # Contribution guide
 └── README.md
 ```
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary

This PR adds contribution guidelines and restricts merge权限 to the repository owner.

### Changes
- **CONTRIBUTING.md** — step-by-step guide for contributors (branch, commit, PR, review, release)
- **.github/CODEOWNERS** — set `@sametcelikbicak` as code owner for all files
- **README.md** — added contributing badge, section, and project structure entry
- **Branch protection** — `main` branch requires 1 approving review before merge