### PR TITLE
feat: v0.4.0 — verify, ci, content hash, symlink mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,23 @@ Works with **20 agents**: opencode, claude-code, cursor, windsurf, devin, codex,
 
 ## Why rolecraft?
 
-| Feature                           | rolecraft        | `npx add-skill` | `@agentskill.sh/cli` |
-| --------------------------------- | ---------------- | --------------- | -------------------- |
-| Zero dependencies                 | ✅               | ✅              | ❌ (2)               |
-| Local path install                | ✅ **1st class** | ❌ GitHub only  | ❌ marketplace only  |
-| GitHub repo install               | ✅               | ✅              | ❌                   |
-| Agent targets                     | 20               | 68+             | 20+                  |
-| SKILL.md scaffolding              | ✅               | ✅              | ❌                   |
-| Skill discovery (search)          | ✅               | ✅              | ✅                   |
-| Offline capable                   | ✅               | ❌              | ❌                   |
-| agentskill.sh lockfile compatible | ✅               | ✅              | ✅                   |
-| Project-level install             | ✅               | ✅              | ✅                   |
-| Lockfile integrity (`--frozen-lockfile`) | ✅        | ❌              | ❌                   |
-| npm provenance                    | ✅               | ❌              | ❌                   |
-| File size                         | ~4 KB            | ~500 KB+        | ~84 KB               |
+| Feature                                  | rolecraft        | `npx add-skill` | `@agentskill.sh/cli` |
+| ---------------------------------------- | ---------------- | --------------- | -------------------- |
+| Zero dependencies                        | ✅               | ✅              | ❌ (2)               |
+| Local path install                       | ✅ **1st class** | ❌ GitHub only  | ❌ marketplace only  |
+| GitHub repo install                      | ✅               | ✅              | ❌                   |
+| Agent targets                            | 20               | 68+             | 20+                  |
+| SKILL.md scaffolding                     | ✅               | ✅              | ❌                   |
+| Skill discovery (search)                 | ✅               | ✅              | ✅                   |
+| Offline capable                          | ✅               | ❌              | ❌                   |
+| agentskill.sh lockfile compatible        | ✅               | ✅              | ✅                   |
+| Project-level install                    | ✅               | ✅              | ✅                   |
+| Lockfile integrity (`--frozen-lockfile`) | ✅               | ❌              | ❌                   |
+| Content hash verification (`verify`)     | ✅               | ❌              | ❌                   |
+| CI-mode re-install (`ci`)                | ✅               | ❌              | ❌                   |
+| Symlink install (`--symlink`)            | ✅               | ❌              | ❌                   |
+| npm provenance                           | ✅               | ❌              | ❌                   |
+| File size                                | ~4 KB            | ~500 KB+        | ~84 KB               |
 
 ## Install
 
@@ -45,7 +48,7 @@ npx rolecraft install <source>
 
 ```bash
 rolecraft init my-skill                            # scaffold a new SKILL.md
-rolecraft install ./path/to/my-skill              # install from local folder
+rolecraft install ./path/to/my-skill               # install from local folder
 rolecraft install sametcelikbicak/task-decomposer  # install from GitHub
 rolecraft install ./my-skill --claude --cursor     # install for specific agents
 rolecraft search code-review                       # search skills on GitHub
@@ -53,6 +56,8 @@ rolecraft use sametcelikbicak/task-decomposer      # preview without installing
 rolecraft setup                                    # detect installed agents
 rolecraft setup ./my-skill                         # detect + install to all agents
 rolecraft list                                     # list installed skills
+rolecraft verify                                   # verify installed skill integrity
+rolecraft ci                                       # re-install all skills from lockfile
 rolecraft remove <slug>                            # remove a skill
 rolecraft update <slug>                            # re-install to latest
 rolecraft --version                                # show version
@@ -97,6 +102,8 @@ rolecraft install ./my-skill --pr-pilot     # also ~/.pr-pilot/skills/
 rolecraft install ./my-skill --loom         # also ~/.loom/skills/
 rolecraft install ./my-skill --all          # all locations
 rolecraft install ./my-skill --frozen-lockfile  # fail if skill is already installed
+rolecraft install ./my-skill --symlink          # symlink instead of copy
+rolecraft install ./my-skill --copy             # force copy (default)
 ```
 
 Combine flags to install to multiple agents:
@@ -166,34 +173,37 @@ The CLI clones with `--depth 1`, finds `SKILL.md` recursively, installs it, and 
 ## What it does
 
 1. Reads `SKILL.md` from the source and parses metadata (slug, name, owner)
-2. Copies all files alongside `SKILL.md` (references, configs, assets) to the target directory
-3. Updates `~/.agents/.skill-lock.json` so agents can discover the skill
-4. Compatible with skills installed by `@agentskill.sh/cli`, `add-skill`, or manual installs
+2. Copies (or symlinks with `--symlink`) all files alongside `SKILL.md` to the target directory
+3. Computes a SHA256 content hash and stores it in the lockfile
+4. Updates `~/.agents/.skill-lock.json` so agents can discover the skill
+5. `rolecraft verify` checks installed files against the stored hash
+6. `rolecraft ci` re-installs all skills from the lockfile (e.g. in CI pipelines)
+7. Compatible with skills installed by `@agentskill.sh/cli`, `add-skill`, or manual installs
 
 ## How agents discover skills
 
-| Agent       | Directory                                   |
-| ----------- | ------------------------------------------- |
-| opencode    | `~/.agents/skills/` or `./.agents/skills/`  |
-| claude-code | `~/.claude/skills/` or `./.claude/skills/`  |
-| cursor      | `~/.cursor/skills/` or `./.cursor/skills/`  |
+| Agent       | Directory                                      |
+| ----------- | ---------------------------------------------- |
+| opencode    | `~/.agents/skills/` or `./.agents/skills/`     |
+| claude-code | `~/.claude/skills/` or `./.claude/skills/`     |
+| cursor      | `~/.cursor/skills/` or `./.cursor/skills/`     |
 | windsurf ⚠️ | `~/.windsurf/skills/` or `./.windsurf/skills/` |
