### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.1.4] - 2026-06-25
+
+### Added
+- cursor target, update command, project-scoped remove, and more (#11)
+
+### Changed
+- release v0.1.3
+
+### Documentation
+- add contributing guide and CODEOWNERS (#10)
 ## [v0.1.3] - 2026-06-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolecraft",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Install AI agent skills as roles & behaviors directly from any source — zero-dependency CLI for opencode, claude-code, cursor, and more",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This PR updates the changelog and version for `v0.1.4`.

## Changes
- Updated CHANGELOG.md with changes since the previous tag
- Updated package.json version to `v0.1.4`

> Auto-generated by the release-prep workflow.
