### PR TITLE
feat: add windsurf, codex, copilot, aider, cline agent targets

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **Zero-dependency** CLI to install AI agent skills as roles & behaviors from any source. No marketplace, no registry, no signup — just point it at a local folder or a GitHub repo and it works.
 
-Works with **opencode**, **claude-code**, **cursor**, and all spec-compliant agents.
+Works with **opencode**, **claude-code**, **cursor**, **windsurf**, **codex**, **copilot**, **aider**, **cline**, and all spec-compliant agents.
 
 ## Why rolecraft?
 
@@ -23,9 +23,11 @@ Works with **opencode**, **claude-code**, **cursor**, and all spec-compliant age
 | Zero dependencies                 | ✅               | ✅              | ❌ (2)               |
 | Local path install                | ✅ **1st class** | ❌ GitHub only  | ❌ marketplace only  |
 | GitHub repo install               | ✅               | ✅              | ❌                   |
+| Agent targets                     | 9                | 68+             | 20+                  |
 | Offline capable                   | ✅               | ❌              | ❌                   |
 | agentskill.sh lockfile compatible | ✅               | ✅              | ✅                   |
 | Project-level install             | ✅               | ✅              | ✅                   |
+| npm provenance                    | ✅               | ❌              | ❌                   |
 | File size                         | ~3 KB            | ~500 KB+        | ~84 KB               |
 
 ## Install
@@ -39,11 +41,13 @@ npx rolecraft install <source>
 ## Usage
 
 ```bash
-rolecraft install ./path/to/my-skill          # install from local folder
+rolecraft install ./path/to/my-skill              # install from local folder
 rolecraft install sametcelikbicak/task-decomposer  # install from GitHub
-rolecraft list                                 # list installed skills
-rolecraft remove <slug>                        # remove a skill
-rolecraft --version                            # show version
+rolecraft install ./my-skill --claude --cursor     # install for specific agents
+rolecraft list                                     # list installed skills
+rolecraft remove <slug>                            # remove a skill
+rolecraft update <slug>                            # re-install to latest
+rolecraft --version                                # show version
 ```
 
 ### Install scope
@@ -57,13 +61,25 @@ Where do you want to install this skill?
   3) Both
 ```
 
-Use flags to skip the prompt:
+Select specific agents with flags:
 
 ```bash
 rolecraft install ./my-skill --global    # ~/.agents/skills/
 rolecraft install ./my-skill --project   # ./.agents/skills/
 rolecraft install ./my-skill --claude    # also ~/.claude/skills/
+rolecraft install ./my-skill --cursor    # also ~/.cursor/skills/
+rolecraft install ./my-skill --windsurf  # also ~/.windsurf/skills/
+rolecraft install ./my-skill --codex     # also ~/.codex/skills/
+rolecraft install ./my-skill --copilot   # also ~/.copilot/skills/
+rolecraft install ./my-skill --aider     # also ~/.aider/skills/
+rolecraft install ./my-skill --cline     # also ~/.cline/skills/
 rolecraft install ./my-skill --all       # all locations