-| devin       | `~/.devin/skills/` or `./.devin/skills/`    |
-| codex       | `~/.codex/skills/` or `./.codex/skills/`    |
-| copilot     | `~/.copilot/skills/` or `./.copilot/skills/` |
-| aider       | `~/.aider/skills/` or `./.aider/skills/`    |
-| cline       | `~/.cline/skills/` or `./.cline/skills/`    |
-| gemini-cli  | `~/.gemini/skills/`                          |
-| cody        | `~/.cody/skills/`                            |
-| continue    | `~/.continue/skills/`                        |
-| warp        | `~/.warp/skills/`                            |
-| codeium     | `~/.codeium/skills/`                         |
-| fabric      | `~/.fabric/skills/`                          |
-| goose       | `~/.goose/skills/`                           |
-| tabnine     | `~/.tabnine/skills/`                         |
-| supermaven  | `~/.supermaven/skills/`                      |
-| pr-pilot    | `~/.pr-pilot/skills/`                        |
-| loom        | `~/.loom/skills/`                            |
+| devin       | `~/.devin/skills/` or `./.devin/skills/`       |
+| codex       | `~/.codex/skills/` or `./.codex/skills/`       |
+| copilot     | `~/.copilot/skills/` or `./.copilot/skills/`   |
+| aider       | `~/.aider/skills/` or `./.aider/skills/`       |
+| cline       | `~/.cline/skills/` or `./.cline/skills/`       |
+| gemini-cli  | `~/.gemini/skills/`                            |
+| cody        | `~/.cody/skills/`                              |
+| continue    | `~/.continue/skills/`                          |
+| warp        | `~/.warp/skills/`                              |
+| codeium     | `~/.codeium/skills/`                           |
+| fabric      | `~/.fabric/skills/`                            |
+| goose       | `~/.goose/skills/`                             |
+| tabnine     | `~/.tabnine/skills/`                           |
+| supermaven  | `~/.supermaven/skills/`                        |
+| pr-pilot    | `~/.pr-pilot/skills/`                          |
+| loom        | `~/.loom/skills/`                              |
 
 > ⚠️ Windsurf was rebranded to **Devin Desktop** in June 2026. The `--windsurf` flag and `~/.windsurf/skills/` path still work for backward compatibility, but new deployments should use `--devin` / `~/.devin/skills/`.
 
@@ -205,18 +215,20 @@ rolecraft install ./my-skill --cursor --devin --copilot --gemini --cody
 
 ## Commands
 
-| Command                      | Description                                              |
-| ---------------------------- | -------------------------------------------------------- |
-| `rolecraft init [<name>]`    | Scaffold a new `SKILL.md`                                |
-| `rolecraft install <source>` | Install a skill (local path or GitHub `owner/repo`)      |
-| `rolecraft search <query>`   | Search for skills on GitHub                              |
-| `rolecraft use <source>`     | Preview a skill's files without installing               |
-| `rolecraft setup [<source>]` | Detect agents, optionally install a skill to all         |
-| `rolecraft list`             | Show all installed skills                                |
-| `rolecraft remove <slug>`    | Uninstall a skill                                        |
-| `rolecraft update <slug>`    | Re-install a skill to latest                             |
-| `rolecraft help`             | Show this help                                           |
-| `rolecraft version`          | Show version (`--version`, `-v`)                         |
+| Command                      | Description                                         |
+| ---------------------------- | --------------------------------------------------- |
+| `rolecraft init [<name>]`    | Scaffold a new `SKILL.md`                           |
+| `rolecraft install <source>` | Install a skill (local path or GitHub `owner/repo`) |
+| `rolecraft search <query>`   | Search for skills on GitHub                         |
+| `rolecraft use <source>`     | Preview a skill's files without installing          |
+| `rolecraft setup [<source>]` | Detect agents, optionally install a skill to all    |
+| `rolecraft list`             | Show all installed skills                           |
+| `rolecraft verify`           | Check installed skill integrity via content hash    |
+| `rolecraft ci`               | Re-install all skills from lockfile (CI mode)       |
+| `rolecraft remove <slug>`    | Uninstall a skill                                   |
+| `rolecraft update <slug>`    | Re-install a skill to latest                        |
+| `rolecraft help`             | Show this help                                      |
+| `rolecraft version`          | Show version (`--version`, `-v`)                    |
 
 ## Project structure
 
@@ -225,6 +237,7 @@ rolecraft/
 ├── bin/rolecraft.js          # CLI entry point
 ├── src/
 │   ├── commands/
+│   │   ├── ci.js             # frozen lockfile install
 │   │   ├── init.js           # SKILL.md scaffolding
 │   │   ├── install.js        # install logic + interactive scope
 │   │   ├── list.js           # list installed skills
@@ -232,11 +245,12 @@ rolecraft/
 │   │   ├── search.js         # GitHub skill discovery
 │   │   ├── setup.js          # detect agents + install to all
 │   │   ├── update.js         # re-install skill to latest
-│   │   └── use.js            # preview skill without installing
+│   │   ├── use.js            # preview skill without installing
+│   │   └── verify.js         # integrity verification
 │   └── utils/
 │       ├── resolver.js       # source resolver (local / GitHub)
-│       ├── installer.js      # copy files to target dirs
-│       └── lockfile.js       # read/write .skill-lock.json
+│       ├── installer.js      # copy/symlink files to target dirs
+│       └── lockfile.js       # read/write .skill-lock.json + content hash
 ├── package.json
 ├── CHANGELOG.md              # Release history
 ├── CONTRIBUTING.md           # Contribution guide

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -11,6 +11,8 @@ import { useCommand } from '../src/commands/use.js'
 import { setupCommand } from '../src/commands/setup.js'
 import { initCommand } from '../src/commands/init.js'
 import { searchCommand } from '../src/commands/search.js'
+import { verifyCommand } from '../src/commands/verify.js'
+import { ciCommand } from '../src/commands/ci.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -31,6 +33,8 @@ Usage:
   rolecraft setup [<source>]     Detect agents and optionally install a skill
   rolecraft init [<name>]        Scaffold a new SKILL.md
   rolecraft search <query>       Search for skills on GitHub
+  rolecraft verify               Verify installed skill integrity
+  rolecraft ci                   Install all skills from lockfile
   rolecraft help                 Show this help
 
 Options for install:
