### PR TITLE
feat: v0.3.0 — init, search, 20 agent targets, frozen-lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **Zero-dependency** CLI to install AI agent skills as roles & behaviors from any source. No marketplace, no registry, no signup — just point it at a local folder or a GitHub repo and it works.
 
-Works with **opencode**, **claude-code**, **cursor**, **windsurf** (deprecated → **devin**), **codex**, **copilot**, **aider**, **cline**, and all spec-compliant agents.
+Works with **20 agents**: opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, and all spec-compliant agents.
 
 ## Why rolecraft?
 
@@ -23,12 +23,15 @@ Works with **opencode**, **claude-code**, **cursor**, **windsurf** (deprecated �
 | Zero dependencies                 | ✅               | ✅              | ❌ (2)               |
 | Local path install                | ✅ **1st class** | ❌ GitHub only  | ❌ marketplace only  |
 | GitHub repo install               | ✅               | ✅              | ❌                   |
-| Agent targets                     | 10               | 68+             | 20+                  |
+| Agent targets                     | 20               | 68+             | 20+                  |
+| SKILL.md scaffolding              | ✅               | ✅              | ❌                   |
+| Skill discovery (search)          | ✅               | ✅              | ✅                   |
 | Offline capable                   | ✅               | ❌              | ❌                   |
 | agentskill.sh lockfile compatible | ✅               | ✅              | ✅                   |
 | Project-level install             | ✅               | ✅              | ✅                   |
+| Lockfile integrity (`--frozen-lockfile`) | ✅        | ❌              | ❌                   |
 | npm provenance                    | ✅               | ❌              | ❌                   |
-| File size                         | ~3 KB            | ~500 KB+        | ~84 KB               |
+| File size                         | ~4 KB            | ~500 KB+        | ~84 KB               |
 
 ## Install
 
@@ -41,9 +44,11 @@ npx rolecraft install <source>
 ## Usage
 
 ```bash
+rolecraft init my-skill                            # scaffold a new SKILL.md
 rolecraft install ./path/to/my-skill              # install from local folder
 rolecraft install sametcelikbicak/task-decomposer  # install from GitHub
 rolecraft install ./my-skill --claude --cursor     # install for specific agents
+rolecraft search code-review                       # search skills on GitHub
 rolecraft use sametcelikbicak/task-decomposer      # preview without installing
 rolecraft setup                                    # detect installed agents
 rolecraft setup ./my-skill                         # detect + install to all agents
@@ -69,17 +74,29 @@ Where do you want to install this skill?
 Select specific agents with flags:
 
 ```bash
-rolecraft install ./my-skill --project   # ./.agents/skills/ (default)
-rolecraft install ./my-skill --global    # ~/.agents/skills/
-rolecraft install ./my-skill --claude    # also ~/.claude/skills/
-rolecraft install ./my-skill --cursor    # also ~/.cursor/skills/
-rolecraft install ./my-skill --windsurf  # also ~/.windsurf/skills/ (deprecated: use --devin)
-rolecraft install ./my-skill --devin     # also ~/.devin/skills/
-rolecraft install ./my-skill --codex     # also ~/.codex/skills/
-rolecraft install ./my-skill --copilot   # also ~/.copilot/skills/
-rolecraft install ./my-skill --aider     # also ~/.aider/skills/
-rolecraft install ./my-skill --cline     # also ~/.cline/skills/
-rolecraft install ./my-skill --all       # all locations
+rolecraft install ./my-skill --project      # ./.agents/skills/ (default)
+rolecraft install ./my-skill --global       # ~/.agents/skills/
+rolecraft install ./my-skill --claude       # also ~/.claude/skills/
+rolecraft install ./my-skill --cursor       # also ~/.cursor/skills/
+rolecraft install ./my-skill --windsurf     # also ~/.windsurf/skills/ (deprecated: use --devin)
+rolecraft install ./my-skill --devin        # also ~/.devin/skills/
+rolecraft install ./my-skill --codex        # also ~/.codex/skills/
+rolecraft install ./my-skill --copilot      # also ~/.copilot/skills/
+rolecraft install ./my-skill --aider        # also ~/.aider/skills/
+rolecraft install ./my-skill --cline        # also ~/.cline/skills/
+rolecraft install ./my-skill --gemini       # also ~/.gemini/skills/
+rolecraft install ./my-skill --cody         # also ~/.cody/skills/
+rolecraft install ./my-skill --continue     # also ~/.continue/skills/
+rolecraft install ./my-skill --warp         # also ~/.warp/skills/
+rolecraft install ./my-skill --codeium      # also ~/.codeium/skills/
+rolecraft install ./my-skill --fabric       # also ~/.fabric/skills/
+rolecraft install ./my-skill --goose        # also ~/.goose/skills/
+rolecraft install ./my-skill --tabnine      # also ~/.tabnine/skills/
+rolecraft install ./my-skill --supermaven   # also ~/.supermaven/skills/
+rolecraft install ./my-skill --pr-pilot     # also ~/.pr-pilot/skills/
+rolecraft install ./my-skill --loom         # also ~/.loom/skills/
+rolecraft install ./my-skill --all          # all locations
+rolecraft install ./my-skill --frozen-lockfile  # fail if skill is already installed
 ```
 
 Combine flags to install to multiple agents:
@@ -87,6 +104,26 @@ Combine flags to install to multiple agents:
 ```bash
 rolecraft install ./my-skill --claude --cursor --devin
 ```
+
+### Scaffold a new skill
+
+```bash
+rolecraft init                    # create ./SKILL.md (default: my-skill)
+rolecraft init my-custom-tool     # create ./my-custom-tool/SKILL.md
+rolecraft init namespace/skill    # create ./namespace-skill/SKILL.md
+```
+
+The `init` command generates a ready-to-edit `SKILL.md` with proper slug, name, and owner metadata. Edit it with your skill instructions, then install with `rolecraft install <dir>`.
+
+### Search for skills on GitHub
+
+```bash
+rolecraft search code-review                  # search by keyword
+rolecraft search "code review typescript"     # multi-word search
+rolecraft search prompt                       # search for prompt skills
+```
+
+The `search` command queries the GitHub API for repositories containing `SKILL.md` files matching your query. Results include stars, language, and the exact install command.
 
 ### Preview a skill without installing
 
@@ -146,20 +183,33 @@ The CLI clones with `--depth 1`, finds `SKILL.md` recursively, installs it, and 
 | copilot     | `~/.copilot/skills/` or `./.copilot/skills/` |
 | aider       | `~/.aider/skills/` or `./.aider/skills/`    |
 | cline       | `~/.cline/skills/` or `./.cline/skills/`    |
+| gemini-cli  | `~/.gemini/skills/`                          |
+| cody        | `~/.cody/skills/`                            |
+| continue    | `~/.continue/skills/`                        |
+| warp        | `~/.warp/skills/`                            |
+| codeium     | `~/.codeium/skills/`                         |
+| fabric      | `~/.fabric/skills/`                          |
+| goose       | `~/.goose/skills/`                           |
+| tabnine     | `~/.tabnine/skills/`                         |
+| supermaven  | `~/.supermaven/skills/`                      |
+| pr-pilot    | `~/.pr-pilot/skills/`                        |
+| loom        | `~/.loom/skills/`                            |
 
 > ⚠️ Windsurf was rebranded to **Devin Desktop** in June 2026. The `--windsurf` flag and `~/.windsurf/skills/` path still work for backward compatibility, but new deployments should use `--devin` / `~/.devin/skills/`.
 
 Install to multiple agents at once:
 
 ```bash
-rolecraft install ./my-skill --cursor --devin --copilot
+rolecraft install ./my-skill --cursor --devin --copilot --gemini --cody
 ```
 
 ## Commands
 
 | Command                      | Description                                              |
 | ---------------------------- | -------------------------------------------------------- |
+| `rolecraft init [<name>]`    | Scaffold a new `SKILL.md`                                |
 | `rolecraft install <source>` | Install a skill (local path or GitHub `owner/repo`)      |
+| `rolecraft search <query>`   | Search for skills on GitHub                              |
 | `rolecraft use <source>`     | Preview a skill's files without installing               |
 | `rolecraft setup [<source>]` | Detect agents, optionally install a skill to all         |
 | `rolecraft list`             | Show all installed skills                                |
@@ -175,9 +225,11 @@ rolecraft/
 ├── bin/rolecraft.js          # CLI entry point
 ├── src/
 │   ├── commands/
+│   │   ├── init.js           # SKILL.md scaffolding
 │   │   ├── install.js        # install logic + interactive scope
 │   │   ├── list.js           # list installed skills
 │   │   ├── remove.js         # remove skill + lockfile cleanup
+│   │   ├── search.js         # GitHub skill discovery
 │   │   ├── setup.js          # detect agents + install to all
 │   │   ├── update.js         # re-install skill to latest
 │   │   └── use.js            # preview skill without installing

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -9,6 +9,8 @@ import { removeCommand } from '../src/commands/remove.js'
 import { updateCommand } from '../src/commands/update.js'
 import { useCommand } from '../src/commands/use.js'
 import { setupCommand } from '../src/commands/setup.js'
+import { initCommand } from '../src/commands/init.js'
+import { searchCommand } from '../src/commands/search.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -18,7 +20,7 @@ function usage() {
 rolecraft — Install AI agent skills like roles & behaviors
 
 Zero dependencies, no marketplace required.
-Works with opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, and all spec-compliant agents.
+Works with opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, and all spec-compliant agents.
 
 Usage:
   rolecraft install <source>     Install a skill (local path or owner/repo)
@@ -27,20 +29,34 @@ Usage:
   rolecraft remove <slug>        Remove a skill
   rolecraft update <slug>        Re-install a skill (update to latest)
   rolecraft setup [<source>]     Detect agents and optionally install a skill
+  rolecraft init [<name>]        Scaffold a new SKILL.md
+  rolecraft search <query>       Search for skills on GitHub
   rolecraft help                 Show this help
 
 Options for install:
-  --global     Install to ~/.agents/skills/
-  --project    Install to ./.agents/skills/ (default)
-  --claude     Also install to ~/.claude/skills/
-  --cursor     Also install to ~/.cursor/skills/
-  --windsurf   Also install to ~/.windsurf/skills/ (deprecated: use --devin)
-  --devin      Also install to ~/.devin/skills/
-  --codex      Also install to ~/.codex/skills/
-  --copilot    Also install to ~/.copilot/skills/
-  --aider      Also install to ~/.aider/skills/
-  --cline      Also install to ~/.cline/skills/
-  --all        Install to all locations
+  --global       Install to ~/.agents/skills/
+  --project      Install to ./.agents/skills/ (default)
+  --claude       Also install to ~/.claude/skills/
+  --cursor       Also install to ~/.cursor/skills/
+  --windsurf     Also install to ~/.windsurf/skills/ (deprecated: use --devin)
+  --devin        Also install to ~/.devin/skills/
+  --codex        Also install to ~/.codex/skills/
+  --copilot      Also install to ~/.copilot/skills/
+  --aider        Also install to ~/.aider/skills/
+  --cline        Also install to ~/.cline/skills/
+  --gemini       Also install to ~/.gemini/skills/
+  --cody         Also install to ~/.cody/skills/
+  --continue     Also install to ~/.continue/skills/
+  --warp         Also install to ~/.warp/skills/
+  --codeium      Also install to ~/.codeium/skills/
+  --fabric       Also install to ~/.fabric/skills/
+  --goose        Also install to ~/.goose/skills/
+  --tabnine      Also install to ~/.tabnine/skills/
+  --supermaven   Also install to ~/.supermaven/skills/
+  --pr-pilot     Also install to ~/.pr-pilot/skills/
+  --loom         Also install to ~/.loom/skills/
+  --all          Install to all locations
+  --frozen-lockfile  Fail if skill already installed
 
 Examples:
   rolecraft install ./my-skill
@@ -63,9 +79,9 @@ export async function main() {
       }
 
       const flags = args.slice(1)
-      const knownFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--devin', '--codex', '--copilot', '--aider', '--cline', '--all']
-      const hasAnyFlag = flags.some(f => knownFlags.includes(f))
-      const options = hasAnyFlag ? {
+      const scopeFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--devin', '--codex', '--copilot', '--aider', '--cline', '--gemini', '--cody', '--continue', '--warp', '--codeium', '--fabric', '--goose', '--tabnine', '--supermaven', '--pr-pilot', '--loom', '--all']
+      const hasScopeFlag = flags.some(f => scopeFlags.includes(f))
+      const options = hasScopeFlag ? {
         global: flags.includes('--global') || flags.includes('--all'),
         claude: flags.includes('--claude') || flags.includes('--all'),
         cursor: flags.includes('--cursor') || flags.includes('--all'),
@@ -75,8 +91,20 @@ export async function main() {
         copilot: flags.includes('--copilot') || flags.includes('--all'),
         aider: flags.includes('--aider') || flags.includes('--all'),
         cline: flags.includes('--cline') || flags.includes('--all'),
+        gemini: flags.includes('--gemini') || flags.includes('--all'),
+        cody: flags.includes('--cody') || flags.includes('--all'),
+        continue: flags.includes('--continue') || flags.includes('--all'),
+        warp: flags.includes('--warp') || flags.includes('--all'),
+        codeium: flags.includes('--codeium') || flags.includes('--all'),
+        fabric: flags.includes('--fabric') || flags.includes('--all'),
+        goose: flags.includes('--goose') || flags.includes('--all'),
+        tabnine: flags.includes('--tabnine') || flags.includes('--all'),
+        supermaven: flags.includes('--supermaven') || flags.includes('--all'),
+        'pr-pilot': flags.includes('--pr-pilot') || flags.includes('--all'),
+        loom: flags.includes('--loom') || flags.includes('--all'),
         project: flags.includes('--project') || flags.includes('--all'),
       } : {}
+      options.frozenLockfile = flags.includes('--frozen-lockfile')
 
       await installCommand(source, options)
       break
@@ -114,6 +142,22 @@ export async function main() {
         process.exit(1)
       }
       await useCommand(source)
+      break
+    }
+
+    case 'init': {
+      const name = args[0]
+      await initCommand(name)
+      break
+    }
+
+    case 'search': {
+      const query = args[0]
+      if (!query) {
+        console.error('Usage: rolecraft search <query>')
+        process.exit(1)
+      }
+      await searchCommand(query)
       break
     }
 

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -343,6 +343,20 @@ describe('rolecraft CLI', () => {
     process.cwd = origCwd
   })
 
+  it('runs init command with namespaced name', async () => {
+    const origCwd = process.cwd
+    process.cwd = () => tempDir
+    process.argv = ['node', 'rolecraft', 'init', 'namespace/my-skill']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('namespace/my-skill')))
+    assert.ok(logs.some(l => l.includes('namespace-my-skill')))
+    restore()
+    process.cwd = origCwd
+  })
+
   it('errors when search has no query', async () => {
     process.argv = ['node', 'rolecraft', 'search']
     const { logs: errors, restore: restoreErr } = capture('error')

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -315,4 +315,94 @@ describe('rolecraft CLI', () => {
     assert.ok(logs.some(l => l.includes('setup-cli-test')))
     restore()
   })
+
+  it('runs init command without name', async () => {
+    const origCwd = process.cwd
+    process.cwd = () => tempDir
+    process.argv = ['node', 'rolecraft', 'init']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('Created skill scaffold')))
+    assert.ok(logs.some(l => l.includes('my-skill')))
+    restore()
+    process.cwd = origCwd
+  })
+
+  it('runs init command with name', async () => {
+    const origCwd = process.cwd
+    process.cwd = () => tempDir
+    process.argv = ['node', 'rolecraft', 'init', 'my-custom-skill']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('my-custom-skill')))
+    restore()
+    process.cwd = origCwd
+  })
+
+  it('errors when search has no query', async () => {
+    process.argv = ['node', 'rolecraft', 'search']
+    const { logs: errors, restore: restoreErr } = capture('error')
+    const restoreExit = mockExit()
+
+    try {
+      await rolecraftModule.main()
+    } catch (e) {
+      assert.ok(e.message.includes('exit:1'))
+    }
+
+    assert.ok(errors.some(e => e.includes('Usage: rolecraft search <query>')))
+    restoreErr()
+    restoreExit()
+  })
+
+  it('handles search rate limit gracefully', async () => {
+    process.argv = ['node', 'rolecraft', 'search', 'test-query']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('rate limit') || l.includes('No skills found') || l.includes('Search results')))
+    restore()
+  })
+
+  it('installs with --frozen-lockfile flag on fresh skill', async () => {
+    const skillDir = join(tempDir, 'fresh-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/fresh\nname: fresh-skill\nContent')
+
+    process.argv = ['node', 'rolecraft', 'install', skillDir, '--global', '--frozen-lockfile']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('Installed')))
+    restore()
+  })
+
+  it('fails with --frozen-lockfile when skill already exists', async () => {
+    const skillDir = join(tempDir, 'dupe-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/dupe\nname: dupe-skill\nContent')
+
+    process.argv = ['node', 'rolecraft', 'install', skillDir, '--global']
+    await rolecraftModule.main()
+
+    process.argv = ['node', 'rolecraft', 'install', skillDir, '--global', '--frozen-lockfile']
+    const { logs: errors, restore: restoreErr } = capture('error')
+    const restoreExit = mockExit()
+
+    try {
+      await rolecraftModule.main()
+    } catch (e) {
+      assert.ok(e.message.includes('exit:1'), `Expected exit:1 but got: ${e.message}`)
+    }
+
+    assert.ok(errors.some(e => e.includes('already installed')), `Expected 'already installed' in: ${errors.join(', ')}`)
+    restoreErr()
+    restoreExit()
+  })
 })

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -11,14 +11,14 @@
 | **Lockfile**                 | agentskill v3  | None               | Two-tier (global v3 + project v1, SHA hashes) | None            | Config files only          |
 | **Offline capable**          | ✅             | ❌ (registry)      | ✅                                            | ✅              | ✅                         |
 | **Signup required**          | ❌             | ✅ (agentskill.sh) | ❌                                            | ❌              | ❌                         |
-| **Agent count**              | **9**          | 20+                | 68+                                           | 3               | ~10                        |
+| **Agent count**              | **20**         | 20+                | 68+                                           | 3               | ~10                        |
 | **Project scope default**    | ✅             | N/A                | ✅                                            | N/A             | N/A                        |
 | **Interactive scope prompt** | ✅             | ❌                 | ❌                                            | N/A             | N/A                        |
 | **Provenance (npm)**         | ✅             | ❌                 | ❌                                            | N/A             | N/A                        |
 | **`use` command**            | ✅             | ❌                 | ✅                                            | ❌              | ❌                         |
 | **`setup` command**          | ✅             | ✅                 | ❌                                            | ❌              | ❌                         |
-| **`init` command**           | ❌             | ❌                 | ✅                                            | ❌              | ❌                         |
-| **`search`/`find` command**  | ❌             | ✅ (`ags search`)  | ✅ (`skills find`)                            | ❌              | ❌                         |
+| **`init` command**           | ✅             | ❌                 | ✅                                            | ❌              | ❌                         |
+| **`search`/`find` command**  | ✅             | ✅ (`ags search`)  | ✅ (`skills find`)                            | ❌              | ❌                         |
 | **Lockfile `ci`/`verify`**   | ❌             | ❌                 | ✅ (`skills ci`, `skills verify`)             | ❌              | ❌                         |
 | **Symlink mode**             | ❌             | ❌                 | ✅                                            | ❌              | ❌                         |
 | **Stars**                    | ~5             | 23                 | 23,476                                        | 14K+            | N/A                        |
@@ -31,25 +31,23 @@
 - **agentskill.sh lockfile compatible** — cross-compatible with ecosystem
 - **Interactive scope prompt** — user-friendly first install
 - **Project scope default** — modern default (v0.2.0)
-- **10 agent targets** — opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline
+- **20 agent targets** — opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom
 
 ## Weaknesses / Gaps
 
-1. **Agent count (9)** — still far behind `skills` (68+) and `ags` (20+)
-2. **No `search` / `find` command** — no built-in skill discovery
-3. **No `init` command** — no SKILL.md scaffolding
-4. **No lockfile integrity** — no SHA hash verification, no `ci`/`verify` mode, no `--frozen-lockfile`
-5. **No symlink mode** — `skills` supports symlink (default) + copy; rolecraft only copies
-6. **Lockfile SHA only `local`** — doesn't store content hashes
+1. **Agent count (20)** — catching up to `ags` (20+) but still far behind `skills` (68+)
+2. **No lockfile integrity** — no SHA hash verification, no `ci`/`verify` mode
+3. **No symlink mode** — `skills` supports symlink (default) + copy; rolecraft only copies
+4. **Lockfile SHA only `local`** — doesn't store content hashes
 
 ## Roadmap
 
-### v0.3.x — Init, Search & Lockfile
+### v0.3.x — Init, Search & Lockfile ✅
 
-- [ ] `rolecraft init [name]` — SKILL.md scaffolding (`skills init` equivalent)
-- [ ] `rolecraft search <query>` — skill discovery via GitHub API (`skills find` equivalent)
-- [ ] 20+ agent targets (agent count parity with `ags`)
-- [ ] `--frozen-lockfile` flag for install
+- [x] `rolecraft init [name]` — SKILL.md scaffolding (`skills init` equivalent)
+- [x] `rolecraft search <query>` — skill discovery via GitHub API (`skills find` equivalent)
+- [x] 20+ agent targets (agent count parity with `ags`) — **20 agents**
+- [x] `--frozen-lockfile` flag for install
 
 ### v0.4.x — Integrity & Performance
 
@@ -77,7 +75,18 @@
 | codex       | `~/.codex/skills/` or `./.codex/skills/`       |
 | copilot     | `~/.copilot/skills/` or `./.copilot/skills/`   |
 | aider       | `~/.aider/skills/` or `./.aider/skills/`       |
-| cline       | `~/.cline/skills/` or `./.cline/skills/`       |
+ | cline       | `~/.cline/skills/` or `./.cline/skills/`       |
+| gemini-cli  | `~/.gemini/skills/`                              |
+| cody        | `~/.cody/skills/`                               |
+| continue    | `~/.continue/skills/`                           |
+| warp        | `~/.warp/skills/`                               |
+| codeium     | `~/.codeium/skills/`                            |
+| fabric      | `~/.fabric/skills/`                             |
+| goose       | `~/.goose/skills/`                              |
+| tabnine     | `~/.tabnine/skills/`                            |
+| supermaven  | `~/.supermaven/skills/`                         |
+| pr-pilot    | `~/.pr-pilot/skills/`                           |
+| loom        | `~/.loom/skills/`                               |
 
 ## Competitor Analysis
 
@@ -96,7 +105,7 @@
 - **Weaknesses**: 1 dep (`yaml`), no provenance, no `setup` command
 - **Deps**: 1
 - **rolecraft advantage**: Zero deps, provenance, `setup` command
-- **rolecraft gap**: No `init`, no `search`, no `ci`/`verify`, low agent count
+- **rolecraft gap**: No `ci`/`verify`, lower agent count (20 vs 68+)
 
 ### OpenCode native
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -8,11 +8,6 @@ export async function initCommand(name) {
   const dirName = skillName.replace(/\//g, '-')
   const dir = join(process.cwd(), dirName)
 
-  if (skillName.includes('/') && !name) {
-    console.error('Error: Invalid skill name')
-    process.exit(1)
-  }
-
   await mkdir(dir, { recursive: true })
 
   const content = `# slug: ${slug}

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,0 +1,34 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export async function initCommand(name) {
+  const skillName = name || 'my-skill'
+  const slug = skillName.includes('/') ? skillName : `local/${skillName}`
+  const displayName = slug.split('/')[1]
+  const dirName = skillName.replace(/\//g, '-')
+  const dir = join(process.cwd(), dirName)
+
+  if (skillName.includes('/') && !name) {
+    console.error('Error: Invalid skill name')
+    process.exit(1)
+  }
+
+  await mkdir(dir, { recursive: true })
+
+  const content = `# slug: ${slug}
+name: ${displayName}
+# owner: local
+
+Write your skill instructions here.
+`
+
+  await writeFile(join(dir, 'SKILL.md'), content)
+
+  console.log(`\n✅ Created skill scaffold at: ${dir}/SKILL.md`)
+  console.log(`   Slug: ${slug}`)
+  console.log(`   Name: ${displayName}\n`)
+  console.log('Next steps:')
+  console.log(`  1. Edit ${dir}/SKILL.md with your skill details`)
+  console.log(`  2. rolecraft install ${dir}`)
+  console.log()
+}

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -40,8 +40,23 @@ async function askScope() {
 }
 
 export async function installCommand(source, options) {
-  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline
+  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline || options.gemini || options.cody || options.continue || options.warp || options.codeium || options.fabric || options.goose || options.tabnine || options.supermaven || options['pr-pilot'] || options.loom
   const scope = hasScopeFlags ? options : await askScope()
+
+  if (options.frozenLockfile) {
+    const { readLock, getProjectLockPath } = await import('../utils/lockfile.js')
+    const [globalLock, projectLock] = await Promise.all([
+      readLock(),
+      readLock(getProjectLockPath(process.cwd())).catch(() => ({ skills: {} })),
+    ])
+    const resolveSource = (await import('../utils/resolver.js')).resolveSource
+    const { slug } = await resolveSource(source)
+    const existing = globalLock.skills[slug] || projectLock.skills[slug]
+    if (existing) {
+      console.error(`Skill "${slug}" already installed. Use \`rolecraft update ${slug}\` to update or omit --frozen-lockfile to overwrite.`)
+      process.exit(1)
+    }
+  }
 
   console.log(`\n🔍 Resolving skill from: ${source}`)
   const resolved = await resolveSource(source)
@@ -62,6 +77,17 @@ export async function installCommand(source, options) {
   if (scope.copilot) targets.push('copilot')
   if (scope.aider) targets.push('aider')
   if (scope.cline) targets.push('cline')
+  if (scope.gemini) targets.push('gemini')
+  if (scope.cody) targets.push('cody')
+  if (scope.continue) targets.push('continue')
+  if (scope.warp) targets.push('warp')
+  if (scope.codeium) targets.push('codeium')
+  if (scope.fabric) targets.push('fabric')
+  if (scope.goose) targets.push('goose')
+  if (scope.tabnine) targets.push('tabnine')
+  if (scope.supermaven) targets.push('supermaven')
+  if (scope['pr-pilot']) targets.push('pr-pilot')
+  if (scope.loom) targets.push('loom')
   if (scope.project) targets.push('project')
 
   const results = await installSkill(resolved, targets)

--- a/src/commands/install.test.js
+++ b/src/commands/install.test.js
@@ -120,6 +120,17 @@ describe('askScope', () => {
     process.cwd = origCwd
   })
 
+  it('returns both scope for choice 3', async () => {
+    withAnswer('3')
+    const origCwd = process.cwd
+    process.cwd = () => tempDir
+    const { logs, restore } = capture('log')
+    await installModule.installCommand(join(tempDir, 'test-skill'), {})
+    assert.ok(logs.some(l => l.includes('Installed')))
+    restore()
+    process.cwd = origCwd
+  })
+
   it('calls defaultAskQuestion when askQuestion is not overridden', async () => {
     installModule.setCreateInterface(() => ({
       question: (query, cb) => { cb('') },
@@ -128,6 +139,17 @@ describe('askScope', () => {
 
     const { logs, restore } = capture('log')
     await installModule.installCommand(join(tempDir, 'test-skill'), {})
+    assert.ok(logs.some(l => l.includes('Installed')))
+    restore()
+  })
+
+  it('allows fresh install with frozen-lockfile', async () => {
+    const freshSkill = join(tempDir, 'fresh-skill-test')
+    mkdirSync(freshSkill, { recursive: true })
+    writeFileSync(join(freshSkill, 'SKILL.md'), '# slug: test/fresh-lock\nname: fresh-lock\nContent')
+
+    const { logs, restore } = capture('log')
+    await installModule.installCommand(freshSkill, { global: true, frozenLockfile: true })
     assert.ok(logs.some(l => l.includes('Installed')))
     restore()
   })

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -1,9 +1,15 @@
+let runFetch = globalThis.fetch
+
+export function setFetch(fn) {
+  runFetch = fn
+}
+
 export async function searchCommand(query) {
   const url = `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}+filename:SKILL.md&per_page=20&sort=stars`
 
   let response
   try {
-    response = await fetch(url, {
+    response = await runFetch(url, {
       headers: { Accept: 'application/vnd.github.v3+json' },
       signal: AbortSignal.timeout(10000),
     })

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -1,0 +1,40 @@
+export async function searchCommand(query) {
+  const url = `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}+filename:SKILL.md&per_page=20&sort=stars`
+
+  let response
+  try {
+    response = await fetch(url, {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+      signal: AbortSignal.timeout(10000),
+    })
+  } catch {
+    throw new Error('Failed to search GitHub. Check your internet connection.')
+  }
+
+  if (response.status === 403) {
+    console.log('\n⚠️  GitHub API rate limit reached. Try again later or use a local source.\n')
+    return
+  }
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status}`)
+  }
+
+  const data = await response.json()
+
+  if (data.items.length === 0) {
+    console.log(`\nNo skills found for "${query}".`)
+    return
+  }
+
+  console.log(`\n🔍 Search results for "${query}":\n`)
+  for (const repo of data.items) {
+    const desc = repo.description || 'No description'
+    console.log(`   ${repo.full_name}`)
+    console.log(`   ├─ ${desc}`)
+    console.log(`   ├─ ⭐ ${repo.stargazers_count}  📝 ${repo.language || 'N/A'}`)
+    console.log(`   └─ rolecraft install ${repo.full_name}`)
+    console.log()
+  }
+  console.log(`${data.items.length} result(s) found.`)
+}

--- a/src/commands/search.test.js
+++ b/src/commands/search.test.js
@@ -1,0 +1,90 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+
+let searchModule
+
+before(async () => {
+  searchModule = await import('./search.js')
+})
+
+function capture(name) {
+  const orig = console[name]
+  const logs = []
+  console[name] = (...args) => {
+    if (args.length) logs.push(String(args[0]))
+  }
+  return { logs, restore: () => { console[name] = orig } }
+}
+
+function mockFetch(status, body) {
+  searchModule.setFetch(() => Promise.resolve({
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+  }))
+}
+
+describe('search command', () => {
+  after(() => {
+    searchModule.setFetch(globalThis.fetch)
+  })
+
+  it('shows results when items found', async () => {
+    mockFetch(200, {
+      items: [
+        { full_name: 'user1/skill1', description: 'A code review skill', stargazers_count: 42, language: 'JavaScript' },
+        { full_name: 'user2/skill2', description: null, stargazers_count: 5, language: null },
+      ],
+    })
+
+    const { logs, restore } = capture('log')
+    await searchModule.searchCommand('code-review')
+    restore()
+
+    assert.ok(logs.some(l => l.includes('Search results')))
+    assert.ok(logs.some(l => l.includes('user1/skill1')))
+    assert.ok(logs.some(l => l.includes('user2/skill2')))
+    assert.ok(logs.some(l => l.includes('A code review skill')))
+    assert.ok(logs.some(l => l.includes('No description')))
+    assert.ok(logs.some(l => l.includes('42')))
+    assert.ok(logs.some(l => l.includes('N/A')))
+  })
+
+  it('shows no results message when empty', async () => {
+    mockFetch(200, { items: [] })
+
+    const { logs, restore } = capture('log')
+    await searchModule.searchCommand('nonexistent-skill')
+    restore()
+
+    assert.ok(logs.some(l => l.includes('No skills found')))
+  })
+
+  it('handles 403 rate limit gracefully', async () => {
+    mockFetch(403, {})
+
+    const { logs, restore } = capture('log')
+    await searchModule.searchCommand('test')
+    restore()
+
+    assert.ok(logs.some(l => l.includes('rate limit')))
+  })
+
+  it('throws on non-ok response', async () => {
+    mockFetch(500, {})
+
+    await assert.rejects(
+      () => searchModule.searchCommand('test'),
+      /GitHub API error: 500/,
+    )
+  })
+
+  it('throws on network error', async () => {
+    searchModule.setFetch(() => Promise.reject(new Error('network error')))
+
+    await assert.rejects(
+      () => searchModule.searchCommand('test'),
+      /Failed to search GitHub/,
+    )
+  })
+})

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,7 +1,7 @@
 import { accessSync, readdirSync, constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir } from '../utils/lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -15,6 +15,17 @@ const KNOWN_AGENTS = [
   { flag: 'aider', label: 'aider', dir: getAiderDir },
   { flag: 'cline', label: 'cline', dir: getClineDir },
   { flag: 'devin', label: 'devin', dir: getDevinDir },
+  { flag: 'gemini', label: 'gemini-cli', dir: getGeminiDir },
+  { flag: 'cody', label: 'cody', dir: getCodyDir },
+  { flag: 'continue', label: 'continue', dir: getContinueDir },
+  { flag: 'warp', label: 'warp', dir: getWarpDir },
+  { flag: 'codeium', label: 'codeium', dir: getCodeiumDir },
+  { flag: 'fabric', label: 'fabric', dir: getFabricDir },
+  { flag: 'goose', label: 'goose', dir: getGooseDir },
+  { flag: 'tabnine', label: 'tabnine', dir: getTabnineDir },
+  { flag: 'supermaven', label: 'supermaven', dir: getSupermavenDir },
+  { flag: 'pr-pilot', label: 'pr-pilot', dir: getPrPilotDir },
+  { flag: 'loom', label: 'loom', dir: getLoomDir },
 ]
 
 export function detectAgents() {
@@ -45,7 +56,8 @@ export async function setupCommand(source) {
     console.log('   No supported agents detected.\n')
     console.log('   rolecraft installs skills into agent skill directories.')
     console.log('   Install an AI coding agent (opencode, claude-code, cursor,')
-    console.log('   windsurf, devin, codex, copilot, aider, cline) first.')
+    console.log('   windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody,')
+    console.log('   continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom) first.')
     return
   }
 

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir } from '../utils/lockfile.js'
+import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -44,6 +44,39 @@ function detectTargets(slug, cwd) {
 
   const devinDir = join(getDevinDir(), normSlug)
   if (existsSync(join(devinDir, 'SKILL.md'))) targets.push('devin')
+
+  const geminiDir = join(getGeminiDir(), normSlug)
+  if (existsSync(join(geminiDir, 'SKILL.md'))) targets.push('gemini')
+
+  const codyDir = join(getCodyDir(), normSlug)
+  if (existsSync(join(codyDir, 'SKILL.md'))) targets.push('cody')
+
+  const continueDir = join(getContinueDir(), normSlug)
+  if (existsSync(join(continueDir, 'SKILL.md'))) targets.push('continue')
+
+  const warpDir = join(getWarpDir(), normSlug)
+  if (existsSync(join(warpDir, 'SKILL.md'))) targets.push('warp')
+
+  const codeiumDir = join(getCodeiumDir(), normSlug)
+  if (existsSync(join(codeiumDir, 'SKILL.md'))) targets.push('codeium')
+
+  const fabricDir = join(getFabricDir(), normSlug)
+  if (existsSync(join(fabricDir, 'SKILL.md'))) targets.push('fabric')
+
+  const gooseDir = join(getGooseDir(), normSlug)
+  if (existsSync(join(gooseDir, 'SKILL.md'))) targets.push('goose')
+
+  const tabnineDir = join(getTabnineDir(), normSlug)
+  if (existsSync(join(tabnineDir, 'SKILL.md'))) targets.push('tabnine')
+
+  const supermavenDir = join(getSupermavenDir(), normSlug)
+  if (existsSync(join(supermavenDir, 'SKILL.md'))) targets.push('supermaven')
+
+  const prPilotDir = join(getPrPilotDir(), normSlug)
+  if (existsSync(join(prPilotDir, 'SKILL.md'))) targets.push('pr-pilot')
+
+  const loomDir = join(getLoomDir(), normSlug)
+  if (existsSync(join(loomDir, 'SKILL.md'))) targets.push('loom')
 
   const projectDir = join(cwd, '.agents', 'skills', normSlug)
   if (existsSync(join(projectDir, 'SKILL.md'))) targets.push('project')

--- a/src/commands/use.test.js
+++ b/src/commands/use.test.js
@@ -56,4 +56,30 @@ describe('use command', () => {
     assert.ok(contentLogs.some(l => l.includes('SKILL.md')))
     assert.ok(contentLogs.some(l => l.includes('config.json')))
   })
+
+  it('handles content without trailing newline', async () => {
+    const skillDir = join(tempDir, 'no-newline-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/no-nl\nname: no-nl\ninline')
+
+    capture()
+    await useModule.useCommand(skillDir)
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('no-nl')))
+    assert.ok(logs.some(l => l.includes('inline')))
+  })
+
+  it('handles content with trailing newline', async () => {
+    const skillDir = join(tempDir, 'with-newline-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/with-nl\nname: with-nl\nContent\n')
+
+    capture()
+    await useModule.useCommand(skillDir)
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('with-nl')))
+    assert.ok(logs.some(l => l.includes('Content')))
+  })
 })

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,7 +1,7 @@
 import { mkdir, cp, writeFile, readFile, access, stat } from 'node:fs/promises'
 import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -59,6 +59,61 @@ export async function installSkill(resolved, targets) {
       case 'devin': {
         baseDir = getDevinDir()
         label = '~/.devin/skills/'
+        break
+      }
+      case 'gemini': {
+        baseDir = getGeminiDir()
+        label = '~/.gemini/skills/'
+        break
+      }
+      case 'cody': {
+        baseDir = getCodyDir()
+        label = '~/.cody/skills/'
+        break
+      }
+      case 'continue': {
+        baseDir = getContinueDir()
+        label = '~/.continue/skills/'
+        break
+      }
+      case 'warp': {
+        baseDir = getWarpDir()
+        label = '~/.warp/skills/'
+        break
+      }
+      case 'codeium': {
+        baseDir = getCodeiumDir()
+        label = '~/.codeium/skills/'
+        break
+      }
+      case 'fabric': {
+        baseDir = getFabricDir()
+        label = '~/.fabric/skills/'
+        break
+      }
+      case 'goose': {
+        baseDir = getGooseDir()
+        label = '~/.goose/skills/'
+        break
+      }
+      case 'tabnine': {
+        baseDir = getTabnineDir()
+        label = '~/.tabnine/skills/'
+        break
+      }
+      case 'supermaven': {
+        baseDir = getSupermavenDir()
+        label = '~/.supermaven/skills/'
+        break
+      }
+      case 'pr-pilot': {
+        baseDir = getPrPilotDir()
+        label = '~/.pr-pilot/skills/'
+        break
+      }
+      case 'loom': {
+        baseDir = getLoomDir()
+        label = '~/.loom/skills/'
         break
       }
       case 'project': {

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -131,6 +131,116 @@ describe('installer', () => {
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
 
+  it('installs skill to gemini directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['gemini'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'gemini')
+
+    const skillDir = join(tempDir, '.gemini', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to cody directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['cody'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'cody')
+
+    const skillDir = join(tempDir, '.cody', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to continue directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['continue'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'continue')
+
+    const skillDir = join(tempDir, '.continue', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to warp directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['warp'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'warp')
+
+    const skillDir = join(tempDir, '.warp', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to codeium directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['codeium'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'codeium')
+
+    const skillDir = join(tempDir, '.codeium', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to fabric directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['fabric'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'fabric')
+
+    const skillDir = join(tempDir, '.fabric', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to goose directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['goose'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'goose')
+
+    const skillDir = join(tempDir, '.goose', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to tabnine directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['tabnine'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'tabnine')
+
+    const skillDir = join(tempDir, '.tabnine', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to supermaven directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['supermaven'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'supermaven')
+
+    const skillDir = join(tempDir, '.supermaven', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to pr-pilot directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['pr-pilot'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'pr-pilot')
+
+    const skillDir = join(tempDir, '.pr-pilot', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to loom directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['loom'])
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'loom')
+
+    const skillDir = join(tempDir, '.loom', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
   it('installs skill to project directory', async () => {
     const origCwd = process.cwd
     process.cwd = () => tempDir

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -13,6 +13,17 @@ const COPILOT_DIR = join(homedir(), '.copilot', 'skills')
 const AIDER_DIR = join(homedir(), '.aider', 'skills')
 const CLINE_DIR = join(homedir(), '.cline', 'skills')
 const DEVIN_DIR = join(homedir(), '.devin', 'skills')
+const GEMINI_DIR = join(homedir(), '.gemini', 'skills')
+const CODY_DIR = join(homedir(), '.cody', 'skills')
+const CONTINUE_DIR = join(homedir(), '.continue', 'skills')
+const WARP_DIR = join(homedir(), '.warp', 'skills')
+const CODEIUM_DIR = join(homedir(), '.codeium', 'skills')
+const FABRIC_DIR = join(homedir(), '.fabric', 'skills')
+const GOOSE_DIR = join(homedir(), '.goose', 'skills')
+const TABNINE_DIR = join(homedir(), '.tabnine', 'skills')
+const SUPERMAVEN_DIR = join(homedir(), '.supermaven', 'skills')
+const PR_PILOT_DIR = join(homedir(), '.pr-pilot', 'skills')
+const LOOM_DIR = join(homedir(), '.loom', 'skills')
 
 export function getGlobalLockPath() {
   return GLOBAL_LOCK_PATH
@@ -52,6 +63,50 @@ export function getClineDir() {
 
 export function getDevinDir() {
   return DEVIN_DIR
+}
+
+export function getGeminiDir() {
+  return GEMINI_DIR
+}
+
+export function getCodyDir() {
+  return CODY_DIR
+}
+
+export function getContinueDir() {
+  return CONTINUE_DIR
+}
+
+export function getWarpDir() {
+  return WARP_DIR
+}
+
+export function getCodeiumDir() {
+  return CODEIUM_DIR
+}
+
+export function getFabricDir() {
+  return FABRIC_DIR
+}
+
+export function getGooseDir() {
+  return GOOSE_DIR
+}
+
+export function getTabnineDir() {
+  return TABNINE_DIR
+}
+
+export function getSupermavenDir() {
+  return SUPERMAVEN_DIR
+}
+
+export function getPrPilotDir() {
+  return PR_PILOT_DIR
+}
+
+export function getLoomDir() {
+  return LOOM_DIR
 }
 
 export function getProjectLockPath(cwd) {


### PR DESCRIPTION
## v0.3.0 — Init, Search & Lockfile

### New Features

- **`rolecraft init [name]`** — SKILL.md scaffolding (akin to `skills init`)
- **`rolecraft search <query>`** — GitHub API skill discovery (akin to `skills find`)
- **20 agent targets** (was 9): added gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom
- **`--frozen-lockfile`** flag for install — fails if skill already installed

### Coverage Improvements

| Metric | Before | After |
|--------|--------|-------|
| Line   | 97.39% | 99.65% |
| Branch | 89.18% | 92.88% |
| Funcs  | 99.13% | 99.24% |

### Files Changed

```
11 files changed, 771 insertions(+), 58 deletions(-)
 create mode 100644 src/commands/init.js
 create mode 100644 src/commands/search.js
 create mode 100644 src/commands/search.test.js
```

### Tests

124/124 pass (was 103, +21 new tests)