+```
+
+Combine flags to install to multiple agents:
+
+```bash
+rolecraft install ./my-skill --claude --cursor --windsurf
 ```
 
 ### Source types
@@ -94,22 +110,33 @@ The CLI clones with `--depth 1`, finds `SKILL.md` recursively, installs it, and 
 
 ## How agents discover skills
 
-| Agent       | Directory                                  |
-| ----------- | ------------------------------------------ |
-| opencode    | `~/.agents/skills/` or `./.agents/skills/` |
-| claude-code | `~/.claude/skills/` or `./.claude/skills/` |
-| cursor      | `~/.cursor/skills/` or `./.cursor/skills/` |
+| Agent       | Directory                                   |
+| ----------- | ------------------------------------------- |
+| opencode    | `~/.agents/skills/` or `./.agents/skills/`  |
+| claude-code | `~/.claude/skills/` or `./.claude/skills/`  |
+| cursor      | `~/.cursor/skills/` or `./.cursor/skills/`  |
+| windsurf    | `~/.windsurf/skills/` or `./.windsurf/skills/` |
+| codex       | `~/.codex/skills/` or `./.codex/skills/`    |
+| copilot     | `~/.copilot/skills/` or `./.copilot/skills/` |
+| aider       | `~/.aider/skills/` or `./.aider/skills/`    |
+| cline       | `~/.cline/skills/` or `./.cline/skills/`    |
+
+Install to multiple agents at once:
+
+```bash
+rolecraft install ./my-skill --cursor --windsurf --copilot
+```
 
 ## Commands
 
-| Command                      | Description                       |
-| ---------------------------- | --------------------------------- |
-| `rolecraft install <source>` | Install a skill (local or GitHub) |
-| `rolecraft list`             | Show all installed skills         |
-| `rolecraft remove <slug>`    | Uninstall a skill                 |
-| `rolecraft update <slug>`    | Re-install a skill to latest      |
-| `rolecraft help`             | Show this help                    |
-| `rolecraft version`          | Show version (`--version`, `-v`) |
+| Command                      | Description                                       |
+| ---------------------------- | ------------------------------------------------- |
+| `rolecraft install <source>` | Install a skill (local path or GitHub `owner/repo`) |
+| `rolecraft list`             | Show all installed skills                         |
+| `rolecraft remove <slug>`    | Uninstall a skill                                 |
+| `rolecraft update <slug>`    | Re-install a skill to latest                      |
+| `rolecraft help`             | Show this help                                    |
+| `rolecraft version`          | Show version (`--version`, `-v`)                 |
 
 ## Project structure
 

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -16,7 +16,7 @@ function usage() {
 rolecraft — Install AI agent skills like roles & behaviors
 
 Zero dependencies, no marketplace required.
-Works with opencode, claude-code, cursor, and all spec-compliant agents.
+Works with opencode, claude-code, cursor, windsurf, codex, copilot, aider, cline, and all spec-compliant agents.
 
 Usage:
   rolecraft install <source>     Install a skill (local path or owner/repo)
@@ -29,13 +29,18 @@ Options for install:
   --global     Install to ~/.agents/skills/ (default)
   --claude     Also install to ~/.claude/skills/
   --cursor     Also install to ~/.cursor/skills/
+  --windsurf   Also install to ~/.windsurf/skills/
+  --codex      Also install to ~/.codex/skills/
+  --copilot    Also install to ~/.copilot/skills/
+  --aider      Also install to ~/.aider/skills/
+  --cline      Also install to ~/.cline/skills/
   --project    Install to ./.agents/skills/
   --all        Install to all locations
 
 Examples:
   rolecraft install ./my-skill
   rolecraft install sametcelikbicak/task-decomposer
-  rolecraft install ./skills/my-skill --claude
+  rolecraft install ./skills/my-skill --claude --cursor
   rolecraft list
   rolecraft remove task-decomposer
 `)
@@ -53,11 +58,17 @@ export async function main() {
       }
 
       const flags = args.slice(1)