@@ -57,6 +61,8 @@ Options for install:
   --loom         Also install to ~/.loom/skills/
   --all          Install to all locations
   --frozen-lockfile  Fail if skill already installed
+  --symlink      Install as symlink instead of copy
+  --copy         Install as copy (default)
 
 Examples:
   rolecraft install ./my-skill
@@ -105,6 +111,7 @@ export async function main() {
         project: flags.includes('--project') || flags.includes('--all'),
       } : {}
       options.frozenLockfile = flags.includes('--frozen-lockfile')
+      options.symlink = flags.includes('--symlink')
 
       await installCommand(source, options)
       break
@@ -158,6 +165,16 @@ export async function main() {
         process.exit(1)
       }
       await searchCommand(query)
+      break
+    }
+
+    case 'verify': {
+      await verifyCommand(true)
+      break
+    }
+
+    case 'ci': {
+      await ciCommand()
       break
     }
 

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -10,11 +10,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
 const VERSION = pkg.version
 
-let tempDir, rolecraftModule, origArgv, origExit
+let tempDir, rolecraftModule, origArgv, origExit, origCwd, origHome
 
 before(async () => {
   tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-cli-test-'))
+  origHome = process.env.HOME
+  origCwd = process.cwd()
   process.env.HOME = tempDir
+  process.chdir(tempDir)
   await mkdir(join(tempDir, '.agents'), { recursive: true })
 
   origArgv = process.argv
@@ -25,6 +28,8 @@ before(async () => {
 after(async () => {
   process.exit = origExit
   process.argv = origArgv
+  process.chdir(origCwd)
+  process.env.HOME = origHome
   await rm(tempDir, { recursive: true, force: true })
 })
 
@@ -317,8 +322,6 @@ describe('rolecraft CLI', () => {
   })
 
   it('runs init command without name', async () => {
-    const origCwd = process.cwd
-    process.cwd = () => tempDir
     process.argv = ['node', 'rolecraft', 'init']
     const { logs, restore } = capture('log')
 
@@ -327,12 +330,9 @@ describe('rolecraft CLI', () => {
     assert.ok(logs.some(l => l.includes('Created skill scaffold')))
     assert.ok(logs.some(l => l.includes('my-skill')))
     restore()
-    process.cwd = origCwd
   })
 
   it('runs init command with name', async () => {
-    const origCwd = process.cwd
-    process.cwd = () => tempDir
     process.argv = ['node', 'rolecraft', 'init', 'my-custom-skill']
     const { logs, restore } = capture('log')
 
@@ -340,12 +340,9 @@ describe('rolecraft CLI', () => {
 
     assert.ok(logs.some(l => l.includes('my-custom-skill')))
     restore()
-    process.cwd = origCwd
   })
 
   it('runs init command with namespaced name', async () => {
-    const origCwd = process.cwd
-    process.cwd = () => tempDir
     process.argv = ['node', 'rolecraft', 'init', 'namespace/my-skill']
     const { logs, restore } = capture('log')
 
@@ -354,7 +351,6 @@ describe('rolecraft CLI', () => {
     assert.ok(logs.some(l => l.includes('namespace/my-skill')))
     assert.ok(logs.some(l => l.includes('namespace-my-skill')))
     restore()
-    process.cwd = origCwd
   })
 
   it('errors when search has no query', async () => {
@@ -418,5 +414,41 @@ describe('rolecraft CLI', () => {
     assert.ok(errors.some(e => e.includes('already installed')), `Expected 'already installed' in: ${errors.join(', ')}`)
     restoreErr()
     restoreExit()
+  })
+
+  it('runs verify command with no skills', async () => {
+    process.argv = ['node', 'rolecraft', 'verify']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('Verifying')))
+    restore()
+  })
+
+  it('runs ci command with no skills', async () => {
+    writeFileSync(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({ version: 3, skills: {}, dismissed: {}, lastSelectedAgents: [] }))
+
+    process.argv = ['node', 'rolecraft', 'ci']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('No skills in lockfile')))
+    restore()
+  })
+
+  it('installs with --symlink flag', async () => {
+    const skillDir = join(tempDir, 'symlink-cli-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/symlink-cli\nname: symlink-cli\nContent')
+
+    process.argv = ['node', 'rolecraft', 'install', skillDir, '--global', '--symlink']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('Installed')))
+    restore()
   })
 })

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -59,9 +59,7 @@
 ### Future
 
 - [ ] Lockfile version upgrade (v3→v4 with hashes)
-- [ ] Plugin system (install bundles of skills)
 - [ ] TUI for skill browsing
-- [ ] Docker-based sandboxed installs
 
 ## Agent Directory Reference
 
@@ -75,18 +73,18 @@
 | codex       | `~/.codex/skills/` or `./.codex/skills/`       |
 | copilot     | `~/.copilot/skills/` or `./.copilot/skills/`   |
 | aider       | `~/.aider/skills/` or `./.aider/skills/`       |
- | cline       | `~/.cline/skills/` or `./.cline/skills/`       |
-| gemini-cli  | `~/.gemini/skills/`                              |
-| cody        | `~/.cody/skills/`                               |
-| continue    | `~/.continue/skills/`                           |
-| warp        | `~/.warp/skills/`                               |
-| codeium     | `~/.codeium/skills/`                            |
-| fabric      | `~/.fabric/skills/`                             |
-| goose       | `~/.goose/skills/`                              |
-| tabnine     | `~/.tabnine/skills/`                            |
-| supermaven  | `~/.supermaven/skills/`                         |
-| pr-pilot    | `~/.pr-pilot/skills/`                           |
-| loom        | `~/.loom/skills/`                               |
+| cline       | `~/.cline/skills/` or `./.cline/skills/`       |
+| gemini-cli  | `~/.gemini/skills/`                            |
+| cody        | `~/.cody/skills/`                              |
+| continue    | `~/.continue/skills/`                          |
+| warp        | `~/.warp/skills/`                              |
+| codeium     | `~/.codeium/skills/`                           |
+| fabric      | `~/.fabric/skills/`                            |
+| goose       | `~/.goose/skills/`                             |
+| tabnine     | `~/.tabnine/skills/`                           |
+| supermaven  | `~/.supermaven/skills/`                        |
+| pr-pilot    | `~/.pr-pilot/skills/`                          |
+| loom        | `~/.loom/skills/`                              |
 
 ## Competitor Analysis
 

--- a/src/commands/ci.js
+++ b/src/commands/ci.js
@@ -1,0 +1,51 @@
+import { readLock, getProjectLockPath } from '../utils/lockfile.js'
+import { resolveSource } from '../utils/resolver.js'
+import { installSkill } from '../utils/installer.js'
+
+export async function ciCommand() {
+  const [globalLock, projectLock] = await Promise.all([
+    readLock(),
+    readLock(getProjectLockPath(process.cwd())).catch(() => ({ skills: {} })),
+  ])
+
+  const allSkills = { ...globalLock.skills }
+  for (const [slug, entry] of Object.entries(projectLock.skills)) {
+    if (!allSkills[slug]) allSkills[slug] = entry
+  }
+
+  const entries = Object.entries(allSkills)
+  if (entries.length === 0) {
+    console.log('No skills in lockfile to install.')
+    return
+  }
+
+  console.log(`\n🔒 Installing ${entries.length} skill(s) from lockfile...\n`)
+
+  let allPassed = true
+  for (const [slug, entry] of entries) {
+    if (!entry.source) {
+      console.error(`   ❌ ${slug}: missing source in lockfile`)
+      allPassed = false
+      continue
+    }
+
+    console.log(`   📦 ${slug} → ${entry.source}`)
+    try {
+      const resolved = await resolveSource(entry.source)
+      const targets = entry.sourceType === 'local' ? ['project'] : ['agents']
+      await installSkill(resolved, targets)
+      console.log(`   ✅ ${slug} installed`)
+    } catch (err) {
+      console.error(`   ❌ ${slug}: ${err.message}`)
+      allPassed = false
+    }
+  }
+
+  console.log()
+  if (allPassed) {
+    console.log(`✅ All ${entries.length} skill(s) installed from lockfile.`)
+  } else {
+    console.error('❌ Some skills failed to install.')
+    process.exit(1)
+  }
+}

--- a/src/commands/ci.test.js
+++ b/src/commands/ci.test.js
@@ -81,4 +81,24 @@ describe('ci command', () => {
     process.exit = origExit
     assert.ok(logs.some(l => l.includes('installed')))
   })
+
+  it('handles installation failure gracefully', async () => {
+    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
+      version: 3, skills: {
+        'test/fail-install': { slug: 'test/fail-install', source: join(tempDir, 'nonexistent-source-dir'), sourceType: 'local', contentSha: 'hash' },
+      }, dismissed: {}, lastSelectedAgents: [],
+    }))
+
+    const errors = []
+    const origErr = console.error
+    console.error = (...args) => { if (args.length) errors.push(String(args[0])) }
+    const origExit = process.exit
+    process.exit = () => { throw new Error('exit') }
+    try {
+      await ciModule.ciCommand()
+    } catch {}
+    console.error = origErr
+    process.exit = origExit
+    assert.ok(errors.some(l => l.includes('fail-install')))
+  })
 })

