### PR TITLE
Bug fixes and improvements for stable release

### DIFF
--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -1,4 +1,4 @@
-import { readFile, access, writeFile } from 'node:fs/promises'
+import { readFile, access, writeFile, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createInterface } from 'node:readline'
 import { stdin as input, stdout as output } from 'node:process'
@@ -33,7 +33,8 @@ async function resolveBundleFile(arg) {
     const resolvedPath = arg.startsWith('~') ? join(process.env.HOME || '/tmp', arg.slice(1)) : arg
     for (const candidate of [resolvedPath, join(process.cwd(), arg)]) {
       try {
-        await access(candidate)
+        const stats = await stat(candidate)
+        if (stats.isDirectory()) return null
         return candidate
       } catch {}
     }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -3,16 +3,20 @@ import { join } from 'node:path'
 
 export async function initCommand(name) {
   const skillName = name || 'my-skill'
-  const slug = skillName.includes('/') ? skillName : `local/${skillName}`
-  const displayName = slug.split('/')[1]
-  const dirName = skillName.replace(/\//g, '-')
+  const slug = skillName.includes('/') ? skillName : skillName
+  const displayName = slug.includes('/') ? slug.split('/')[1] : slug
+  const dirName = slug.replace(/\//g, '-')
   const dir = join(process.cwd(), dirName)
+  const owner = slug.includes('/') ? slug.split('/')[0] : 'local'
 
   await mkdir(dir, { recursive: true })
 
-  const content = `# slug: ${slug}
+  const content = `---
 name: ${displayName}
-# owner: local
+slug: ${slug}
+owner: ${owner}
+description: Describe what this skill does
+---
 
 Write your skill instructions here.
 `

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -9,7 +9,12 @@ function normalizeSlug(slug) {
 function findActualSlug(slug, lock) {
   if (lock.skills[slug]) return slug
   const normalized = normalizeSlug(slug)
-  return Object.keys(lock.skills).find(k => normalizeSlug(k) === normalized)
+  let found = Object.keys(lock.skills).find(k => normalizeSlug(k) === normalized)
+  if (found) return found
+  return Object.keys(lock.skills).find(k => {
+    const namePart = k.split('/').pop()
+    return namePart === slug || normalizeSlug(namePart) === normalized
+  })
 }
 
 export async function removeCommand(slug) {

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -52,36 +52,74 @@ async function pickAndInstall(items) {
   }
 }
 
-export async function searchCommand(query, options = {}) {
-  const url = `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}+filename:SKILL.md&per_page=20&sort=stars`
+function isGitHubRef(source) {
+  return /^[\w.-]+\/[\w.-]+$/.test(source) && !source.startsWith('/') && !source.startsWith('.')
+}
 
-  let response
-  try {
-    response = await runFetch(url, {
-      headers: { Accept: 'application/vnd.github.v3+json' },
-      signal: AbortSignal.timeout(10000),
-    })
-  } catch {
-    throw new Error('Failed to search GitHub. Check your internet connection.')
-  }
+async function searchGitHub(query, filenameFilter = true) {
+  const q = filenameFilter
+    ? `${encodeURIComponent(query)}+filename:SKILL.md`
+    : encodeURIComponent(query)
+  const url = `https://api.github.com/search/repositories?q=${q}&per_page=20&sort=stars`
+
+  const response = await runFetch(url, {
+    headers: { Accept: 'application/vnd.github.v3+json' },
+    signal: AbortSignal.timeout(10000),
+  })
 
   if (response.status === 403) {
-    console.log('\n⚠️  GitHub API rate limit reached. Try again later or use a local source.\n')
-    return
+    return { rateLimited: true }
   }
 
   if (!response.ok) {
-    throw new Error(`GitHub API error: ${response.status}`)
+    return { error: `GitHub API error: ${response.status}` }
   }
 
-  const data = await response.json()
+  return await response.json()
+}
 
-  if (data.items.length === 0) {
-    console.log(`\nNo skills found for "${query}".`)
-    return
+async function lookupGithubRepo(ref) {
+  const url = `https://api.github.com/repos/${ref}`
+  try {
+    const response = await runFetch(url, {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+      signal: AbortSignal.timeout(10000),
+    })
+    if (!response.ok) return null
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+async function searchOrLookup(query) {
+  if (isGitHubRef(query)) {
+    const repo = await lookupGithubRepo(query)
+    if (repo) {
+      const items = [{
+        full_name: repo.full_name,
+        description: repo.description,
+        stargazers_count: repo.stargazers_count,
+        language: repo.language,
+      }]
+      const data = await searchGitHub(query, true)
+      if (data.items && data.items.length > 0) {
+        return data
+      }
+      return { items, fromLookup: true }
+    }
+  }
+  return await searchGitHub(query, true)
+}
+
+function displayResults(data, query) {
+  const fromLookup = data.fromLookup
+  if (fromLookup) {
+    console.log(`\n🔍 Search results for "${query}":\n`)
+  } else {
+    console.log(`\n🔍 Search results for "${query}":\n`)
   }
 
-  console.log(`\n🔍 Search results for "${query}":\n`)
   for (const repo of data.items) {
     const desc = repo.description || 'No description'
     console.log(`   ${repo.full_name}`)
@@ -91,6 +129,47 @@ export async function searchCommand(query, options = {}) {
     console.log()
   }
   console.log(`${data.items.length} result(s) found.`)
+}
+
+export async function searchCommand(query, options = {}) {
+  let data
+
+  try {
+    data = await searchOrLookup(query)
+  } catch {
+    throw new Error('Failed to search GitHub. Check your internet connection.')
+  }
+
+  if (data.rateLimited) {
+    console.log('\n⚠️  GitHub API rate limit reached. Try again later or use a local source.\n')
+    return
+  }
+
+  if (data.error) {
+    throw new Error(data.error)
+  }
+
+  if (data.items.length === 0) {
+    try {
+      data = await searchGitHub(query, false)
+    } catch {
+      throw new Error('Failed to search GitHub. Check your internet connection.')
+    }
+
+    if (data.rateLimited) {
+      console.log('\n⚠️  GitHub API rate limit reached. Try again later or use a local source.\n')
+      return
+    }
+
+    if (data.items.length === 0) {
+      console.log(`\nNo skills found for "${query}".`)
+      return
+    }
+
+    console.log(`\nNo skills found with SKILL.md file. Search results for "${query}":\n`)
+  }
+
+  displayResults(data, query)
 
   if (options.interactive) {
     await pickAndInstall(data.items)

--- a/src/commands/search.test.js
+++ b/src/commands/search.test.js
@@ -24,6 +24,19 @@ function mockFetch(status, body) {
   }))
 }
 
+function mockSequentialFetch(responses) {
+  let idx = 0
+  searchModule.setFetch(() => {
+    const resp = responses[idx]
+    if (resp) idx++
+    return Promise.resolve({
+      status: resp?.status || 200,
+      ok: resp?.status ? (resp.status >= 200 && resp.status < 300) : true,
+      json: () => Promise.resolve(resp?.body || {}),
+    })
+  })
+}
+
 describe('search command', () => {
   after(() => {
     searchModule.setFetch(globalThis.fetch)
@@ -87,6 +100,35 @@ describe('search command', () => {
       () => searchModule.searchCommand('test'),
       /Failed to search GitHub/,
     )
+  })
+
+  it('shows repo from lookup when owner/repo query has no SKILL.md search results', async () => {
+    mockSequentialFetch([
+      { status: 200, body: { full_name: 'owner/skill-repo', description: 'A skill repo', stargazers_count: 10, language: 'TypeScript' } },
+      { status: 200, body: { items: [] } },
+    ])
+
+    const { logs, restore } = capture('log')
+    await searchModule.searchCommand('owner/skill-repo')
+    restore()
+
+    assert.ok(logs.some(l => l.includes('owner/skill-repo')))
+    assert.ok(logs.some(l => l.includes('A skill repo')))
+    assert.ok(logs.some(l => l.includes('10')))
+  })
+
+  it('falls back to broader search when lookup fails', async () => {
+    mockSequentialFetch([
+      { status: 404, body: {} },
+      { status: 200, body: { items: [] } },
+      { status: 200, body: { items: [] } },
+    ])
+
+    const { logs, restore } = capture('log')
+    await searchModule.searchCommand('owner/skill-repo')
+    restore()
+
+    assert.ok(logs.some(l => l.includes('No skills found')))
   })
 
   describe('interactive mode', () => {

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -11,7 +11,12 @@ function normalizeSlug(slug) {
 function findActualSlug(slug, lock) {
   if (lock.skills[slug]) return slug
   const normalized = normalizeSlug(slug)
-  return Object.keys(lock.skills).find(k => normalizeSlug(k) === normalized)
+  let found = Object.keys(lock.skills).find(k => normalizeSlug(k) === normalized)
+  if (found) return found
+  return Object.keys(lock.skills).find(k => {
+    const namePart = k.split('/').pop()
+    return namePart === slug || normalizeSlug(namePart) === normalized
+  })
 }
 
 function detectTargets(slug, cwd) {

--- a/src/commands/use.js
+++ b/src/commands/use.js
@@ -7,6 +7,7 @@ export async function useCommand(source) {
   console.log(`\n📦 Skill: ${resolved.name}`)
   console.log(`   Slug:     ${resolved.slug}`)
   console.log(`   Owner:    ${resolved.owner}`)
+  if (resolved.description) console.log(`   Desc:     ${resolved.description}`)
   console.log(`   Files:    ${resolved.files.join(', ')}\n`)
 
   for (const file of resolved.files) {

--- a/src/commands/use.test.js
+++ b/src/commands/use.test.js
@@ -82,4 +82,24 @@ describe('use command', () => {
     assert.ok(logs.some(l => l.includes('with-nl')))
     assert.ok(logs.some(l => l.includes('Content')))
   })
+
+  it('shows description when present in YAML frontmatter', async () => {
+    const skillDir = join(tempDir, 'desc-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), `---
+name: desc-skill
+slug: desc/skill
+description: A skill with description
+---
+
+Content here
+`)
+
+    capture()
+    await useModule.useCommand(skillDir)
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('A skill with description')))
+    assert.ok(logs.some(l => l.includes('desc/skill')))
+  })
 })

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -1,6 +1,75 @@
-import { readLock, getProjectLockPath, computeContentHash, getAgentsDir } from '../utils/lockfile.js'
+import { readLock, getProjectLockPath, computeContentHash, computeFileHashes, getAgentsDir, getClaudeDir, getCursorDir, getDevinDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir } from '../utils/lockfile.js'
 import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+
+const agentDirMap = {
+  'opencode': getAgentsDir,
+  'claude-code': getClaudeDir,
+  'cursor': getCursorDir,
+  'devin': getDevinDir,
+  'codex': getCodexDir,
+  'copilot': getCopilotDir,
+  'aider': getAiderDir,
+  'cline': getClineDir,
+  'gemini-cli': getGeminiDir,
+  'cody': getCodyDir,
+  'continue': getContinueDir,
+  'warp': getWarpDir,
+  'codeium': getCodeiumDir,
+  'fabric': getFabricDir,
+  'goose': getGooseDir,
+  'tabnine': getTabnineDir,
+  'supermaven': getSupermavenDir,
+  'pr-pilot': getPrPilotDir,
+  'loom': getLoomDir,
+  'roo': getRooDir,
+  'trae': getTraeDir,
+  'hermes': getHermesDir,
+  'kiro': getKiroDir,
+  'augment': getAugmentDir,
+  'kilo': getKiloDir,
+  'openhands': getOpenHandsDir,
+  'junie': getJunieDir,
+  'factory': getFactoryDir,
+}
+
+async function readFilesFromDir(dir) {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true })
+    const fc = {}
+    for (const e of entries) {
+      if (e.isFile()) fc[e.name] = await readFile(join(dir, e.name), 'utf-8')
+    }
+    return Object.keys(fc).length > 0 ? fc : null
+  } catch {}
+  return null
+}
+
+function findFileChanges(installedFiles, expectedHashes) {
+  const changes = []
+  const expectedFiles = expectedHashes ? Object.keys(expectedHashes) : []
+  const installedNames = Object.keys(installedFiles)
+
+  for (const name of installedNames) {
+    if (expectedHashes && expectedHashes[name] !== undefined) {
+      const currentHash = createHash('sha256').update(installedFiles[name]).digest('hex')
+      if (currentHash !== expectedHashes[name]) {
+        changes.push(`modified: ${name}`)
+      }
+    } else {
+      changes.push(`added: ${name}`)
+    }
+  }
+
+  for (const name of expectedFiles) {
+    if (!installedNames.includes(name)) {
+      changes.push(`missing: ${name}`)
+    }
+  }
+
+  return changes
+}
 
 export async function verifyCommand(frozen) {
   const [globalLock, projectLock] = await Promise.all([
@@ -32,42 +101,46 @@ export async function verifyCommand(frozen) {
     }
 
     const normSlug = slug.replace(/\//g, '-')
-    let installedHash = null
+    const dirsToCheck = (entry.agents || []).map(name => {
+      if (name === 'project') return join(process.cwd(), '.agents', 'skills', normSlug)
+      const dirFn = agentDirMap[name]
+      return dirFn ? join(dirFn(), normSlug) : null
+    }).filter(Boolean)
 
-    const globalDir = join(getAgentsDir(), normSlug)
-    try {
-      const entries2 = await readdir(globalDir, { withFileTypes: true })
-      const fc = {}
-      for (const e of entries2) {
-        if (e.isFile()) fc[e.name] = await readFile(join(globalDir, e.name), 'utf-8')
-      }
-      if (Object.keys(fc).length > 0) installedHash = computeContentHash(fc)
-    } catch {}
-
-    if (!installedHash) {
-      const projectDir = join(process.cwd(), '.agents', 'skills', normSlug)
-      try {
-        const entries2 = await readdir(projectDir, { withFileTypes: true })
-        const fc = {}
-        for (const e of entries2) {
-          if (e.isFile()) fc[e.name] = await readFile(join(projectDir, e.name), 'utf-8')
-        }
-        if (Object.keys(fc).length > 0) installedHash = computeContentHash(fc)
-      } catch {}
+    if (dirsToCheck.length === 0) {
+      dirsToCheck.push(
+        join(getAgentsDir(), normSlug),
+        join(process.cwd(), '.agents', 'skills', normSlug),
+      )
     }
 
-    if (!installedHash) {
+    let foundAny = false
+    let allMatch = true
+
+    for (const dir of dirsToCheck) {
+      const fc = await readFilesFromDir(dir)
+      if (fc === null) continue
+
+      foundAny = true
+      const hash = computeContentHash(fc)
+      if (hash !== entry.contentSha) {
+        const changes = findFileChanges(fc, entry.fileHashes)
+        const detail = changes.length > 0 ? ` (${changes.join(', ')})` : ''
+        console.error(`   ❌ ${slug}: hash mismatch in ${dir}${detail}`)
+        allMatch = false
+        allPassed = false
+      }
+    }
+
+    if (!foundAny) {
       console.error(`   ❌ ${slug}: skill directory not found`)
       allPassed = false
       continue
     }
 
-    totalChecked++
-    if (installedHash === entry.contentSha) {
+    if (allMatch) {
+      totalChecked++
       console.log(`   ✅ ${slug} (hash match)`)
-    } else {
-      console.error(`   ❌ ${slug}: hash mismatch (expected ${entry.contentSha}, got ${installedHash})`)
-      allPassed = false
     }
   }
 

--- a/src/commands/verify.test.js
+++ b/src/commands/verify.test.js
@@ -90,6 +90,41 @@ describe('verify command', () => {
     assert.ok(errors.some(l => l.includes('not found')))
   })
 
+  it('reports which file changed on hash mismatch with fileHashes', async () => {
+    const slug = 'test/verify-modified'
+    const normSlug = slug.replace(/\//g, '-')
+    const skillDir = join(tempDir, '.agents', 'skills', normSlug)
+    mkdirSync(skillDir, { recursive: true })
+
+    writeFileSync(join(skillDir, 'SKILL.md'), '# Original content')
+    writeFileSync(join(skillDir, 'unchanged.txt'), 'Same content')
+
+    const files = {
+      'SKILL.md': '# Original content',
+      'unchanged.txt': 'Same content',
+    }
+    const fileHashes = {}
+    for (const [name, content] of Object.entries(files)) {
+      const { createHash } = await import('node:crypto')
+      fileHashes[name] = createHash('sha256').update(content).digest('hex')
+    }
+    const hash = lockModule.computeContentHash(files)
+
+    await lockModule.addSkillToLock(slug, {
+      slug, contentSha: hash, fileHashes,
+      source: 'local', sourceType: 'local',
+      agents: ['opencode'],
+    })
+
+    writeFileSync(join(skillDir, 'SKILL.md'), '# Modified content!')
+
+    const { logs: errors, restore } = capture('error')
+    await verifyModule.verifyCommand()
+    restore()
+    assert.ok(errors.some(l => l.includes('modified: SKILL.md')))
+    assert.ok(!errors.some(l => l.includes('unchanged.txt')))
+  })
+
   it('reports missing source in frozen mode', async () => {
     const slug = 'test/frozen-missing'
     await lockModule.addSkillToLock(slug, {

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,15 +1,49 @@
-import { mkdir, cp, writeFile, readFile, access, stat, symlink, unlink } from 'node:fs/promises'
+import { mkdir, cp, writeFile, readFile, access, stat, symlink, unlink, rm } from 'node:fs/promises'
 import { join, basename, relative, dirname } from 'node:path'
 import { homedir } from 'node:os'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, addSkillToLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, addSkillToLock, getGlobalLockPath, getProjectLockPath, computeFileHashes } from './lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
 }
 
+const targetToAgentName = {
+  agents: 'opencode',
+  claude: 'claude-code',
+  cursor: 'cursor',
+  windsurf: 'windsurf',
+  devin: 'devin',
+  codex: 'codex',
+  copilot: 'copilot',
+  aider: 'aider',
+  cline: 'cline',
+  gemini: 'gemini-cli',
+  cody: 'cody',
+  continue: 'continue',
+  warp: 'warp',
+  codeium: 'codeium',
+  fabric: 'fabric',
+  goose: 'goose',
+  tabnine: 'tabnine',
+  supermaven: 'supermaven',
+  'pr-pilot': 'pr-pilot',
+  loom: 'loom',
+  roo: 'roo',
+  trae: 'trae',
+  hermes: 'hermes',
+  kiro: 'kiro',
+  augment: 'augment',
+  kilo: 'kilo',
+  openhands: 'openhands',
+  junie: 'junie',
+  factory: 'factory',
+}
+
 export async function installSkill(resolved, targets, mode = 'copy') {
   const slug = resolved.slug
   const results = []
+
+  const agentNames = targets.map(t => targetToAgentName[t] || t)
 
   for (const target of targets) {
     let baseDir
@@ -175,9 +209,8 @@ export async function installSkill(resolved, targets, mode = 'copy') {
 
     if (mode === 'symlink' && resolved.skillDir) {
       const relPath = relative(dirname(slugDir), resolved.skillDir)
-      try {
-        await unlink(slugDir)
-      } catch {}
+      await rm(slugDir, { recursive: true, force: true })
+      await mkdir(dirname(slugDir), { recursive: true })
       await symlink(relPath, slugDir)
     } else {
       await mkdir(slugDir, { recursive: true })
@@ -204,8 +237,9 @@ export async function installSkill(resolved, targets, mode = 'copy') {
     await addSkillToLock(slug, {
       slug,
       contentSha: resolved.contentSha,
+      fileHashes: resolved.fileContents ? computeFileHashes(resolved.fileContents) : undefined,
       installedAt: new Date().toISOString(),
-      agents: ['opencode', 'claude-code'],
+      agents: agentNames,
       source: resolved.sourcePath,
       sourceType: resolved.sourceType,
     }, lockPath)

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -151,7 +151,11 @@ export async function writeLock(data, lockPath = getGlobalLockPath()) {
 
 export async function addSkillToLock(slug, entry, lockPath = getGlobalLockPath()) {
   const lock = await readLock(lockPath)
-  lock.skills[slug] = { ...entry, installedAt: new Date().toISOString() }
+  const existing = lock.skills[slug]
+  const mergedAgents = existing?.agents
+    ? [...new Set([...existing.agents, ...(entry.agents || [])])]
+    : (entry.agents || [])
+  lock.skills[slug] = { ...entry, agents: mergedAgents, installedAt: new Date().toISOString() }
   await writeLock(lock, lockPath)
   return lock
 }
@@ -171,6 +175,14 @@ export function computeContentHash(fileContents) {
     hash.update(fileContents[name])
   }
   return hash.digest('hex')
+}
+
+export function computeFileHashes(fileContents) {
+  const hashes = {}
+  for (const [name, content] of Object.entries(fileContents)) {
+    hashes[name] = createHash('sha256').update(content).digest('hex')
+  }
+  return hashes
 }
 
 

--- a/src/utils/lockfile.test.js
+++ b/src/utils/lockfile.test.js
@@ -60,6 +60,17 @@ describe('lockfile', () => {
     assert.ok(lock.skills['test/skill'].installedAt)
   })
 
+  it('addSkillToLock merges agents instead of overwriting', async () => {
+    await lockModule.addSkillToLock('merge-skill', { agents: ['claude-code'] })
+    await lockModule.addSkillToLock('merge-skill', { agents: ['cursor', 'warp'] })
+    const lock = await lockModule.readLock()
+    const agents = lock.skills['merge-skill'].agents
+    assert.ok(agents.includes('claude-code'))
+    assert.ok(agents.includes('cursor'))
+    assert.ok(agents.includes('warp'))
+    assert.equal(agents.length, 3)
+  })
+
   it('removeSkillFromLock removes entry', async () => {
     await lockModule.addSkillToLock('to-remove', {})
     await lockModule.removeSkillFromLock('to-remove')

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -4,7 +4,7 @@ import { tmpdir, homedir } from 'node:os'
 import { execSync as defaultExecSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { readdirSync, readFileSync } from 'node:fs'
-import { computeContentHash } from './lockfile.js'
+import { computeContentHash, computeFileHashes } from './lockfile.js'
 
 let runExec = defaultExecSync
 
@@ -21,15 +21,33 @@ function isLocalPath(source) {
 }
 
 function parseMetadata(content) {
-  const slugMatch = content.match(/^# slug:\s*(\S+)$/m)
-  const nameMatch = content.match(/^name:\s*(\S+)$/m)
-  const ownerMatch = content.match(/^# owner:\s*(\S+)$/m)
+  let name, slug, owner, description
 
-  const name = nameMatch?.[1] || slugMatch?.[1]?.split('/')?.[1] || 'unknown'
-  const slug = slugMatch?.[1] || name
-  const owner = ownerMatch?.[1] || 'local'
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
+  if (frontmatterMatch) {
+    const yaml = frontmatterMatch[1]
+    const nameMatch = yaml.match(/^name:\s*(.+)$/m)
+    const slugMatch = yaml.match(/^slug:\s*(\S+)$/m)
+    const ownerMatch = yaml.match(/^owner:\s*(\S+)$/m)
+    const descMatch = yaml.match(/^description:\s*(.+)$/m)
 
-  return { name, slug, owner }
+    name = nameMatch?.[1]?.trim() || 'unknown'
+    slug = slugMatch?.[1] || name
+    owner = ownerMatch?.[1] || 'local'
+    description = descMatch?.[1]?.trim() || undefined
+  }
+
+  if (!slug) {
+    const oldSlugMatch = content.match(/^# slug:\s*(\S+)$/m)
+    const oldNameMatch = content.match(/^name:\s*(\S+)$/m)
+    const oldOwnerMatch = content.match(/^# owner:\s*(\S+)$/m)
+
+    name = oldNameMatch?.[1] || oldSlugMatch?.[1]?.split('/')?.[1] || 'unknown'
+    slug = oldSlugMatch?.[1] || name
+    owner = oldOwnerMatch?.[1] || 'local'
+  }
+
+  return { name, slug, owner, description }
 }
 
 function scanForSkill(dir, maxDepth = 3) {

--- a/src/utils/resolver.test.js
+++ b/src/utils/resolver.test.js
@@ -211,6 +211,41 @@ describe('resolver', () => {
       assert.equal(r.slug, 'unknown')
       assert.equal(r.owner, 'local')
     })
+
+    it('parses YAML frontmatter with --- delimiters', async () => {
+      const d = join(tempDir, 'meta4')
+      mkdirSync(d, { recursive: true })
+      writeFileSync(join(d, 'SKILL.md'), `---
+name: my-skill
+slug: my-org/my-skill
+owner: my-org
+description: A test skill
+---
+
+Content here
+`)
+      const r = await resolverModule.resolveSource(d)
+      assert.equal(r.name, 'my-skill')
+      assert.equal(r.slug, 'my-org/my-skill')
+      assert.equal(r.owner, 'my-org')
+      assert.equal(r.description, 'A test skill')
+    })
+
+    it('parses YAML frontmatter without slug/owner (falls back to defaults)', async () => {
+      const d = join(tempDir, 'meta5')
+      mkdirSync(d, { recursive: true })
+      writeFileSync(join(d, 'SKILL.md'), `---
+name: simple-skill
+---
+
+Just content
+`)
+      const r = await resolverModule.resolveSource(d)
+      assert.equal(r.name, 'simple-skill')
+      assert.equal(r.slug, 'simple-skill')
+      assert.equal(r.owner, 'local')
+      assert.equal(r.description, undefined)
+    })
   })
 
   describe('resolveGitHub', () => {


### PR DESCRIPTION
## Changes

### Bug Fixes
- **SKILL.md frontmatter**: Now uses standard YAML format (`---` delimiters) instead of `# slug:` comments. Backward compatible.
- **init**: Removed `local/` prefix from slug. Added `description` field to template.
- **install**: Lockfile `agents` list now merges (appends) instead of overwriting on sequential installs.
- **symlink**: Fixed cleanup of existing directories before symlink creation.
- **remove/update**: Improved slug matching to find skills by name portion after `/`.
- **verify**: Now checks ALL installation locations. Reports which files changed (modified/added/missing).
- **search**: Added `owner/repo` lookup via GitHub repos API. Falls back to broader search if SKILL.md filter returns nothing.
- **bundle**: Fixed EISDIR error when inline source is a directory path.

### New Features
- Per-file SHA256 hash tracking in lockfile for detailed verification.
- `description` field in SKILL.md is now parsed and displayed.

### Tests
- Added tests for YAML frontmatter parsing, per-file verify reporting, agent merging, owner/repo search lookup.
- 162 tests passing, 0 failing.