### PR TITLE
add devin (Devin Desktop) agent target with windsurf backward compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **Zero-dependency** CLI to install AI agent skills as roles & behaviors from any source. No marketplace, no registry, no signup — just point it at a local folder or a GitHub repo and it works.
 
-Works with **opencode**, **claude-code**, **cursor**, **windsurf**, **codex**, **copilot**, **aider**, **cline**, and all spec-compliant agents.
+Works with **opencode**, **claude-code**, **cursor**, **windsurf** (deprecated → **devin**), **codex**, **copilot**, **aider**, **cline**, and all spec-compliant agents.
 
 ## Why rolecraft?
 
@@ -23,7 +23,7 @@ Works with **opencode**, **claude-code**, **cursor**, **windsurf**, **codex**, *
 | Zero dependencies                 | ✅               | ✅              | ❌ (2)               |
 | Local path install                | ✅ **1st class** | ❌ GitHub only  | ❌ marketplace only  |
 | GitHub repo install               | ✅               | ✅              | ❌                   |
-| Agent targets                     | 9                | 68+             | 20+                  |
+| Agent targets                     | 10               | 68+             | 20+                  |
 | Offline capable                   | ✅               | ❌              | ❌                   |
 | agentskill.sh lockfile compatible | ✅               | ✅              | ✅                   |
 | Project-level install             | ✅               | ✅              | ✅                   |
@@ -73,7 +73,8 @@ rolecraft install ./my-skill --project   # ./.agents/skills/ (default)
 rolecraft install ./my-skill --global    # ~/.agents/skills/
 rolecraft install ./my-skill --claude    # also ~/.claude/skills/
 rolecraft install ./my-skill --cursor    # also ~/.cursor/skills/
-rolecraft install ./my-skill --windsurf  # also ~/.windsurf/skills/
+rolecraft install ./my-skill --windsurf  # also ~/.windsurf/skills/ (deprecated: use --devin)
+rolecraft install ./my-skill --devin     # also ~/.devin/skills/
 rolecraft install ./my-skill --codex     # also ~/.codex/skills/
 rolecraft install ./my-skill --copilot   # also ~/.copilot/skills/
 rolecraft install ./my-skill --aider     # also ~/.aider/skills/
@@ -84,7 +85,7 @@ rolecraft install ./my-skill --all       # all locations
 Combine flags to install to multiple agents:
 
 ```bash
-rolecraft install ./my-skill --claude --cursor --windsurf
+rolecraft install ./my-skill --claude --cursor --devin
 ```
 
 ### Preview a skill without installing
@@ -139,16 +140,19 @@ The CLI clones with `--depth 1`, finds `SKILL.md` recursively, installs it, and 
 | opencode    | `~/.agents/skills/` or `./.agents/skills/`  |
 | claude-code | `~/.claude/skills/` or `./.claude/skills/`  |
 | cursor      | `~/.cursor/skills/` or `./.cursor/skills/`  |
-| windsurf    | `~/.windsurf/skills/` or `./.windsurf/skills/` |
+| windsurf ⚠️ | `~/.windsurf/skills/` or `./.windsurf/skills/` |
+| devin       | `~/.devin/skills/` or `./.devin/skills/`    |
 | codex       | `~/.codex/skills/` or `./.codex/skills/`    |
 | copilot     | `~/.copilot/skills/` or `./.copilot/skills/` |
 | aider       | `~/.aider/skills/` or `./.aider/skills/`    |
 | cline       | `~/.cline/skills/` or `./.cline/skills/`    |
 