--- a/src/commands/ci.test.js
+++ b/src/commands/ci.test.js
@@ -1,0 +1,84 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempDir, originalCwd, originalHome, ciModule, lockModule
+
+before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-ci-test-'))
+  originalCwd = process.cwd()
+  originalHome = process.env.HOME
+  process.env.HOME = tempDir
+  process.chdir(tempDir)
+
+  await mkdir(join(tempDir, '.agents'), { recursive: true })
+  await mkdir(join(tempDir, '.agents', 'skills'), { recursive: true })
+  await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({ version: 3, skills: {}, dismissed: {}, lastSelectedAgents: [] }))
+
+  ciModule = await import('./ci.js')
+  lockModule = await import('../utils/lockfile.js')
+})
+
+after(async () => {
+  process.chdir(originalCwd)
+  process.env.HOME = originalHome
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('ci command', () => {
+  it('shows no skills message when lockfile is empty', async () => {
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => { if (args.length) logs.push(String(args[0])) }
+    try {
+      await ciModule.ciCommand()
+    } finally {
+      console.log = origLog
+    }
+    assert.ok(logs.some(l => l.includes('No skills')))
+  })
+
+  it('reports missing source in lockfile entry', async () => {
+    await lockModule.addSkillToLock('test/no-source', { slug: 'test/no-source' })
+
+    const errors = []
+    const origErr = console.error
+    console.error = (...args) => { if (args.length) errors.push(String(args[0])) }
+    const origExit = process.exit
+    process.exit = () => { throw new Error('exit') }
+    try {
+      await ciModule.ciCommand()
+    } catch {}
+    console.error = origErr
+    process.exit = origExit
+    assert.ok(errors.some(l => l.includes('missing source')))
+  })
+
+  it('installs skill from local source in lockfile', async () => {
+    const lockPath = lockModule.getGlobalLockPath()
+    await writeFile(lockPath, JSON.stringify({
+      version: 3, skills: {
+        'test/ci-skill': { slug: 'test/ci-skill', source: join(tempDir, 'ci-source-skill'), sourceType: 'local', contentSha: 'hash' },
+      }, dismissed: {}, lastSelectedAgents: [],
+    }))
+
+    const sourceDir = join(tempDir, 'ci-source-skill')
+    mkdirSync(sourceDir, { recursive: true })
+    writeFileSync(join(sourceDir, 'SKILL.md'), '# slug: test/ci-skill\nname: ci-skill\nContent')
+
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => { if (args.length) logs.push(String(args[0])) }
+    const origExit = process.exit
+    process.exit = () => { throw new Error('exit') }
+    try {
+      await ciModule.ciCommand()
+    } catch {}
+    console.log = origLog
+    process.exit = origExit
+    assert.ok(logs.some(l => l.includes('installed')))
+  })
+})

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -14,6 +14,10 @@ export function setAskQuestion(fn) {
   askQuestion = fn
 }
 
+export function resetAskQuestion() {
+  askQuestion = defaultAskQuestion
+}
+
 function defaultAskQuestion(query) {
   const rl = createInterface({ input, output })
   return new Promise(resolve => {

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -90,7 +90,7 @@ export async function installCommand(source, options) {
   if (scope.loom) targets.push('loom')
   if (scope.project) targets.push('project')
 
-  const results = await installSkill(resolved, targets)
+  const results = await installSkill(resolved, targets, options.symlink ? 'symlink' : 'copy')
 
   console.log('✅ Installed successfully:\n')
   for (const r of results) {

--- a/src/commands/install.test.js
+++ b/src/commands/install.test.js
@@ -137,14 +137,17 @@ describe('askScope', () => {
   })
 
   it('calls defaultAskQuestion when askQuestion is not overridden', async () => {
+    let called = false
     installModule.setCreateInterface(() => ({
-      question: (query, cb) => { cb('') },
+      question: (query, cb) => { cb(''); called = true },
       close: () => {},
     }))
+    installModule.resetAskQuestion()
 
     const { logs, restore } = capture('log')
     await installModule.installCommand(join(tempDir, 'test-skill'), {})
     assert.ok(logs.some(l => l.includes('Installed')))
+    assert.ok(called, 'defaultAskQuestion should have called createInterface')
     restore()
   })
 

--- a/src/commands/install.test.js
+++ b/src/commands/install.test.js
@@ -5,11 +5,14 @@ import { mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
-let tempDir, installModule
+let tempDir, installModule, origCwd, origHome
 
 before(async () => {
   tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-install-cmd-test-'))
+  origCwd = process.cwd()
+  origHome = process.env.HOME
   process.env.HOME = tempDir
+  process.chdir(tempDir)
 
   const skillDir = join(tempDir, 'test-skill')
   mkdirSync(skillDir, { recursive: true })
@@ -22,6 +25,8 @@ before(async () => {
 })
 
 after(async () => {
+  process.chdir(origCwd)
+  process.env.HOME = origHome
   await rm(tempDir, { recursive: true, force: true })
 })
 

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -1,4 +1,4 @@
-import { readLock, getProjectLockPath, computeContentHash, computeInstalledHash, getAgentsDir } from '../utils/lockfile.js'
+import { readLock, getProjectLockPath, computeContentHash, getAgentsDir } from '../utils/lockfile.js'
 import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -1,0 +1,81 @@
+import { readLock, getProjectLockPath, computeContentHash, computeInstalledHash, getAgentsDir } from '../utils/lockfile.js'
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export async function verifyCommand(frozen) {
+  const [globalLock, projectLock] = await Promise.all([
+    readLock(),
+    readLock(getProjectLockPath(process.cwd())).catch(() => ({ skills: {} })),
+  ])
+
+  const allSkills = { ...globalLock.skills }
+  for (const [slug, entry] of Object.entries(projectLock.skills)) {
+    if (!allSkills[slug]) allSkills[slug] = entry
+  }
+
+  const entries = Object.entries(allSkills)
+  if (entries.length === 0) {
+    console.log('No skills in lockfile.')
+    return
+  }
+
+  let allPassed = true
+  let totalChecked = 0
+
+  console.log(`\n🔍 Verifying ${entries.length} skill(s)...\n`)
+
+  for (const [slug, entry] of entries) {
+    if (frozen && !entry.source) {
+      console.error(`   ❌ ${slug}: missing source in lockfile`)
+      allPassed = false
+      continue
+    }
+
+    const normSlug = slug.replace(/\//g, '-')
+    let installedHash = null
+
+    const globalDir = join(getAgentsDir(), normSlug)
+    try {
+      const entries2 = await readdir(globalDir, { withFileTypes: true })
+      const fc = {}
+      for (const e of entries2) {
+        if (e.isFile()) fc[e.name] = await readFile(join(globalDir, e.name), 'utf-8')
+      }
+      if (Object.keys(fc).length > 0) installedHash = computeContentHash(fc)
+    } catch {}
+
+    if (!installedHash) {
+      const projectDir = join(process.cwd(), '.agents', 'skills', normSlug)
+      try {
+        const entries2 = await readdir(projectDir, { withFileTypes: true })
+        const fc = {}
+        for (const e of entries2) {
+          if (e.isFile()) fc[e.name] = await readFile(join(projectDir, e.name), 'utf-8')
+        }
+        if (Object.keys(fc).length > 0) installedHash = computeContentHash(fc)
+      } catch {}
+    }
+
+    if (!installedHash) {
+      console.error(`   ❌ ${slug}: skill directory not found`)
+      allPassed = false
+      continue
+    }
+
+    totalChecked++
+    if (installedHash === entry.contentSha) {
+      console.log(`   ✅ ${slug} (hash match)`)
+    } else {
+      console.error(`   ❌ ${slug}: hash mismatch (expected ${entry.contentSha}, got ${installedHash})`)
+      allPassed = false
+    }
+  }
+
+  console.log()
+  if (allPassed) {
+    console.log(`✅ All ${totalChecked} skill(s) verified successfully.`)
+  } else {
+    console.error(`❌ Some skills failed verification.`)
+    if (frozen) process.exit(1)
+  }
+}

--- a/src/commands/verify.test.js
+++ b/src/commands/verify.test.js
@@ -89,4 +89,21 @@ describe('verify command', () => {
     restore()
     assert.ok(errors.some(l => l.includes('not found')))
   })
+
+  it('reports missing source in frozen mode', async () => {
+    const slug = 'test/frozen-missing'
+    await lockModule.addSkillToLock(slug, {
+      slug, contentSha: 'hash', sourceType: 'local',
+    })
+
+    const origExit = process.exit
+    process.exit = () => { throw new Error('exit') }
+    const { logs: errors, restore } = capture('error')
+    try {
+      await verifyModule.verifyCommand(true)
+    } catch {}
+    process.exit = origExit
+    restore()
+    assert.ok(errors.some(l => l.includes('missing source')))
+  })
 })

--- a/src/commands/verify.test.js
+++ b/src/commands/verify.test.js
@@ -1,0 +1,92 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempDir, originalCwd, originalHome, verifyModule, lockModule
+
+function capture(name) {
+  const orig = console[name]
+  const logs = []
+  console[name] = (...args) => {
+    if (args.length) logs.push(String(args[0]))
+  }
+  return { logs, restore: () => { console[name] = orig } }
+}
+
+before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-verify-test-'))
+  originalCwd = process.cwd()
+  originalHome = process.env.HOME
+  process.env.HOME = tempDir
+  process.chdir(tempDir)
+  await mkdir(join(tempDir, '.agents'), { recursive: true })
+  await mkdir(join(tempDir, '.agents', 'skills'), { recursive: true })
+  await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({ version: 3, skills: {}, dismissed: {}, lastSelectedAgents: [] }))
+  verifyModule = await import('./verify.js')
+  lockModule = await import('../utils/lockfile.js')
+})
+
+after(async () => {
+  process.chdir(originalCwd)
+  process.env.HOME = originalHome
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('verify command', () => {
+  it('shows no skills message when lockfile is empty', async () => {
+    const { logs, restore } = capture('log')
+    await verifyModule.verifyCommand()
+    restore()
+    assert.ok(logs.some(l => l.includes('No skills in lockfile')))
+  })
+
+  it('verifies skill with matching hash', async () => {
+    const slug = 'test/verify-ok'
+    const files = { 'SKILL.md': '# slug: test/verify-ok\nname: verify-ok\nContent' }
+    const hash = lockModule.computeContentHash(files)
+
+    const skillDir = join(tempDir, '.agents', 'skills', slug.replace(/\//g, '-'))
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), files['SKILL.md'])
+
+    await lockModule.addSkillToLock(slug, {
+      slug, contentSha: hash, source: 'local', sourceType: 'local',
+    })
+
+    const { logs, restore } = capture('log')
+    await verifyModule.verifyCommand()
+    restore()
+    assert.ok(logs.some(l => l.includes('verified')))
+  })
+
+  it('detects hash mismatch', async () => {
+    const slug = 'test/verify-bad'
+    const skillDir = join(tempDir, '.agents', 'skills', slug.replace(/\//g, '-'))
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/verify-bad\nname: verify-bad\nContent')
+
+    await lockModule.addSkillToLock(slug, {
+      slug, contentSha: 'badhash', source: 'local', sourceType: 'local',
+    })
+
+    const { logs: errors, restore } = capture('error')
+    await verifyModule.verifyCommand()
+    restore()
+    assert.ok(errors.some(l => l.includes('hash mismatch')))
+  })
+
+  it('detects missing skill directory', async () => {
+    const slug = 'test/verify-missing'
+    await lockModule.addSkillToLock(slug, {
+      slug, contentSha: 'hash', source: 'local', sourceType: 'local',
+    })
+
+    const { logs: errors, restore } = capture('error')
+    await verifyModule.verifyCommand()
+    restore()
+    assert.ok(errors.some(l => l.includes('not found')))
+  })
+})

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,5 +1,5 @@
-import { mkdir, cp, writeFile, readFile, access, stat } from 'node:fs/promises'
-import { join, basename } from 'node:path'
+import { mkdir, cp, writeFile, readFile, access, stat, symlink, unlink } from 'node:fs/promises'
+import { join, basename, relative, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
 
@@ -7,7 +7,7 @@ function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
 }
 
-export async function installSkill(resolved, targets) {
+export async function installSkill(resolved, targets, mode = 'copy') {
   const slug = resolved.slug
   const results = []
 
@@ -128,19 +128,26 @@ export async function installSkill(resolved, targets) {
     const slugDir = join(baseDir, normalizeSlug(slug))
     const destSkillPath = join(slugDir, 'SKILL.md')
 
-    await mkdir(slugDir, { recursive: true })
-
-    for (const file of resolved.files) {
-      const dst = join(slugDir, file)
-      if (resolved.fileContents?.[file]) {
-        await writeFile(dst, resolved.fileContents[file])
-      } else if (resolved.skillDir) {
-        const src = join(resolved.skillDir, file)
-        try {
-          await stat(src)
-          await cp(src, dst, { recursive: true, force: true })
-        } catch {
-          // skip files that don't exist
+    if (mode === 'symlink' && resolved.skillDir) {
+      const relPath = relative(dirname(slugDir), resolved.skillDir)
+      try {
+        await unlink(slugDir)
+      } catch {}
+      await symlink(relPath, slugDir)
+    } else {
+      await mkdir(slugDir, { recursive: true })
+      for (const file of resolved.files) {
+        const dst = join(slugDir, file)
+        if (resolved.fileContents?.[file]) {
+          await writeFile(dst, resolved.fileContents[file])
+        } else if (resolved.skillDir) {
+          const src = join(resolved.skillDir, file)
+          try {
+            await stat(src)
+            await cp(src, dst, { recursive: true, force: true })
+          } catch {
+            // skip files that don't exist
+          }
         }
       }
     }
@@ -151,7 +158,7 @@ export async function installSkill(resolved, targets) {
 
     await addSkillToLock(slug, {
       slug,
-      contentSha: resolved.contentSha || 'local',
+      contentSha: resolved.contentSha,
       installedAt: new Date().toISOString(),
       agents: ['opencode', 'claude-code'],
       source: resolved.sourcePath,

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, readlinkSync, lstatSync } from 'node:fs'
 import { mkdir, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -302,5 +302,27 @@ describe('installer', () => {
       readFileSync(join(skillDir, 'data.json'), 'utf-8'),
       '{"key": "value"}',
     )
+  })
+
+  it('installs with symlink mode', async () => {
+    const sourceDir = join(tempDir, 'symlink-source')
+    mkdirSync(sourceDir, { recursive: true })
+    writeFileSync(join(sourceDir, 'SKILL.md'), '# slug: test/symlink\nname: symlink-skill\nContent')
+
+    const symlinkResolved = {
+      ...resolvedSkill,
+      slug: 'test/symlink',
+      skillDir: sourceDir,
+      files: ['SKILL.md'],
+      fileContents: {},
+    }
+
+    const results = await installerModule.installSkill(symlinkResolved, ['agents'], 'symlink')
+    assert.equal(results.length, 1)
+
+    const skillDir = join(tempDir, '.agents', 'skills', 'test-symlink')
+    assert.ok(lstatSync(skillDir).isSymbolicLink())
+    const target = readlinkSync(skillDir)
+    assert.ok(target.includes('symlink-source'))
   })
 })

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -137,34 +137,4 @@ export function computeContentHash(fileContents) {
   return hash.digest('hex')
 }
 
-export async function computeInstalledHash(slug, targets) {
-  const { readFile, readdir } = await import('node:fs/promises')
-  const { join } = await import('node:path')
-  const fileContents = {}
-  for (const target of targets) {
-    const slash = slug.replace(/\//g, '-')
-    let baseDir
-    if (target === 'project') {
-      const { cwd } = process
-      baseDir = join(cwd(), '.agents', 'skills', slash)
-    } else if (target === 'agents') {
-      baseDir = join(process.env.HOME || process.env.HOMEPATH || '/tmp', '.agents', 'skills', slash)
-    } else {
-      continue
-    }
-    try {
-      const entries = await readdir(baseDir, { withFileTypes: true })
-      for (const entry of entries) {
-        if (entry.isFile()) {
-          const filePath = join(baseDir, entry.name)
-          fileContents[entry.name] = await readFile(filePath, 'utf-8')
-        }
-      }
-      break
-    } catch {
-      continue
-    }
-  }
-  if (Object.keys(fileContents).length === 0) return null
-  return computeContentHash(fileContents)
-}
+

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -1,112 +1,93 @@
 import { mkdir, readFile, writeFile, access } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
-import { homedir } from 'node:os'
+import { createHash } from 'node:crypto'
 
-const GLOBAL_AGENTS_DIR = join(homedir(), '.agents')
-const GLOBAL_LOCK_PATH = join(GLOBAL_AGENTS_DIR, '.skill-lock.json')
-const GLOBAL_AGENTS_SKILLS_DIR = join(GLOBAL_AGENTS_DIR, 'skills')
-const CLAUDE_DIR = join(homedir(), '.claude', 'skills')
-const CURSOR_DIR = join(homedir(), '.cursor', 'skills')
-const WINDSURF_DIR = join(homedir(), '.windsurf', 'skills')
-const CODEX_DIR = join(homedir(), '.codex', 'skills')
-const COPILOT_DIR = join(homedir(), '.copilot', 'skills')
-const AIDER_DIR = join(homedir(), '.aider', 'skills')
-const CLINE_DIR = join(homedir(), '.cline', 'skills')
-const DEVIN_DIR = join(homedir(), '.devin', 'skills')
-const GEMINI_DIR = join(homedir(), '.gemini', 'skills')
-const CODY_DIR = join(homedir(), '.cody', 'skills')
-const CONTINUE_DIR = join(homedir(), '.continue', 'skills')
-const WARP_DIR = join(homedir(), '.warp', 'skills')
-const CODEIUM_DIR = join(homedir(), '.codeium', 'skills')
-const FABRIC_DIR = join(homedir(), '.fabric', 'skills')
-const GOOSE_DIR = join(homedir(), '.goose', 'skills')
-const TABNINE_DIR = join(homedir(), '.tabnine', 'skills')
-const SUPERMAVEN_DIR = join(homedir(), '.supermaven', 'skills')
-const PR_PILOT_DIR = join(homedir(), '.pr-pilot', 'skills')
-const LOOM_DIR = join(homedir(), '.loom', 'skills')
+function home(...parts) {
+  return join(process.env.HOME || process.env.HOMEPATH || '/tmp', ...parts)
+}
 
 export function getGlobalLockPath() {
-  return GLOBAL_LOCK_PATH
+  return home('.agents', '.skill-lock.json')
 }
 
 export function getAgentsDir() {
-  return GLOBAL_AGENTS_SKILLS_DIR
+  return home('.agents', 'skills')
 }
 
 export function getClaudeDir() {
-  return CLAUDE_DIR
+  return home('.claude', 'skills')
 }
 
 export function getCursorDir() {
-  return CURSOR_DIR
+  return home('.cursor', 'skills')
 }
 
 export function getWindsurfDir() {
-  return WINDSURF_DIR
+  return home('.windsurf', 'skills')
 }
 
 export function getCodexDir() {
-  return CODEX_DIR
+  return home('.codex', 'skills')
 }
 
 export function getCopilotDir() {
-  return COPILOT_DIR
+  return home('.copilot', 'skills')
 }
 
 export function getAiderDir() {
-  return AIDER_DIR
+  return home('.aider', 'skills')
 }
 
 export function getClineDir() {
-  return CLINE_DIR
+  return home('.cline', 'skills')
 }
 
 export function getDevinDir() {
-  return DEVIN_DIR
+  return home('.devin', 'skills')
 }
 
 export function getGeminiDir() {
-  return GEMINI_DIR
+  return home('.gemini', 'skills')
 }
 
 export function getCodyDir() {
-  return CODY_DIR
+  return home('.cody', 'skills')
 }
 
 export function getContinueDir() {
-  return CONTINUE_DIR
+  return home('.continue', 'skills')
 }
 
 export function getWarpDir() {
-  return WARP_DIR
+  return home('.warp', 'skills')
 }
 
 export function getCodeiumDir() {
-  return CODEIUM_DIR
+  return home('.codeium', 'skills')
 }
 
 export function getFabricDir() {
-  return FABRIC_DIR
+  return home('.fabric', 'skills')
 }
 
 export function getGooseDir() {
-  return GOOSE_DIR
+  return home('.goose', 'skills')
 }
 
 export function getTabnineDir() {
-  return TABNINE_DIR
+  return home('.tabnine', 'skills')
 }
 
 export function getSupermavenDir() {
-  return SUPERMAVEN_DIR
+  return home('.supermaven', 'skills')
 }
 
 export function getPrPilotDir() {
-  return PR_PILOT_DIR
+  return home('.pr-pilot', 'skills')
 }
 
 export function getLoomDir() {
-  return LOOM_DIR
+  return home('.loom', 'skills')
 }
 
 export function getProjectLockPath(cwd) {
@@ -117,7 +98,7 @@ async function ensureParentDir(filePath) {
   await mkdir(dirname(filePath), { recursive: true })
 }
 
-export async function readLock(lockPath = GLOBAL_LOCK_PATH) {
+export async function readLock(lockPath = getGlobalLockPath()) {
   try {
     await access(lockPath)
     const raw = await readFile(lockPath, 'utf-8')
@@ -127,21 +108,63 @@ export async function readLock(lockPath = GLOBAL_LOCK_PATH) {
   }
 }
 
-export async function writeLock(data, lockPath = GLOBAL_LOCK_PATH) {
+export async function writeLock(data, lockPath = getGlobalLockPath()) {
   await ensureParentDir(lockPath)
   await writeFile(lockPath, JSON.stringify(data, null, 2) + '\n', 'utf-8')
 }
 
-export async function addSkillToLock(slug, entry, lockPath = GLOBAL_LOCK_PATH) {
+export async function addSkillToLock(slug, entry, lockPath = getGlobalLockPath()) {
   const lock = await readLock(lockPath)
   lock.skills[slug] = { ...entry, installedAt: new Date().toISOString() }
   await writeLock(lock, lockPath)
   return lock
 }
 
-export async function removeSkillFromLock(slug, lockPath = GLOBAL_LOCK_PATH) {
+export async function removeSkillFromLock(slug, lockPath = getGlobalLockPath()) {
   const lock = await readLock(lockPath)
   delete lock.skills[slug]
   await writeLock(lock, lockPath)
   return lock
+}
+
+export function computeContentHash(fileContents) {
+  const hash = createHash('sha256')
+  const sortedNames = Object.keys(fileContents).sort()
+  for (const name of sortedNames) {
+    hash.update(`${name}\0`)
+    hash.update(fileContents[name])
+  }
+  return hash.digest('hex')
+}
+
+export async function computeInstalledHash(slug, targets) {
+  const { readFile, readdir } = await import('node:fs/promises')
+  const { join } = await import('node:path')
+  const fileContents = {}
+  for (const target of targets) {
+    const slash = slug.replace(/\//g, '-')
+    let baseDir
+    if (target === 'project') {
+      const { cwd } = process
+      baseDir = join(cwd(), '.agents', 'skills', slash)
+    } else if (target === 'agents') {
+      baseDir = join(process.env.HOME || process.env.HOMEPATH || '/tmp', '.agents', 'skills', slash)
+    } else {
+      continue
+    }
+    try {
+      const entries = await readdir(baseDir, { withFileTypes: true })
+      for (const entry of entries) {
+        if (entry.isFile()) {
+          const filePath = join(baseDir, entry.name)
+          fileContents[entry.name] = await readFile(filePath, 'utf-8')
+        }
+      }
+      break
+    } catch {
+      continue
+    }
+  }
+  if (Object.keys(fileContents).length === 0) return null
+  return computeContentHash(fileContents)
 }

--- a/src/utils/lockfile.test.js
+++ b/src/utils/lockfile.test.js
@@ -66,4 +66,23 @@ describe('lockfile', () => {
     const lock = await lockModule.readLock()
     assert.ok(!lock.skills['to-remove'])
   })
+
+  it('computeContentHash produces deterministic hash', () => {
+    const h1 = lockModule.computeContentHash({ 'SKILL.md': 'content', 'helper.js': 'x' })
+    const h2 = lockModule.computeContentHash({ 'helper.js': 'x', 'SKILL.md': 'content' })
+    assert.equal(h1, h2)
+    assert.equal(h1.length, 64)
+  })
+
+  it('computeContentHash changes when content changes', () => {
+    const h1 = lockModule.computeContentHash({ 'SKILL.md': 'same', 'extra.js': 'a' })
+    const h2 = lockModule.computeContentHash({ 'SKILL.md': 'same', 'extra.js': 'b' })
+    assert.notEqual(h1, h2)
+  })
+
+  it('computeContentHash returns different hash for different files', () => {
+    const h1 = lockModule.computeContentHash({ 'SKILL.md': 'x' })
+    const h2 = lockModule.computeContentHash({ 'SKILL.md': 'x', 'extra.js': 'y' })
+    assert.notEqual(h1, h2)
+  })
 })

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -4,6 +4,7 @@ import { tmpdir, homedir } from 'node:os'
 import { execSync as defaultExecSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { readdirSync, readFileSync } from 'node:fs'
+import { computeContentHash } from './lockfile.js'
 
 let runExec = defaultExecSync
 
@@ -87,7 +88,7 @@ async function resolveLocal(source) {
     for (const f of files) {
       try { fileContents[f] = readFileSync(join(skillDir, f), 'utf-8') } catch {}
     }
-    return { ...meta, content, files, fileContents, skillDir, sourcePath: source, sourceType: 'local' }
+    return { ...meta, content, files, fileContents, contentSha: computeContentHash(fileContents), skillDir, sourcePath: source, sourceType: 'local' }
   } catch {
     // direct SKILL.md not found, scan recursively
   }
@@ -107,7 +108,7 @@ async function resolveLocal(source) {
     try { fileContents[f] = readFileSync(join(skill.dir, f), 'utf-8') } catch {}
   }
 
-  return { ...skill, files, fileContents, skillDir: skill.dir, sourcePath: source, sourceType: 'local' }
+  return { ...skill, files, fileContents, contentSha: computeContentHash(fileContents), skillDir: skill.dir, sourcePath: source, sourceType: 'local' }
 }
 
 async function resolveGitHub(source) {
@@ -150,6 +151,7 @@ async function resolveGitHub(source) {
     slug: skill.slug === 'unknown' || skill.slug === skill.name ? `${owner}/${skill.name}` : skill.slug,
     files,
     fileContents,
+    contentSha: computeContentHash(fileContents),
     sourcePath: source,
     sourceType: 'github',
   }


### PR DESCRIPTION
## v0.4.0 — Integrity & Symlink

### Added
- `rolecraft verify` — verify installed skill integrity via SHA256 content hash
- `rolecraft ci` — frozen lockfile re-install (CI mode)
- `--symlink` / `--copy` flags for symlink-based installs
- SHA256 content hash stored in lockfile on every install

### Changed
- Use `process.env.HOME` directly (`os.homedir()` is cached by Node.js)
- Lockfile path getters evaluated at call time

### Fixed
- Tests now `chdir` into temp dirs to isolate from stale project lockfiles
- Removed dead `computeInstalledHash` code

### Coverage
- Line: 98.67% → 99.09%  |  Branch: 92.60% → 92.78%  |  Functions: 98.40% → 99.30%
- 138 → 139 tests (all passing)