### PR TITLE
ci: enable npm provenance and add SECURITY.md

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -29,6 +30,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in rolecraft, please report it privately.
+
+**Do not** disclose the issue publicly until it has been addressed.
+
+To report a vulnerability, open a GitHub Security Advisory at:
+
+https://github.com/sametcelikbicak/rolecraft/security/advisories/new
+
+Or email the maintainer directly (see the committer history for contact).
+
+You should receive a response within 48 hours. If you don't, please follow up.
+
+## Scope
+
+This security policy covers:
+
+- The `rolecraft` CLI tool and its source code
+- The automated release pipeline (GitHub Actions workflows)
+- npm package integrity
+
+## Supported Versions
+
+Only the latest published version on npm receives security updates.
+
+## Supply Chain
+
+rolecraft has **zero runtime dependencies**. Security recommendations:
+
+- Always install from the official npm registry
+- Verify the package provenance (available since v0.1.5) via `npm audit --provenance`
+- Pin the version in production environments


### PR DESCRIPTION
## Summary

Supply Chain Security skorunu artırmak için:

### npm Provenance (SLSA Level 1+)
- `id-token: write` permission eklendi (OIDC token için)
- `npm publish --provenance` ile publish artık imzalı
- Socket.dev'de **"Provenance"** etiketi görünecek → Supply Chain skoruna ~10+ puan

### SECURITY.md
- Güvenlik açığı raporlama politikası
- Maintenance skoruna katkı (well-maintained sinyali)