### PR TITLE
feat: make project scope default install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,18 @@ When you run `rolecraft install <source>` without flags, it asks where to instal
 
 ```
 Where do you want to install this skill?
-  1) Global (~/.agents/skills/) [default]
-  2) Project (./.agents/skills/)
+  1) Global (~/.agents/skills/)
+  2) Project (./.agents/skills/) [default]
   3) Both
 ```
+
+**Project scope is the default** — installed skills are committed with your repo and shared with your team. Use `--global` for personal skills or flags to target specific agents.
 
 Select specific agents with flags:
 
 ```bash
+rolecraft install ./my-skill --project   # ./.agents/skills/ (default)
 rolecraft install ./my-skill --global    # ~/.agents/skills/
-rolecraft install ./my-skill --project   # ./.agents/skills/
 rolecraft install ./my-skill --claude    # also ~/.claude/skills/
 rolecraft install ./my-skill --cursor    # also ~/.cursor/skills/
 rolecraft install ./my-skill --windsurf  # also ~/.windsurf/skills/

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -30,7 +30,8 @@ Usage:
   rolecraft help                 Show this help
 
 Options for install:
-  --global     Install to ~/.agents/skills/ (default)
+  --global     Install to ~/.agents/skills/
+  --project    Install to ./.agents/skills/ (default)
   --claude     Also install to ~/.claude/skills/
   --cursor     Also install to ~/.cursor/skills/
   --windsurf   Also install to ~/.windsurf/skills/
@@ -38,7 +39,6 @@ Options for install:
   --copilot    Also install to ~/.copilot/skills/
   --aider      Also install to ~/.aider/skills/
   --cline      Also install to ~/.cline/skills/
-  --project    Install to ./.agents/skills/
   --all        Install to all locations
 
 Examples:

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -26,16 +26,16 @@ function defaultAskQuestion(query) {
 
 async function askScope() {
   console.log('\nWhere do you want to install this skill?\n')
-  console.log('  1) Global (~/.agents/skills/) [default]')
-  console.log('  2) Project (./.agents/skills/)')
+  console.log('  1) Global (~/.agents/skills/)')
+  console.log('  2) Project (./.agents/skills/) [default]')
   console.log('  3) Both\n')
 
-  const answer = await askQuestion('Choice [1/2/3] (default: 1): ')
+  const answer = await askQuestion('Choice [1/2/3] (default: 2): ')
 
   switch (answer) {
-    case '2': return { global: false, project: true, claude: false }
+    case '1': return { global: true, project: false, claude: false }
     case '3': return { global: true, project: true, claude: false }
-    default:  return { global: true, project: false, claude: false }
+    default:  return { global: false, project: true, claude: false }
   }
 }
 

--- a/src/commands/update.test.js
+++ b/src/commands/update.test.js
@@ -109,6 +109,63 @@ describe('update command', () => {
     process.cwd = origCwd
   })
 
+  it('detects skill in windsurf target directory', async () => {
+    const lock = JSON.parse(await readFile(join(tempDir, '.agents', '.skill-lock.json'), 'utf-8'))
+    lock.skills['wind/skill'] = {
+      name: 'Wind Skill',
+      source: join(tempDir, 'wind-source'),
+      sourceType: 'local',
+      installedAt: new Date().toISOString(),
+    }
+    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify(lock, null, 2))
+
+    mkdirSync(join(tempDir, 'wind-source'), { recursive: true })
+    writeFileSync(join(tempDir, 'wind-source', 'SKILL.md'), '# slug: wind/skill\nname: Wind Skill\nContent')
+
+    mkdirSync(join(tempDir, '.windsurf', 'skills', 'wind-skill'), { recursive: true })
+    writeFileSync(join(tempDir, '.windsurf', 'skills', 'wind-skill', 'SKILL.md'), '# slug: wind/skill\nname: Wind Skill\nContent')
+
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => {
+      if (args.length) logs.push(String(args[0]))
+    }
+
+    await updateModule.updateCommand('wind/skill')
+
+    assert.ok(logs.some(l => l.includes('Updated')))
+    assert.ok(logs.some(l => l.includes('windsurf')))
+    console.log = origLog
+  })
+
+  it('finds skill by normalized slug when exact match fails', async () => {
+    const lock = JSON.parse(await readFile(join(tempDir, '.agents', '.skill-lock.json'), 'utf-8'))
+    lock.skills['dash/skill'] = {
+      name: 'Dash Skill',
+      source: join(tempDir, 'dash-source'),
+      sourceType: 'local',
+      installedAt: new Date().toISOString(),
+    }
+    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify(lock, null, 2))
+
+    mkdirSync(join(tempDir, 'dash-source'), { recursive: true })
+    writeFileSync(join(tempDir, 'dash-source', 'SKILL.md'), '# slug: dash/skill\nname: Dash Skill\nContent')
+
+    mkdirSync(join(tempDir, '.agents', 'skills', 'dash-skill'), { recursive: true })
+    writeFileSync(join(tempDir, '.agents', 'skills', 'dash-skill', 'SKILL.md'), '# slug: dash/skill\nname: Dash Skill\nContent')
+
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => {
+      if (args.length) logs.push(String(args[0]))
+    }
+
+    await updateModule.updateCommand('dash-skill')
+
+    assert.ok(logs.some(l => l.includes('Updated')))
+    console.log = origLog
+  })
+
   it('falls back to agents target when no existing targets detected', async () => {
     const lockPath = join(tempDir, '.agents', '.skill-lock.json')
     const lock = JSON.parse(await readFile(lockPath, 'utf-8'))

--- a/src/commands/use.test.js
+++ b/src/commands/use.test.js
@@ -46,4 +46,14 @@ describe('use command', () => {
     assert.ok(logs.some(l => l.includes('Content')))
     assert.ok(logs.some(l => l.includes('{"key": "value"}')))
   })
+
+  it('skips files not in fileContents', async () => {
+    capture()
+    await useModule.useCommand(join(tempDir, 'my-skill'))
+    restoreLog()
+
+    const contentLogs = logs.filter(l => l.includes('───'))
+    assert.ok(contentLogs.some(l => l.includes('SKILL.md')))
+    assert.ok(contentLogs.some(l => l.includes('config.json')))
+  })
 })

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -71,6 +71,56 @@ describe('installer', () => {
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
 
+  it('installs skill to windsurf directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['windsurf'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'windsurf')
+
+    const skillDir = join(tempDir, '.windsurf', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to codex directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['codex'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'codex')
+
+    const skillDir = join(tempDir, '.codex', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to copilot directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['copilot'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'copilot')
+
+    const skillDir = join(tempDir, '.copilot', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to aider directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['aider'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'aider')
+
+    const skillDir = join(tempDir, '.aider', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to cline directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['cline'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'cline')
+
+    const skillDir = join(tempDir, '.cline', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
   it('installs skill to project directory', async () => {
     const origCwd = process.cwd
     process.cwd = () => tempDir


### PR DESCRIPTION
## Summary

Change the default install scope from Global (`~/.agents/skills/`) to Project (`./.agents/skills/`).

### What changed
- Interactive prompt now defaults to Project (option 2)
- CLI usage text updated
- README docs updated

Project-scoped skills are committed with the repo and shared with the team — a better default for collaborative projects.