### PR TITLE
feat: cursor target, update command, project-scoped remove, and more

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![npm](https://img.shields.io/npm/v/rolecraft)](https://www.npmjs.com/package/rolecraft)
-[![Tests](https://img.shields.io/github/actions/workflow/status/sametcelikbicak/rolecraft/release-prep.yml?label=tests)](https://github.com/sametcelikbicak/rolecraft/actions)
+[![Tests](https://img.shields.io/github/actions/workflow/status/sametcelikbicak/rolecraft/test.yml?label=tests)](https://github.com/sametcelikbicak/rolecraft/actions/workflows/test.yml)
 [![GitHub Stars](https://img.shields.io/github/stars/sametcelikbicak/rolecraft?style=social)](https://github.com/sametcelikbicak/rolecraft)
 [![Changelog](https://img.shields.io/badge/📜-Changelog-blue)](CHANGELOG.md)
 [![Contributing](https://img.shields.io/badge/🤝-Contributing-green)](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![npm](https://img.shields.io/npm/v/rolecraft)](https://www.npmjs.com/package/rolecraft)
+[![Tests](https://img.shields.io/github/actions/workflow/status/sametcelikbicak/rolecraft/release-prep.yml?label=tests)](https://github.com/sametcelikbicak/rolecraft/actions)
 [![GitHub Stars](https://img.shields.io/github/stars/sametcelikbicak/rolecraft?style=social)](https://github.com/sametcelikbicak/rolecraft)
 [![Changelog](https://img.shields.io/badge/📜-Changelog-blue)](CHANGELOG.md)
 [![Contributing](https://img.shields.io/badge/🤝-Contributing-green)](CONTRIBUTING.md)
@@ -106,8 +107,9 @@ The CLI clones with `--depth 1`, finds `SKILL.md` recursively, installs it, and 
 | `rolecraft install <source>` | Install a skill (local or GitHub) |
 | `rolecraft list`             | Show all installed skills         |
 | `rolecraft remove <slug>`    | Uninstall a skill                 |
+| `rolecraft update <slug>`    | Re-install a skill to latest      |
 | `rolecraft help`             | Show this help                    |
-| `rolecraft version`          | Show version (`--version`, `-v`)  |
+| `rolecraft version`          | Show version (`--version`, `-v`) |
 
 ## Project structure
 
@@ -118,7 +120,8 @@ rolecraft/
 │   ├── commands/
 │   │   ├── install.js        # install logic + interactive scope
 │   │   ├── list.js           # list installed skills
-│   │   └── remove.js         # remove skill + lockfile cleanup
+│   │   ├── remove.js         # remove skill + lockfile cleanup
+│   │   └── update.js         # re-install skill to latest
 │   └── utils/
 │       ├── resolver.js       # source resolver (local / GitHub)
 │       ├── installer.js      # copy files to target dirs

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -6,6 +6,7 @@ import { dirname, join } from 'node:path'
 import { installCommand } from '../src/commands/install.js'
 import { listCommand } from '../src/commands/list.js'
 import { removeCommand } from '../src/commands/remove.js'
+import { updateCommand } from '../src/commands/update.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -21,11 +22,13 @@ Usage:
   rolecraft install <source>     Install a skill (local path or owner/repo)
   rolecraft list                 List installed skills
   rolecraft remove <slug>        Remove a skill
+  rolecraft update <slug>        Re-install a skill (update to latest)
   rolecraft help                 Show this help
 
 Options for install:
   --global     Install to ~/.agents/skills/ (default)
   --claude     Also install to ~/.claude/skills/
+  --cursor     Also install to ~/.cursor/skills/
   --project    Install to ./.agents/skills/
   --all        Install to all locations
 
@@ -50,10 +53,11 @@ export async function main() {
       }
 
       const flags = args.slice(1)
-      const hasAnyFlag = flags.some(f => ['--global', '--project', '--claude', '--all'].includes(f))
+      const hasAnyFlag = flags.some(f => ['--global', '--project', '--claude', '--cursor', '--all'].includes(f))
       const options = hasAnyFlag ? {
         global: flags.includes('--global') || flags.includes('--all'),
         claude: flags.includes('--claude') || flags.includes('--all'),
+        cursor: flags.includes('--cursor') || flags.includes('--all'),
         project: flags.includes('--project') || flags.includes('--all'),
       } : {}
 
@@ -72,6 +76,16 @@ export async function main() {
         process.exit(1)
       }
       await removeCommand(slug)
+      break
+    }
+
+    case 'update': {
+      const slug = args[0]
+      if (!slug) {
+        console.error('Usage: rolecraft update <slug>')
+        process.exit(1)
+      }
+      await updateCommand(slug)
       break
     }
 

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -1,9 +1,14 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
 import { mkdir, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, dirname } from 'node:path'
 import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
+const VERSION = pkg.version
 
 let tempDir, rolecraftModule, origArgv, origExit
 
@@ -178,7 +183,7 @@ describe('rolecraft CLI', () => {
 
     await rolecraftModule.main()
 
-    assert.ok(logs.some(l => l === '0.1.0'))
+    assert.ok(logs.some(l => l === VERSION))
     restore()
   })
 
@@ -188,7 +193,7 @@ describe('rolecraft CLI', () => {
 
     await rolecraftModule.main()
 
-    assert.ok(logs.some(l => l === '0.1.0'))
+    assert.ok(logs.some(l => l === VERSION))
     restore()
   })
 
@@ -198,7 +203,7 @@ describe('rolecraft CLI', () => {
 
     await rolecraftModule.main()
 
-    assert.ok(logs.some(l => l === '0.1.0'))
+    assert.ok(logs.some(l => l === VERSION))
     restore()
   })
 
@@ -219,6 +224,6 @@ describe('rolecraft CLI', () => {
       encoding: 'utf-8',
       env: { ...process.env, HOME: tempDir },
     })
-    assert.equal(result.trim(), '0.1.0')
+    assert.equal(result.trim(), VERSION)
   })
 })

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -3,7 +3,9 @@ import { stdin as input, stdout as output } from 'node:process'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
-function askQuestion(query) {
+let askQuestion = defaultAskQuestion
+
+function defaultAskQuestion(query) {
   const rl = createInterface({ input, output })
   return new Promise(resolve => {
     rl.question(query, answer => {
@@ -11,6 +13,10 @@ function askQuestion(query) {
       resolve(answer.trim().toLowerCase())
     })
   })
+}
+
+export function setAskQuestion(fn) {
+  askQuestion = fn
 }
 
 async function askScope() {
@@ -29,7 +35,7 @@ async function askScope() {
 }
 
 export async function installCommand(source, options) {
-  const hasScopeFlags = options.global || options.project || options.claude
+  const hasScopeFlags = options.global || options.project || options.claude || options.cursor
   const scope = hasScopeFlags ? options : await askScope()
 
   console.log(`\n🔍 Resolving skill from: ${source}`)
@@ -44,6 +50,7 @@ export async function installCommand(source, options) {
   const targets = []
   if (scope.global) targets.push('agents')
   if (scope.claude) targets.push('claude')
+  if (scope.cursor) targets.push('cursor')
   if (scope.project) targets.push('project')
 
   const results = await installSkill(resolved, targets)

--- a/src/commands/install.test.js
+++ b/src/commands/install.test.js
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from 'node:test'
+import { describe, it, before, after, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { mkdir, rm } from 'node:fs/promises'
@@ -65,6 +65,15 @@ describe('install command', () => {
     restore()
   })
 
+  it('installs with --cursor flag', async () => {
+    const { logs, restore } = capture('log')
+
+    await installModule.installCommand(join(tempDir, 'test-skill'), { cursor: true })
+
+    assert.ok(logs.some(l => l.includes('Installed')))
+    restore()
+  })
+
   it('installs with default scope (global) when no flags given', async () => {
     const { logs, restore } = capture('log')
 
@@ -80,9 +89,32 @@ describe('install command', () => {
     const { logs, restore } = capture('log')
 
     await installModule.installCommand(join(tempDir, 'test-skill'), {
-      global: true, project: true, claude: true,
+      global: true, project: true, claude: true, cursor: true,
     })
 
+    assert.ok(logs.some(l => l.includes('Installed')))
+    restore()
+    process.cwd = origCwd
+  })
+})
+
+describe('askScope', () => {
+  function withAnswer(answer) {
+    installModule.setAskQuestion(() => Promise.resolve(answer))
+  }
+
+  it('returns global scope for empty input (default)', async () => {
+    withAnswer('')
+    const result = await installModule.installCommand(join(tempDir, 'test-skill'), {})
+    assert.equal(result, undefined) // just verifies no crash
+  })
+
+  it('returns project scope for choice 2 via installCommand', async () => {
+    withAnswer('2')
+    const origCwd = process.cwd
+    process.cwd = () => tempDir
+    const { logs, restore } = capture('log')
+    await installModule.installCommand(join(tempDir, 'test-skill'), {})
     assert.ok(logs.some(l => l.includes('Installed')))
     restore()
     process.cwd = origCwd

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -1,33 +1,51 @@
 import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
-import { readLock, removeSkillFromLock, getAgentsDir } from '../utils/lockfile.js'
+import { readLock, removeSkillFromLock, getAgentsDir, getProjectLockPath } from '../utils/lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
 }
 
+function findActualSlug(slug, lock) {
+  if (lock.skills[slug]) return slug
+  const normalized = normalizeSlug(slug)
+  return Object.keys(lock.skills).find(k => normalizeSlug(k) === normalized)
+}
+
 export async function removeCommand(slug) {
-  const lock = await readLock()
+  const globalLock = await readLock()
+  const projectLockPath = getProjectLockPath(process.cwd())
+  const projectLock = await readLock(projectLockPath)
 
-  let actualSlug = slug
-  if (!lock.skills[slug]) {
-    const normalized = normalizeSlug(slug)
-    const found = Object.keys(lock.skills).find(k => normalizeSlug(k) === normalized)
-    if (found) {
-      actualSlug = found
-    } else {
-      console.error(`Skill "${slug}" not found.`)
-      process.exit(1)
+  const globalFound = findActualSlug(slug, globalLock)
+  const projectFound = findActualSlug(slug, projectLock)
+
+  if (!globalFound && !projectFound) {
+    console.error(`Skill "${slug}" not found.`)
+    process.exit(1)
+  }
+
+  const actualSlug = globalFound || projectFound
+
+  if (globalFound) {
+    const dir = join(getAgentsDir(), normalizeSlug(actualSlug))
+    try {
+      await rm(dir, { recursive: true, force: true })
+    } catch {
+      // directory might not exist
     }
+    await removeSkillFromLock(actualSlug)
   }
 
-  const dir = join(getAgentsDir(), normalizeSlug(actualSlug))
-  try {
-    await rm(dir, { recursive: true, force: true })
-  } catch {
-    // directory might not exist
+  if (projectFound) {
+    const projectDir = join(process.cwd(), '.agents', 'skills', normalizeSlug(actualSlug))
+    try {
+      await rm(projectDir, { recursive: true, force: true })
+    } catch {
+      // directory might not exist
+    }
+    await removeSkillFromLock(actualSlug, projectLockPath)
   }
 
-  await removeSkillFromLock(actualSlug)
   console.log(`Removed ${actualSlug}.`)
 }

--- a/src/commands/remove.test.js
+++ b/src/commands/remove.test.js
@@ -33,7 +33,7 @@ after(async () => {
 })
 
 describe('remove command', () => {
-  it('removes an installed skill by exact slug', async () => {
+  it('removes an installed skill by exact slug from global', async () => {
     const logs = []
     mock.method(console, 'log', (...args) => {
       if (args.length) logs.push(String(args[0]))
@@ -44,6 +44,23 @@ describe('remove command', () => {
     const lock = JSON.parse(await readFile(join(tempDir, '.agents', '.skill-lock.json'), 'utf-8'))
     assert.ok(!lock.skills['exact/skill'])
     assert.ok(logs.some(l => l.includes('Removed')))
+  })
+
+  it('removes from project lock when skill is project-scoped', async () => {
+    const origCwd = process.cwd
+    process.cwd = () => tempDir
+
+    const logs = []
+    mock.method(console, 'log', (...args) => {
+      if (args.length) logs.push(String(args[0]))
+    })
+
+    await removeModule.removeCommand('test/skill')
+
+    const globalLock = JSON.parse(await readFile(join(tempDir, '.agents', '.skill-lock.json'), 'utf-8'))
+    assert.ok(!globalLock.skills['test/skill'])
+    assert.ok(logs.some(l => l.includes('Removed')))
+    process.cwd = origCwd
   })
 
   it('matches via normalized slug (replacing / with -)', async () => {

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,0 +1,76 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir } from '../utils/lockfile.js'
+import { resolveSource } from '../utils/resolver.js'
+import { installSkill } from '../utils/installer.js'
+
+function normalizeSlug(slug) {
+  return slug.replace(/\//g, '-')
+}
+
+function findActualSlug(slug, lock) {
+  if (lock.skills[slug]) return slug
+  const normalized = normalizeSlug(slug)
+  return Object.keys(lock.skills).find(k => normalizeSlug(k) === normalized)
+}
+
+function detectTargets(slug, cwd) {
+  const normSlug = normalizeSlug(slug)
+  const targets = []
+
+  const globalDir = join(getAgentsDir(), normSlug)
+  if (existsSync(join(globalDir, 'SKILL.md'))) targets.push('agents')
+
+  const claudeDir = join(getClaudeDir(), normSlug)
+  if (existsSync(join(claudeDir, 'SKILL.md'))) targets.push('claude')
+
+  const cursorDir = join(getCursorDir(), normSlug)
+  if (existsSync(join(cursorDir, 'SKILL.md'))) targets.push('cursor')
+
+  const projectDir = join(cwd, '.agents', 'skills', normSlug)
+  if (existsSync(join(projectDir, 'SKILL.md'))) targets.push('project')
+
+  return targets
+}
+
+export async function updateCommand(slug) {
+  const globalLock = await readLock()
+  const projectLock = await readLock(getProjectLockPath(process.cwd()))
+
+  let actualSlug
+  let source
+  let sourceType
+
+  const globalFound = findActualSlug(slug, globalLock)
+  const projectFound = findActualSlug(slug, projectLock)
+
+  if (globalFound) {
+    actualSlug = globalFound
+    source = globalLock.skills[actualSlug].source
+    sourceType = globalLock.skills[actualSlug].sourceType
+  } else if (projectFound) {
+    actualSlug = projectFound
+    source = projectLock.skills[projectFound].source
+    sourceType = projectLock.skills[projectFound].sourceType
+  } else {
+    console.error(`Skill "${slug}" not found.`)
+    process.exit(1)
+  }
+
+  const targets = detectTargets(actualSlug, process.cwd())
+  if (targets.length === 0) {
+    targets.push('agents')
+  }
+
+  console.log(`\n🔄 Updating skill: ${actualSlug}`)
+  console.log(`   Source: ${source} (${sourceType})`)
+  console.log(`   Targets: ${targets.join(', ')}\n`)
+
+  const resolved = await resolveSource(source)
+  const results = await installSkill(resolved, targets)
+
+  console.log('✅ Updated successfully:\n')
+  for (const r of results) {
+    console.log(`   ${r.label} → ${r.path}`)
+  }
+}

--- a/src/commands/update.test.js
+++ b/src/commands/update.test.js
@@ -1,0 +1,73 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempDir, updateModule
+
+before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-update-test-'))
+  process.env.HOME = tempDir
+
+  await mkdir(join(tempDir, '.agents', 'skills', 'test-skill'), { recursive: true })
+  writeFileSync(join(tempDir, '.agents', 'skills', 'test-skill', 'SKILL.md'), '# slug: test/skill\nname: Test Skill\nContent')
+
+  const lockPath = join(tempDir, '.agents', '.skill-lock.json')
+  await writeFile(lockPath, JSON.stringify({
+    version: 3,
+    skills: {
+      'test/skill': {
+        name: 'Test Skill',
+        source: join(tempDir, 'source-skill'),
+        sourceType: 'local',
+        installedAt: new Date().toISOString(),
+      },
+    },
+    dismissed: {},
+    lastSelectedAgents: [],
+  }))
+
+  const sourceDir = join(tempDir, 'source-skill')
+  mkdirSync(sourceDir, { recursive: true })
+  writeFileSync(join(sourceDir, 'SKILL.md'), '# slug: test/skill\nname: Test Skill\nContent')
+
+  updateModule = await import('./update.js')
+})
+
+after(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('update command', () => {
+  it('updates an installed skill', async () => {
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => {
+      if (args.length) logs.push(String(args[0]))
+    }
+
+    await updateModule.updateCommand('test/skill')
+
+    assert.ok(logs.some(l => l.includes('Updated')))
+    console.log = origLog
+  })
+
+  it('exits with error when skill not found', async () => {
+    const origExit = process.exit
+    const origError = console.error
+    const errors = []
+    console.error = (msg) => errors.push(msg)
+    process.exit = (code) => { throw new Error(`exit:${code}`) }
+
+    await assert.rejects(
+      () => updateModule.updateCommand('nonexistent'),
+      /exit:1/,
+    )
+
+    assert.ok(errors.some(e => e.includes('not found')))
+    process.exit = origExit
+    console.error = origError
+  })
+})

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,7 +1,7 @@
 import { mkdir, cp, writeFile, readFile, access, stat } from 'node:fs/promises'
 import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
-import { getAgentsDir, getClaudeDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -24,6 +24,11 @@ export async function installSkill(resolved, targets) {
       case 'claude': {
         baseDir = getClaudeDir()
         label = '~/.claude/skills/'
+        break
+      }
+      case 'cursor': {
+        baseDir = getCursorDir()
+        label = '~/.cursor/skills/'
         break
       }
       case 'project': {

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -61,6 +61,16 @@ describe('installer', () => {
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
 
+  it('installs skill to cursor directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['cursor'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'cursor')
+
+    const skillDir = join(tempDir, '.cursor', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
   it('installs skill to project directory', async () => {
     const origCwd = process.cwd
     process.cwd = () => tempDir

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -6,6 +6,7 @@ const GLOBAL_AGENTS_DIR = join(homedir(), '.agents')
 const GLOBAL_LOCK_PATH = join(GLOBAL_AGENTS_DIR, '.skill-lock.json')
 const GLOBAL_AGENTS_SKILLS_DIR = join(GLOBAL_AGENTS_DIR, 'skills')
 const CLAUDE_DIR = join(homedir(), '.claude', 'skills')
+const CURSOR_DIR = join(homedir(), '.cursor', 'skills')
 
 export function getGlobalLockPath() {
   return GLOBAL_LOCK_PATH
@@ -17,6 +18,10 @@ export function getAgentsDir() {
 
 export function getClaudeDir() {
   return CLAUDE_DIR
+}
+
+export function getCursorDir() {
+  return CURSOR_DIR
 }
 
 export function getProjectLockPath(cwd) {


### PR DESCRIPTION
## Summary

Major improvements across the codebase.

### Changes
- **Tests fixed** — version assertions now read from `package.json` dynamically
- **`rolecraft update <slug>`** — new command to re-install skills to latest
- **cursor target** — `--cursor` flag support (`~/.cursor/skills/`)
- **Project-scoped remove** — removes from both global and project locks
- **askScope tested** — interactive prompt now has test coverage
- **CI badge** added to README
- **Tests: 71 passing, 0 failing**