-      const hasAnyFlag = flags.some(f => ['--global', '--project', '--claude', '--cursor', '--all'].includes(f))
+      const knownFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--codex', '--copilot', '--aider', '--cline', '--all']
+      const hasAnyFlag = flags.some(f => knownFlags.includes(f))
       const options = hasAnyFlag ? {
         global: flags.includes('--global') || flags.includes('--all'),
         claude: flags.includes('--claude') || flags.includes('--all'),
         cursor: flags.includes('--cursor') || flags.includes('--all'),
+        windsurf: flags.includes('--windsurf') || flags.includes('--all'),
+        codex: flags.includes('--codex') || flags.includes('--all'),
+        copilot: flags.includes('--copilot') || flags.includes('--all'),
+        aider: flags.includes('--aider') || flags.includes('--all'),
+        cline: flags.includes('--cline') || flags.includes('--all'),
         project: flags.includes('--project') || flags.includes('--all'),
       } : {}
 

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -40,7 +40,7 @@ async function askScope() {
 }
 
 export async function installCommand(source, options) {
-  const hasScopeFlags = options.global || options.project || options.claude || options.cursor
+  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.codex || options.copilot || options.aider || options.cline
   const scope = hasScopeFlags ? options : await askScope()
 
   console.log(`\n🔍 Resolving skill from: ${source}`)
@@ -56,6 +56,11 @@ export async function installCommand(source, options) {
   if (scope.global) targets.push('agents')
   if (scope.claude) targets.push('claude')
   if (scope.cursor) targets.push('cursor')
+  if (scope.windsurf) targets.push('windsurf')
+  if (scope.codex) targets.push('codex')
+  if (scope.copilot) targets.push('copilot')
+  if (scope.aider) targets.push('aider')
+  if (scope.cline) targets.push('cline')
   if (scope.project) targets.push('project')
 
   const results = await installSkill(resolved, targets)

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir } from '../utils/lockfile.js'
+import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -26,6 +26,21 @@ function detectTargets(slug, cwd) {
 
   const cursorDir = join(getCursorDir(), normSlug)
   if (existsSync(join(cursorDir, 'SKILL.md'))) targets.push('cursor')
+
+  const windsurfDir = join(getWindsurfDir(), normSlug)
+  if (existsSync(join(windsurfDir, 'SKILL.md'))) targets.push('windsurf')
+
+  const codexDir = join(getCodexDir(), normSlug)
+  if (existsSync(join(codexDir, 'SKILL.md'))) targets.push('codex')
+
+  const copilotDir = join(getCopilotDir(), normSlug)
+  if (existsSync(join(copilotDir, 'SKILL.md'))) targets.push('copilot')
+
+  const aiderDir = join(getAiderDir(), normSlug)
+  if (existsSync(join(aiderDir, 'SKILL.md'))) targets.push('aider')
+
+  const clineDir = join(getClineDir(), normSlug)
+  if (existsSync(join(clineDir, 'SKILL.md'))) targets.push('cline')
 
   const projectDir = join(cwd, '.agents', 'skills', normSlug)
   if (existsSync(join(projectDir, 'SKILL.md'))) targets.push('project')

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,7 +1,7 @@
 import { mkdir, cp, writeFile, readFile, access, stat } from 'node:fs/promises'
 import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
-import { getAgentsDir, getClaudeDir, getCursorDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -29,6 +29,31 @@ export async function installSkill(resolved, targets) {
       case 'cursor': {
         baseDir = getCursorDir()
         label = '~/.cursor/skills/'
+        break
+      }
+      case 'windsurf': {
+        baseDir = getWindsurfDir()
+        label = '~/.windsurf/skills/'
+        break
+      }
+      case 'codex': {
+        baseDir = getCodexDir()
+        label = '~/.codex/skills/'
+        break
+      }
+      case 'copilot': {
+        baseDir = getCopilotDir()
+        label = '~/.copilot/skills/'
+        break
+      }
+      case 'aider': {
+        baseDir = getAiderDir()
+        label = '~/.aider/skills/'
+        break
+      }
+      case 'cline': {
+        baseDir = getClineDir()
+        label = '~/.cline/skills/'
         break
       }
       case 'project': {

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -7,6 +7,11 @@ const GLOBAL_LOCK_PATH = join(GLOBAL_AGENTS_DIR, '.skill-lock.json')
 const GLOBAL_AGENTS_SKILLS_DIR = join(GLOBAL_AGENTS_DIR, 'skills')
 const CLAUDE_DIR = join(homedir(), '.claude', 'skills')
 const CURSOR_DIR = join(homedir(), '.cursor', 'skills')
+const WINDSURF_DIR = join(homedir(), '.windsurf', 'skills')
+const CODEX_DIR = join(homedir(), '.codex', 'skills')
+const COPILOT_DIR = join(homedir(), '.copilot', 'skills')
+const AIDER_DIR = join(homedir(), '.aider', 'skills')
+const CLINE_DIR = join(homedir(), '.cline', 'skills')
 
 export function getGlobalLockPath() {
   return GLOBAL_LOCK_PATH
@@ -22,6 +27,26 @@ export function getClaudeDir() {
 
 export function getCursorDir() {
   return CURSOR_DIR
+}
+
+export function getWindsurfDir() {
+  return WINDSURF_DIR
+}
+
+export function getCodexDir() {
+  return CODEX_DIR
+}
+
+export function getCopilotDir() {
+  return COPILOT_DIR
+}
+
+export function getAiderDir() {
+  return AIDER_DIR
+}
+
+export function getClineDir() {
+  return CLINE_DIR
 }
 
 export function getProjectLockPath(cwd) {


### PR DESCRIPTION
## Summary

5 new agent targets:

| Flag | Directory |
|------|-----------|
| `--windsurf` | `~/.windsurf/skills/` |
| `--codex` | `~/.codex/skills/` |
| `--copilot` | `~/.copilot/skills/` |
| `--aider` | `~/.aider/skills/` |
| `--cline` | `~/.cline/skills/` |

All new targets are included in `--all`. `rolecraft update` now detects
these directories too. README updated with docs and examples.