+> ⚠️ Windsurf was rebranded to **Devin Desktop** in June 2026. The `--windsurf` flag and `~/.windsurf/skills/` path still work for backward compatibility, but new deployments should use `--devin` / `~/.devin/skills/`.
+
 Install to multiple agents at once:
 
 ```bash
-rolecraft install ./my-skill --cursor --windsurf --copilot
+rolecraft install ./my-skill --cursor --devin --copilot
 ```
 
 ## Commands

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -18,7 +18,7 @@ function usage() {
 rolecraft — Install AI agent skills like roles & behaviors
 
 Zero dependencies, no marketplace required.
-Works with opencode, claude-code, cursor, windsurf, codex, copilot, aider, cline, and all spec-compliant agents.
+Works with opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, and all spec-compliant agents.
 
 Usage:
   rolecraft install <source>     Install a skill (local path or owner/repo)
@@ -34,7 +34,8 @@ Options for install:
   --project    Install to ./.agents/skills/ (default)
   --claude     Also install to ~/.claude/skills/
   --cursor     Also install to ~/.cursor/skills/
-  --windsurf   Also install to ~/.windsurf/skills/
+  --windsurf   Also install to ~/.windsurf/skills/ (deprecated: use --devin)
+  --devin      Also install to ~/.devin/skills/
   --codex      Also install to ~/.codex/skills/
   --copilot    Also install to ~/.copilot/skills/
   --aider      Also install to ~/.aider/skills/
@@ -62,13 +63,14 @@ export async function main() {
       }
 
       const flags = args.slice(1)
-      const knownFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--codex', '--copilot', '--aider', '--cline', '--all']
+      const knownFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--devin', '--codex', '--copilot', '--aider', '--cline', '--all']
       const hasAnyFlag = flags.some(f => knownFlags.includes(f))
       const options = hasAnyFlag ? {
         global: flags.includes('--global') || flags.includes('--all'),
         claude: flags.includes('--claude') || flags.includes('--all'),
         cursor: flags.includes('--cursor') || flags.includes('--all'),
         windsurf: flags.includes('--windsurf') || flags.includes('--all'),
+        devin: flags.includes('--devin') || flags.includes('--all'),
         codex: flags.includes('--codex') || flags.includes('--all'),
         copilot: flags.includes('--copilot') || flags.includes('--all'),
         aider: flags.includes('--aider') || flags.includes('--all'),

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -31,7 +31,7 @@
 - **agentskill.sh lockfile compatible** — cross-compatible with ecosystem
 - **Interactive scope prompt** — user-friendly first install
 - **Project scope default** — modern default (v0.2.0)
-- **9 agent targets** — opencode, claude-code, cursor, windsurf, codex, copilot, aider, cline
+- **10 agent targets** — opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline
 
 ## Weaknesses / Gaps
 
@@ -72,7 +72,8 @@
 | opencode    | `~/.agents/skills/` or `./.agents/skills/`     |
 | claude-code | `~/.claude/skills/` or `./.claude/skills/`     |
 | cursor      | `~/.cursor/skills/` or `./.cursor/skills/`     |
-| windsurf    | `~/.windsurf/skills/` or `./.windsurf/skills/` |
+| windsurf ⚠️ | `~/.windsurf/skills/` or `./.windsurf/skills/` |
+| devin       | `~/.devin/skills/` or `./.devin/skills/`       |
 | codex       | `~/.codex/skills/` or `./.codex/skills/`       |
 | copilot     | `~/.copilot/skills/` or `./.copilot/skills/`   |
 | aider       | `~/.aider/skills/` or `./.aider/skills/`       |

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -40,7 +40,7 @@ async function askScope() {
 }
 
 export async function installCommand(source, options) {
-  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.codex || options.copilot || options.aider || options.cline
+  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline
   const scope = hasScopeFlags ? options : await askScope()
 
   console.log(`\n🔍 Resolving skill from: ${source}`)
@@ -57,6 +57,7 @@ export async function installCommand(source, options) {
   if (scope.claude) targets.push('claude')
   if (scope.cursor) targets.push('cursor')
   if (scope.windsurf) targets.push('windsurf')
+  if (scope.devin) targets.push('devin')
   if (scope.codex) targets.push('codex')
   if (scope.copilot) targets.push('copilot')
   if (scope.aider) targets.push('aider')

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,7 +1,7 @@
 import { accessSync, readdirSync, constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir } from '../utils/lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -14,6 +14,7 @@ const KNOWN_AGENTS = [
   { flag: 'copilot', label: 'copilot', dir: getCopilotDir },
   { flag: 'aider', label: 'aider', dir: getAiderDir },
   { flag: 'cline', label: 'cline', dir: getClineDir },
+  { flag: 'devin', label: 'devin', dir: getDevinDir },
 ]
 
 export function detectAgents() {
@@ -44,7 +45,7 @@ export async function setupCommand(source) {
     console.log('   No supported agents detected.\n')
     console.log('   rolecraft installs skills into agent skill directories.')
     console.log('   Install an AI coding agent (opencode, claude-code, cursor,')
-    console.log('   windsurf, codex, copilot, aider, cline) first.')
+    console.log('   windsurf, devin, codex, copilot, aider, cline) first.')
     return
   }
 

--- a/src/commands/setup.test.js
+++ b/src/commands/setup.test.js
@@ -52,7 +52,25 @@ describe('setup command', () => {
     assert.ok(logs.some(l => l.includes('claude-code')))
   })
 
+  it('handles missing project dir when detecting agents', async () => {
+    mkdirSync(join(tempDir, '.agents', 'skills'), { recursive: true })
+    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true })
+
+    const origCwd = process.cwd
+    process.cwd = () => join(tempDir, 'nonexistent')
+    capture()
+    await setupModule.setupCommand()
+    restoreLog()
+    process.cwd = origCwd
+
+    assert.ok(logs.some(l => l.includes('opencode')))
+    assert.ok(logs.some(l => l.includes('claude-code')))
+  })
+
   it('installs a skill when source is provided', async () => {
+    mkdirSync(join(tempDir, '.agents', 'skills'), { recursive: true })
+    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true })
+
     const skillDir = join(tempDir, 'setup-skill')
     mkdirSync(skillDir, { recursive: true })
     writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/setup-skill\nname: setup-test\nContent')

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir } from '../utils/lockfile.js'
+import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -41,6 +41,9 @@ function detectTargets(slug, cwd) {
 
   const clineDir = join(getClineDir(), normSlug)
   if (existsSync(join(clineDir, 'SKILL.md'))) targets.push('cline')
+
+  const devinDir = join(getDevinDir(), normSlug)
+  if (existsSync(join(devinDir, 'SKILL.md'))) targets.push('devin')
 
   const projectDir = join(cwd, '.agents', 'skills', normSlug)
   if (existsSync(join(projectDir, 'SKILL.md'))) targets.push('project')

--- a/src/commands/update.test.js
+++ b/src/commands/update.test.js
@@ -138,6 +138,35 @@ describe('update command', () => {
     console.log = origLog
   })
 
+  it('detects skill in devin target directory', async () => {
+    const lock = JSON.parse(await readFile(join(tempDir, '.agents', '.skill-lock.json'), 'utf-8'))
+    lock.skills['dev/skill'] = {
+      name: 'Dev Skill',
+      source: join(tempDir, 'dev-source'),
+      sourceType: 'local',
+      installedAt: new Date().toISOString(),
+    }
+    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify(lock, null, 2))
+
+    mkdirSync(join(tempDir, 'dev-source'), { recursive: true })
+    writeFileSync(join(tempDir, 'dev-source', 'SKILL.md'), '# slug: dev/skill\nname: Dev Skill\nContent')
+
+    mkdirSync(join(tempDir, '.devin', 'skills', 'dev-skill'), { recursive: true })
+    writeFileSync(join(tempDir, '.devin', 'skills', 'dev-skill', 'SKILL.md'), '# slug: dev/skill\nname: Dev Skill\nContent')
+
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => {
+      if (args.length) logs.push(String(args[0]))
+    }
+
+    await updateModule.updateCommand('dev/skill')
+
+    assert.ok(logs.some(l => l.includes('Updated')))
+    assert.ok(logs.some(l => l.includes('devin')))
+    console.log = origLog
+  })
+
   it('finds skill by normalized slug when exact match fails', async () => {
     const lock = JSON.parse(await readFile(join(tempDir, '.agents', '.skill-lock.json'), 'utf-8'))
     lock.skills['dash/skill'] = {

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,7 +1,7 @@
 import { mkdir, cp, writeFile, readFile, access, stat } from 'node:fs/promises'
 import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -54,6 +54,11 @@ export async function installSkill(resolved, targets) {
       case 'cline': {
         baseDir = getClineDir()
         label = '~/.cline/skills/'
+        break
+      }
+      case 'devin': {
+        baseDir = getDevinDir()
+        label = '~/.devin/skills/'
         break
       }
       case 'project': {

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -121,6 +121,16 @@ describe('installer', () => {
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
 
+  it('installs skill to devin directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['devin'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'devin')
+
+    const skillDir = join(tempDir, '.devin', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
   it('installs skill to project directory', async () => {
     const origCwd = process.cwd
     process.cwd = () => tempDir

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -12,6 +12,7 @@ const CODEX_DIR = join(homedir(), '.codex', 'skills')
 const COPILOT_DIR = join(homedir(), '.copilot', 'skills')
 const AIDER_DIR = join(homedir(), '.aider', 'skills')
 const CLINE_DIR = join(homedir(), '.cline', 'skills')
+const DEVIN_DIR = join(homedir(), '.devin', 'skills')
 
 export function getGlobalLockPath() {
   return GLOBAL_LOCK_PATH
@@ -47,6 +48,10 @@ export function getAiderDir() {
 
 export function getClineDir() {
   return CLINE_DIR
+}
+
+export function getDevinDir() {
+  return DEVIN_DIR
 }
 
 export function getProjectLockPath(cwd) {


### PR DESCRIPTION
- --devin flag installs to ~/.devin/skills/
- --windsurf kept for backward compat with deprecation notice
- add DEVIN_DIR + getDevinDir() in lockfile
- add devin case in installer, update detection, setup
- add installer + update tests for devin
- cover countSkills catch block in setup test
- update README, docs/ANALYSIS, CHANGELOG
