### PR TITLE
feat: add rolecraft use command to preview skills without installing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '22.14.0'
 
       - name: Run tests
         run: npm test

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ npx rolecraft install <source>
 rolecraft install ./path/to/my-skill              # install from local folder
 rolecraft install sametcelikbicak/task-decomposer  # install from GitHub
 rolecraft install ./my-skill --claude --cursor     # install for specific agents
+rolecraft use sametcelikbicak/task-decomposer      # preview without installing
 rolecraft list                                     # list installed skills
 rolecraft remove <slug>                            # remove a skill
 rolecraft update <slug>                            # re-install to latest
@@ -81,6 +82,15 @@ Combine flags to install to multiple agents:
 ```bash
 rolecraft install ./my-skill --claude --cursor --windsurf
 ```
+
+### Preview a skill without installing
+
+```bash
+rolecraft use ./my-skill
+rolecraft use sametcelikbicak/task-decomposer
+```
+
+The `use` command resolves the source, shows metadata, and prints all file contents to stdout — without writing anything to disk. Useful for inspecting a skill before installing, or piping content into other tools.
 
 ### Source types
 
@@ -129,14 +139,15 @@ rolecraft install ./my-skill --cursor --windsurf --copilot
 
 ## Commands
 
-| Command                      | Description                                       |
-| ---------------------------- | ------------------------------------------------- |
-| `rolecraft install <source>` | Install a skill (local path or GitHub `owner/repo`) |
-| `rolecraft list`             | Show all installed skills                         |
-| `rolecraft remove <slug>`    | Uninstall a skill                                 |
-| `rolecraft update <slug>`    | Re-install a skill to latest                      |
-| `rolecraft help`             | Show this help                                    |
-| `rolecraft version`          | Show version (`--version`, `-v`)                 |
+| Command                      | Description                                              |
+| ---------------------------- | -------------------------------------------------------- |
+| `rolecraft install <source>` | Install a skill (local path or GitHub `owner/repo`)      |
+| `rolecraft use <source>`     | Preview a skill's files without installing               |
+| `rolecraft list`             | Show all installed skills                                |
+| `rolecraft remove <slug>`    | Uninstall a skill                                        |
+| `rolecraft update <slug>`    | Re-install a skill to latest                             |
+| `rolecraft help`             | Show this help                                           |
+| `rolecraft version`          | Show version (`--version`, `-v`)                         |
 
 ## Project structure
 
@@ -148,7 +159,8 @@ rolecraft/
 │   │   ├── install.js        # install logic + interactive scope
 │   │   ├── list.js           # list installed skills
 │   │   ├── remove.js         # remove skill + lockfile cleanup
-│   │   └── update.js         # re-install skill to latest
+│   │   ├── update.js         # re-install skill to latest
+│   │   └── use.js            # preview skill without installing
 │   └── utils/
 │       ├── resolver.js       # source resolver (local / GitHub)
 │       ├── installer.js      # copy files to target dirs

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -7,6 +7,7 @@ import { installCommand } from '../src/commands/install.js'
 import { listCommand } from '../src/commands/list.js'
 import { removeCommand } from '../src/commands/remove.js'
 import { updateCommand } from '../src/commands/update.js'
+import { useCommand } from '../src/commands/use.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -20,6 +21,7 @@ Works with opencode, claude-code, cursor, windsurf, codex, copilot, aider, cline
 
 Usage:
   rolecraft install <source>     Install a skill (local path or owner/repo)
+  rolecraft use <source>         Preview a skill without installing
   rolecraft list                 List installed skills
   rolecraft remove <slug>        Remove a skill
   rolecraft update <slug>        Re-install a skill (update to latest)
@@ -97,6 +99,17 @@ export async function main() {
         process.exit(1)
       }
       await updateCommand(slug)
+      break
+    }
+
+    case 'use': {
+      const source = args[0]
+      if (!source) {
+        console.error('Usage: rolecraft use <source>')
+        console.error('Source can be a local path (./, /, ~) or a GitHub ref (owner/repo)')
+        process.exit(1)
+      }
+      await useCommand(source)
       break
     }
 

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -259,4 +259,36 @@ describe('rolecraft CLI', () => {
     })
     assert.equal(result.trim(), VERSION)
   })
