### PR TITLE
feat: add rolecraft setup command to detect agents and install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
           node-version: '22.14.0'
 
       - name: Run tests
-        run: npm test
+        run: node --test --test-concurrency=1

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ rolecraft install ./path/to/my-skill              # install from local folder
 rolecraft install sametcelikbicak/task-decomposer  # install from GitHub
 rolecraft install ./my-skill --claude --cursor     # install for specific agents
 rolecraft use sametcelikbicak/task-decomposer      # preview without installing
+rolecraft setup                                    # detect installed agents
+rolecraft setup ./my-skill                         # detect + install to all agents
 rolecraft list                                     # list installed skills
 rolecraft remove <slug>                            # remove a skill
 rolecraft update <slug>                            # re-install to latest
@@ -91,6 +93,16 @@ rolecraft use sametcelikbicak/task-decomposer
 ```
 
 The `use` command resolves the source, shows metadata, and prints all file contents to stdout — without writing anything to disk. Useful for inspecting a skill before installing, or piping content into other tools.
+
+### Detect agents and install to all
+
+```bash
+rolecraft setup                    # detect which agents are available
+rolecraft setup ./my-skill         # detect + install to all detected agents
+rolecraft setup sametcelikbicak/task-decomposer
+```
+
+Run `rolecraft setup` to see which AI agents are installed on your system. Pass a source to automatically install a skill to all detected agents at once.
 
 ### Source types
 
@@ -143,6 +155,7 @@ rolecraft install ./my-skill --cursor --windsurf --copilot
 | ---------------------------- | -------------------------------------------------------- |
 | `rolecraft install <source>` | Install a skill (local path or GitHub `owner/repo`)      |
 | `rolecraft use <source>`     | Preview a skill's files without installing               |
+| `rolecraft setup [<source>]` | Detect agents, optionally install a skill to all         |
 | `rolecraft list`             | Show all installed skills                                |
 | `rolecraft remove <slug>`    | Uninstall a skill                                        |
 | `rolecraft update <slug>`    | Re-install a skill to latest                             |
@@ -159,6 +172,7 @@ rolecraft/
 │   │   ├── install.js        # install logic + interactive scope
 │   │   ├── list.js           # list installed skills
 │   │   ├── remove.js         # remove skill + lockfile cleanup
+│   │   ├── setup.js          # detect agents + install to all
 │   │   ├── update.js         # re-install skill to latest
 │   │   └── use.js            # preview skill without installing
 │   └── utils/

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -8,6 +8,7 @@ import { listCommand } from '../src/commands/list.js'
 import { removeCommand } from '../src/commands/remove.js'
 import { updateCommand } from '../src/commands/update.js'
 import { useCommand } from '../src/commands/use.js'
+import { setupCommand } from '../src/commands/setup.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -25,6 +26,7 @@ Usage:
   rolecraft list                 List installed skills
   rolecraft remove <slug>        Remove a skill
   rolecraft update <slug>        Re-install a skill (update to latest)
+  rolecraft setup [<source>]     Detect agents and optionally install a skill
   rolecraft help                 Show this help
 
 Options for install:
@@ -110,6 +112,12 @@ export async function main() {
         process.exit(1)
       }
       await useCommand(source)
+      break
+    }
+
+    case 'setup': {
+      const source = args[0]
+      await setupCommand(source)
       break
     }
 

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -291,4 +291,28 @@ describe('rolecraft CLI', () => {
     assert.ok(logs.some(l => l.includes('Content')))
     restore()
   })
+
+  it('runs setup command without source', async () => {
+    process.argv = ['node', 'rolecraft', 'setup']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('Detecting agents')))
+    restore()
+  })
+
+  it('runs setup command with source', async () => {
+    const skillDir = join(tempDir, 'setup-cli-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/setup-cli\nname: setup-cli-test\nContent')
+
+    process.argv = ['node', 'rolecraft', 'setup', skillDir]
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('setup-cli-test')))
+    restore()
+  })
 })

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/sametcelikbicak/rolecraft#readme",
   "scripts": {
-    "test": "node --test",
+    "test": "node --test --test-concurrency=1",
     "test:coverage": "node --experimental-test-coverage --test"
   },
   "engines": {

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,0 +1,98 @@
+import { accessSync, readdirSync, constants } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir } from '../utils/lockfile.js'
+import { resolveSource } from '../utils/resolver.js'
+import { installSkill } from '../utils/installer.js'
+
+const KNOWN_AGENTS = [
+  { flag: 'agents', label: 'opencode', dir: getAgentsDir },
+  { flag: 'claude', label: 'claude-code', dir: getClaudeDir },
+  { flag: 'cursor', label: 'cursor', dir: getCursorDir },
+  { flag: 'windsurf', label: 'windsurf', dir: getWindsurfDir },
+  { flag: 'codex', label: 'codex', dir: getCodexDir },
+  { flag: 'copilot', label: 'copilot', dir: getCopilotDir },
+  { flag: 'aider', label: 'aider', dir: getAiderDir },
+  { flag: 'cline', label: 'cline', dir: getClineDir },
+]
+
+export function detectAgents() {
+  const found = []
+  for (const agent of KNOWN_AGENTS) {
+    const dir = agent.dir()
+    try {
+      accessSync(dir, constants.F_OK)
+      found.push(agent)
+    } catch {
+      // agent not installed
+    }
+  }
+  return found
+}
+
+function globalAgentsDir() {
+  return join(homedir(), '.agents', 'skills')
+}
+
+export async function setupCommand(source) {
+  const agents = detectAgents()
+  const projectDir = join(process.cwd(), '.agents', 'skills')
+
+  console.log('\n🔍 Detecting agents...\n')
+
+  if (agents.length === 0) {
+    console.log('   No supported agents detected.\n')
+    console.log('   rolecraft installs skills into agent skill directories.')
+    console.log('   Install an AI coding agent (opencode, claude-code, cursor,')
+    console.log('   windsurf, codex, copilot, aider, cline) first.')
+    return
+  }
+
+  console.log('   Detected agents:')
+  for (const agent of agents) {
+    const skillCount = countSkills(agent.dir())
+    console.log(`   • ${agent.label.padEnd(15)} ${skillCount} skill(s)`)
+  }
+
+  const globalCount = countSkills(globalAgentsDir())
+  console.log(`\n   Global (~/.agents/skills/):   ${globalCount} skill(s)`)
+  const projectSkillCount = countSkills(projectDir)
+  if (projectSkillCount > 0) {
+    console.log(`   Project (./.agents/skills/):  ${projectSkillCount} skill(s)`)
+  }
+
+  console.log()
+
+  if (source) {
+    console.log(`📦 Installing skill from: ${source}`)
+    const resolved = await resolveSource(source)
+
+    console.log(`   Found: ${resolved.name} (${resolved.slug})\n`)
+
+    const targets = agents.map(a => a.flag)
+    targets.push('project')
+
+    const results = await installSkill(resolved, targets)
+
+    console.log('✅ Installed to all detected agents:\n')
+    for (const r of results) {
+      console.log(`   ${r.label} → ${r.path}`)
+    }
+  } else {
+    console.log('To install a skill to all detected agents:')
+    console.log('  rolecraft setup <source>\n')
+    console.log('Examples:')
+    console.log('  rolecraft setup ./my-skill')
+    console.log('  rolecraft setup sametcelikbicak/task-decomposer')
+  }
+}
+
+function countSkills(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+      .length
+  } catch {
+    return 0
+  }
+}

--- a/src/commands/setup.test.js
+++ b/src/commands/setup.test.js
@@ -1,0 +1,67 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { homedir, tmpdir } from 'node:os'
+
+let tempDir, setupModule, origHome, logs, origLog
+
+function capture() {
+  logs = []
+  origLog = console.log
+  console.log = (...args) => {
+    if (args.length) logs.push(String(args[0]))
+  }
+}
+
+function restoreLog() {
+  console.log = origLog
+}
+
+before(async () => {
+  tempDir = join(tmpdir(), 'rolecraft-setup-test-' + Date.now())
+  mkdirSync(tempDir, { recursive: true })
+  origHome = process.env.HOME
+  process.env.HOME = tempDir
+  setupModule = await import('./setup.js')
+})
+
+after(async () => {
+  process.env.HOME = origHome
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('setup command', () => {
+  it('detects no agents when no directories exist', async () => {
+    capture()
+    await setupModule.setupCommand()
+    restoreLog()
+    assert.ok(logs.some(l => l.includes('No supported agents detected')))
+  })
+
+  it('detects agents when directories exist', async () => {
+    mkdirSync(join(tempDir, '.agents', 'skills'), { recursive: true })
+    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true })
+
+    capture()
+    await setupModule.setupCommand()
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('opencode')))
+    assert.ok(logs.some(l => l.includes('claude-code')))
+  })
+
+  it('installs a skill when source is provided', async () => {
+    const skillDir = join(tempDir, 'setup-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/setup-skill\nname: setup-test\nContent')
+
+    capture()
+    await setupModule.setupCommand(skillDir)
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('setup-test')))
+    assert.ok(logs.some(l => l.includes('Installed')))
+  })
+})


### PR DESCRIPTION
## Summary

New `rolecraft setup` command for agent detection and bulk installation.

```bash
rolecraft setup                    # detect which agents are available
rolecraft setup ./my-skill         # detect + install to all detected agents
rolecraft setup sametcelikbicak/task-decomposer
```

### What it does
- Checks 8 known agent skill directories (opencode, claude-code, cursor, windsurf, codex, copilot, aider, cline)
- Reports which agents are installed with skill counts
- When a source is provided, installs the skill to all detected agents + project scope

### Files
- `src/commands/setup.js` — command implementation
- `src/commands/setup.test.js` — unit tests
- `bin/rolecraft.js` — CLI dispatch
- `README.md` — docs and examples