+
+  it('errors when use has no source', async () => {
+    process.argv = ['node', 'rolecraft', 'use']
+    const { logs: errors, restore: restoreErr } = capture('error')
+    const restoreExit = mockExit()
+
+    try {
+      await rolecraftModule.main()
+    } catch (e) {
+      assert.ok(e.message.includes('exit:1'))
+    }
+
+    assert.ok(errors.some(e => e.includes('Usage: rolecraft use <source>')))
+    restoreErr()
+    restoreExit()
+  })
+
+  it('runs use command with existing source', async () => {
+    const skillDir = join(tempDir, 'use-cli-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/use-skill\nname: use-skill\nContent')
+
+    process.argv = ['node', 'rolecraft', 'use', skillDir]
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('use-skill')))
+    assert.ok(logs.some(l => l.includes('SKILL.md')))
+    assert.ok(logs.some(l => l.includes('Content')))
+    restore()
+  })
 })

--- a/src/commands/use.js
+++ b/src/commands/use.js
@@ -1,0 +1,22 @@
+import { resolveSource } from '../utils/resolver.js'
+
+export async function useCommand(source) {
+  console.log(`\n🔍 Resolving skill from: ${source}`)
+  const resolved = await resolveSource(source)
+
+  console.log(`\n📦 Skill: ${resolved.name}`)
+  console.log(`   Slug:     ${resolved.slug}`)
+  console.log(`   Owner:    ${resolved.owner}`)
+  console.log(`   Files:    ${resolved.files.join(', ')}\n`)
+
+  for (const file of resolved.files) {
+    const content = resolved.fileContents?.[file]
+    if (!content) continue
+
+    const separator = `─── ${file} ${'─'.repeat(Math.max(0, 50 - file.length))}`
+    console.log(separator)
+    console.log(content)
+    if (!content.endsWith('\n')) console.log()
+    console.log()
+  }
+}

--- a/src/commands/use.test.js
+++ b/src/commands/use.test.js
@@ -1,0 +1,49 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempDir, useModule, logs, origLog
+
+function capture() {
+  logs = []
+  origLog = console.log
+  console.log = (...args) => {
+    if (args.length) logs.push(String(args[0]))
+  }
+}
+
+function restoreLog() {
+  console.log = origLog
+}
+
+before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-use-test-'))
+  useModule = await import('./use.js')
+})
+
+after(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('use command', () => {
+  it('resolves and prints content for a local skill', async () => {
+    const skillDir = join(tempDir, 'my-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/my-skill\nname: My Skill\nContent')
+    writeFileSync(join(skillDir, 'config.json'), '{"key": "value"}')
+
+    capture()
+    await useModule.useCommand(skillDir)
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('My Skill')))
+    assert.ok(logs.some(l => l.includes('test/my-skill')))
+    assert.ok(logs.some(l => l.includes('SKILL.md')))
+    assert.ok(logs.some(l => l.includes('config.json')))
+    assert.ok(logs.some(l => l.includes('Content')))
+    assert.ok(logs.some(l => l.includes('{"key": "value"}')))
+  })
+})

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -83,7 +83,11 @@ async function resolveLocal(source) {
     const meta = parseMetadata(content)
     const dirEntries = await readdir(skillDir, { withFileTypes: true })
     const files = dirEntries.filter(e => e.name !== '.git').map(e => e.name)
-    return { ...meta, content, files, skillDir, sourcePath: source, sourceType: 'local' }
+    const fileContents = {}
+    for (const f of files) {
+      try { fileContents[f] = readFileSync(join(skillDir, f), 'utf-8') } catch {}
+    }
+    return { ...meta, content, files, fileContents, skillDir, sourcePath: source, sourceType: 'local' }
   } catch {
     // direct SKILL.md not found, scan recursively
   }
@@ -98,7 +102,12 @@ async function resolveLocal(source) {
     .filter(e => e.name !== '.git')
     .map(e => e.name)
 
-  return { ...skill, files, skillDir: skill.dir, sourcePath: source, sourceType: 'local' }
+  const fileContents = {}
+  for (const f of files) {
+    try { fileContents[f] = readFileSync(join(skill.dir, f), 'utf-8') } catch {}
+  }
+
+  return { ...skill, files, fileContents, skillDir: skill.dir, sourcePath: source, sourceType: 'local' }
 }
 
 async function resolveGitHub(source) {


### PR DESCRIPTION
## Summary

New `rolecraft use <source>` command that resolves a skill and prints all file contents to stdout — without installing anything.

```bash
rolecraft use ./my-skill
rolecraft use sametcelikbicak/task-decomposer
```

Useful for:
- Inspecting a skill before installing
- Piping content into other tools
- Quick verification without side effects

### Also
- Resolver now populates `fileContents` for local sources (was GitHub-only previously)
- Updated README with usage docs and examples
- Tests: CLI dispatch (error + success) + command unit test