### PR TITLE
feat: add 13 new agent targets (43 total) + docs update

### DIFF
--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -24,7 +24,7 @@ function usage() {
 rolecraft — Install AI agent skills like roles & behaviors
 
 Zero dependencies, no marketplace required.
-Works with opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, and all spec-compliant agents.
+Works with opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo, firebender, bob, aider-desk, and all spec-compliant agents.
 
 Usage:
   rolecraft install <source>     Install a skill (local path or owner/repo)
@@ -76,6 +76,19 @@ Options for install:
   --openhands    Also install to ~/.openhands/skills/
   --junie        Also install to ~/.junie/skills/
   --factory      Also install to ~/.factory/skills/
+  --command-code  Also install to ~/.commandcode/skills/
+  --cortex        Also install to ~/.snowflake/cortex/skills/
+  --mistral-vibe  Also install to ~/.vibe/skills/
+  --qwen-code     Also install to ~/.qwen/skills/
+  --openclaw      Also install to ~/.openclaw/skills/
+  --codebuddy     Also install to ~/.codebuddy/skills/
+  --mux           Also install to ~/.mux/skills/
+  --pi            Also install to ~/.pi/agent/skills/
+  --autohand-code Also install to ~/.autohand/skills/
+  --rovo          Also install to ~/.rovodev/skills/
+  --firebender    Also install to ~/.firebender/skills/
+  --bob           Also install to ~/.bob/skills/
+  --aider-desk    Also install to ~/.aider-desk/skills/
   --all          Install to all locations
   --frozen-lockfile  Fail if skill already installed
   --symlink      Install as symlink instead of copy
@@ -108,7 +121,9 @@ export async function main() {
       }
 
       const flags = args.slice(1)
-      const scopeFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--devin', '--codex', '--copilot', '--aider', '--cline', '--gemini', '--cody', '--continue', '--warp', '--codeium', '--fabric', '--goose', '--tabnine', '--supermaven', '--pr-pilot', '--loom', '--roo', '--trae', '--hermes', '--kiro', '--augment', '--kilo', '--openhands', '--junie', '--factory', '--all']
+      const scopeFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--devin', '--codex', '--copilot', '--aider', '--cline', '--gemini', '--cody', '--continue', '--warp', '--codeium', '--fabric', '--goose', '--tabnine', '--supermaven', '--pr-pilot', '--loom', '--roo', '--trae', '--hermes', '--kiro', '--augment', '--kilo', '--openhands', '--junie', '--factory', '--command-code', '--cortex', '--mistral-vibe', '--qwen-code', '--openclaw', '--codebuddy',
+  '--mux', '--pi', '--autohand-code', '--rovo', '--firebender', '--bob', '--aider-desk',
+  '--all']
       const hasScopeFlag = flags.some(f => scopeFlags.includes(f))
       const options = hasScopeFlag ? {
         global: flags.includes('--global') || flags.includes('--all'),
@@ -140,6 +155,19 @@ export async function main() {
         openhands: flags.includes('--openhands') || flags.includes('--all'),
         junie: flags.includes('--junie') || flags.includes('--all'),
         factory: flags.includes('--factory') || flags.includes('--all'),
+        'command-code': flags.includes('--command-code') || flags.includes('--all'),
+        cortex: flags.includes('--cortex') || flags.includes('--all'),
+        'mistral-vibe': flags.includes('--mistral-vibe') || flags.includes('--all'),
+        'qwen-code': flags.includes('--qwen-code') || flags.includes('--all'),
+        openclaw: flags.includes('--openclaw') || flags.includes('--all'),
+        codebuddy: flags.includes('--codebuddy') || flags.includes('--all'),
+        mux: flags.includes('--mux') || flags.includes('--all'),
+        pi: flags.includes('--pi') || flags.includes('--all'),
+        'autohand-code': flags.includes('--autohand-code') || flags.includes('--all'),
+        rovo: flags.includes('--rovo') || flags.includes('--all'),
+        firebender: flags.includes('--firebender') || flags.includes('--all'),
+        bob: flags.includes('--bob') || flags.includes('--all'),
+        'aider-desk': flags.includes('--aider-desk') || flags.includes('--all'),
         project: flags.includes('--project') || flags.includes('--all'),
       } : {}
       options.frozenLockfile = flags.includes('--frozen-lockfile')

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -11,7 +11,7 @@
 | **Lockfile**                 | agentskill v3  | Two-tier (global v3 + project v1, SHA)    | None                     | None              | None                | ✅                | None            | Config only   |
 | **Offline capable**          | ✅             | ✅                                        | ❌ (registry)             | ✅                | ✅                  | ✅                | ✅              | ✅           |
 | **Signup required**          | ❌             | ❌                                        | ✅ (agentskill.sh)        | ❌                | ❌                  | ❌                | ❌              | ❌           |
-| **Agent count**              | **30**         | 55+                                       | 15+                      | 10+               | 10+                 | 39                | 1 (+ compat)    | 1 (+ plugins) |
+| **Agent count**              | **43**         | 72                                        | 15+                      | 10+               | 10+                 | 39                | 1 (+ compat)    | 1 (+ plugins) |
 | **Project scope default**    | ✅             | ✅                                        | N/A                      | ❌ (global)        | ✅ (project)        | ✅                | N/A             | N/A         |
 | **Interactive scope prompt** | ✅             | ❌                                        | ❌                       | ❌                | ❌                  | ❌                | N/A             | N/A         |
 | **Provenance (npm)**         | ✅             | ❌                                        | ❌                       | ❌                | ❌                  | ❌                | N/A             | N/A         |
@@ -39,7 +39,7 @@
 - **agentskill.sh lockfile compatible** — cross-compatible with ecosystem
 - **Interactive scope prompt** — user-friendly first install
 - **Project scope default** — modern default
-- **30 install targets** — 29 named agents + project-local
+- **43 install targets** — 42 named agents + project-local
 - **SHA256 content hash verification** — `rolecraft verify`
 - **CI mode** — `rolecraft ci` for pipeline installs
 - **Symlink + Copy modes** — `--symlink`/`--copy`
@@ -50,17 +50,18 @@
 
 ### Feature gaps vs competitors
 
-1. **Agent count (30)** — ahead of `ags` (15+), `openskills` (10+), `skills-npm` (10+) but behind `skills` (55+), `qntx/skill` (39)
+1. **Agent count (43)** — ahead of `ags` (15+), `openskills` (10+), `skills-npm` (10+), `qntx/skill` (39) but behind `skills` (72)
 2. **No `doctor` command** — `qntx/skill` has `skills doctor` for health checks
-3. **No self-upgrade** — `qntx/skill` has `skills upgrade` (like `bun upgrade`)
-4. **No GitLab/Bitbucket/SSH git URL support** — only GitHub `owner/repo` and local paths
-7. **npm package source unsupported** — `skills` supports `npx skills add some-package`, `skills-npm` is built around it
-8. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
-9. **Stars / community adoption very low (~5)** — building trust and visibility
+3. **No GitLab/Bitbucket/SSH git URL support** — only GitHub `owner/repo` and local paths
+4. **npm package source unsupported** — `skills` supports `npx skills add some-package`, `skills-npm` is built around it
+5. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
+6. **Stars / community adoption very low (~5)** — building trust and visibility
 
-### Technical gaps
+### ✅ Resolved Gaps
 
-10. **Copilot agent path** — Copilot uses `.github/copilot/skills/` but rolecraft targets `~/.copilot/skills/`
+- **Copilot agent path** — now uses `.github/copilot/skills/` (project scope)
+- **Self-upgrade** — `rolecraft upgrade` command added
+- **Agent count (30 → 43)** — 13 new agent targets added
 
 ## Roadmap
 
@@ -84,11 +85,11 @@
 
 ### v0.5.x — Agent Coverage & Source Expansion
 
-- [ ] Copilot agent path fix (`.github/copilot/skills/` instead of `~/.copilot/skills/`)
+- [x] Copilot agent path fix (`.github/copilot/skills/` instead of `~/.copilot/skills/`)
+- [x] 13 new agent targets (command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo, firebender, bob, aider-desk) — **43 total**
 - [ ] GitLab URL support (`https://gitlab.com/org/repo`)
 - [ ] SSH git URL support (`git@github.com:owner/repo.git`)
 - [ ] Full git URL support (any remote with SKILL.md)
-- [ ] 10+ new agent targets to match `skills` (55+)
 - [ ] `rolecraft doctor` — system health check
 
 ### v0.6.x — UX & Shell Integration

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -32,7 +32,20 @@ rolecraft knows where each AI agent looks for skills. When you use a flag like `
 | kilo        | `~/.kilo/skills/`                              |
 | openhands   | `~/.openhands/skills/`                         |
 | junie       | `~/.junie/skills/`                             |
-| factory     | `~/.factory/skills/`                           |
+| factory     | `~/.factory/skills/`                             |
+| command-code | `~/.commandcode/skills/`                        |
+| cortex      | `~/.snowflake/cortex/skills/`                   |
+| mistral-vibe | `~/.vibe/skills/`                              |
+| qwen-code   | `~/.qwen/skills/`                               |
+| openclaw    | `~/.openclaw/skills/`                           |
+| codebuddy   | `~/.codebuddy/skills/`                          |
+| mux         | `~/.mux/skills/`                                |
+| pi          | `~/.pi/agent/skills/`                           |
+| autohand-code | `~/.autohand/skills/`                         |
+| rovo        | `~/.rovodev/skills/`                            |
+| firebender  | `~/.firebender/skills/`                         |
+| bob         | `~/.bob/skills/`                                |
+| aider-desk  | `~/.aider-desk/skills/`                         |
 
 > ⚠️ Windsurf has been rebranded to **Devin Desktop**. The `--windsurf` flag and `~/.windsurf/skills/` path still work for backward compatibility, but new deployments should use `--devin` / `~/.devin/skills/`.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,6 +58,19 @@ Where do you want to install this skill?
 | `--openhands`   | `~/.openhands/skills/`             |
 | `--junie`       | `~/.junie/skills/`                 |
 | `--factory`     | `~/.factory/skills/`               |
+| `--command-code` | `~/.commandcode/skills/`         |
+| `--cortex`      | `~/.snowflake/cortex/skills/`      |
+| `--mistral-vibe` | `~/.vibe/skills/`                |
+| `--qwen-code`   | `~/.qwen/skills/`                  |
+| `--openclaw`    | `~/.openclaw/skills/`              |
+| `--codebuddy`   | `~/.codebuddy/skills/`             |
+| `--mux`         | `~/.mux/skills/`                   |
+| `--pi`          | `~/.pi/agent/skills/`              |
+| `--autohand-code` | `~/.autohand/skills/`           |
+| `--rovo`        | `~/.rovodev/skills/`               |
+| `--firebender`  | `~/.firebender/skills/`            |
+| `--bob`         | `~/.bob/skills/`                   |
+| `--aider-desk`  | `~/.aider-desk/skills/`            |
 
 Combine flags to install to multiple agents at once:
 

--- a/src/commands/completions.js
+++ b/src/commands/completions.js
@@ -17,7 +17,11 @@ const SCOPE_FLAGS = [
   '--gemini', '--cody', '--continue', '--warp', '--codeium',
   '--fabric', '--goose', '--tabnine', '--supermaven', '--pr-pilot',
   '--loom', '--roo', '--trae', '--hermes', '--kiro', '--augment',
-  '--kilo', '--openhands', '--junie', '--factory', '--all',
+  '--kilo', '--openhands', '--junie', '--factory',
+  '--command-code', '--cortex', '--mistral-vibe', '--qwen-code', '--openclaw',
+  '--codebuddy', '--mux', '--pi', '--autohand-code', '--rovo', '--firebender',
+  '--bob', '--aider-desk',
+  '--all',
 ]
 
 const OPTION_FLAGS = [
@@ -130,7 +134,20 @@ _rolecraft() {
             '--kilo[Also install to ~/.kilo/skills/]' \\
             '--openhands[Also install to ~/.openhands/skills/]' \\
             '--junie[Also install to ~/.junie/skills/]' \\
-            '--factory[Also install to ~/.factory/skills/]' \\
+            '--factory[Also install to ~/.factory/skills/]' \
+            '--command-code[Also install to ~/.commandcode/skills/]' \
+            '--cortex[Also install to ~/.snowflake/cortex/skills/]' \
+            '--mistral-vibe[Also install to ~/.vibe/skills/]' \
+            '--qwen-code[Also install to ~/.qwen/skills/]' \
+            '--openclaw[Also install to ~/.openclaw/skills/]' \
+            '--codebuddy[Also install to ~/.codebuddy/skills/]' \
+            '--mux[Also install to ~/.mux/skills/]' \
+            '--pi[Also install to ~/.pi/agent/skills/]' \
+            '--autohand-code[Also install to ~/.autohand/skills/]' \
+            '--rovo[Also install to ~/.rovodev/skills/]' \
+            '--firebender[Also install to ~/.firebender/skills/]' \
+            '--bob[Also install to ~/.bob/skills/]' \
+            '--aider-desk[Also install to ~/.aider-desk/skills/]' \\
             '--all[Install to all locations]' \\
             '--dry-run[Preview without copying]' \\
             '--frozen-lockfile[Fail if already installed]' \\
@@ -233,6 +250,19 @@ for cmd in install bundle use setup
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l openhands      -d 'Install to ~/.openhands/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l junie          -d 'Install to ~/.junie/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l factory        -d 'Install to ~/.factory/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l command-code    -d 'Install to ~/.commandcode/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l cortex          -d 'Install to ~/.snowflake/cortex/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l mistral-vibe    -d 'Install to ~/.vibe/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l qwen-code       -d 'Install to ~/.qwen/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l openclaw        -d 'Install to ~/.openclaw/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l codebuddy       -d 'Install to ~/.codebuddy/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l mux             -d 'Install to ~/.mux/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l pi              -d 'Install to ~/.pi/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l autohand-code   -d 'Install to ~/.autohand/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l rovo            -d 'Install to ~/.rovodev/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l firebender      -d 'Install to ~/.firebender/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l bob             -d 'Install to ~/.bob/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l aider-desk      -d 'Install to ~/.aider-desk/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l all            -d 'Install to all locations'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l dry-run        -d 'Preview without copying'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l frozen-lockfile -d 'Fail if already installed'

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -44,7 +44,7 @@ async function askScope() {
 }
 
 export async function installCommand(source, options) {
-  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline || options.gemini || options.cody || options.continue || options.warp || options.codeium || options.fabric || options.goose || options.tabnine || options.supermaven || options['pr-pilot'] || options.loom || options.roo || options.trae || options.hermes || options.kiro || options.augment || options.kilo || options.openhands || options.junie || options.factory
+  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline || options.gemini || options.cody || options.continue || options.warp || options.codeium || options.fabric || options.goose || options.tabnine || options.supermaven || options['pr-pilot'] || options.loom || options.roo || options.trae || options.hermes || options.kiro || options.augment || options.kilo || options.openhands || options.junie || options.factory || options['command-code'] || options.cortex || options['mistral-vibe'] || options['qwen-code'] || options.openclaw || options.codebuddy || options.mux || options.pi || options['autohand-code'] || options.rovo || options.firebender || options.bob || options['aider-desk']
   const scope = hasScopeFlags ? options : await askScope()
 
   if (options.frozenLockfile) {
@@ -101,6 +101,19 @@ export async function installCommand(source, options) {
   if (scope.openhands) targets.push('openhands')
   if (scope.junie) targets.push('junie')
   if (scope.factory) targets.push('factory')
+  if (scope['command-code']) targets.push('command-code')
+  if (scope.cortex) targets.push('cortex')
+  if (scope['mistral-vibe']) targets.push('mistral-vibe')
+  if (scope['qwen-code']) targets.push('qwen-code')
+  if (scope.openclaw) targets.push('openclaw')
+  if (scope.codebuddy) targets.push('codebuddy')
+  if (scope.mux) targets.push('mux')
+  if (scope.pi) targets.push('pi')
+  if (scope['autohand-code']) targets.push('autohand-code')
+  if (scope.rovo) targets.push('rovo')
+  if (scope.firebender) targets.push('firebender')
+  if (scope.bob) targets.push('bob')
+  if (scope['aider-desk']) targets.push('aider-desk')
   if (scope.project) targets.push('project')
 
   if (options.dryRun) {

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,7 +1,7 @@
 import { accessSync, readdirSync, constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir } from '../utils/lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -35,6 +35,19 @@ const KNOWN_AGENTS = [
   { flag: 'openhands', label: 'openhands', dir: getOpenHandsDir },
   { flag: 'junie', label: 'junie', dir: getJunieDir },
   { flag: 'factory', label: 'factory', dir: getFactoryDir },
+  { flag: 'command-code', label: 'command-code', dir: getCommandCodeDir },
+  { flag: 'cortex', label: 'cortex', dir: getCortexDir },
+  { flag: 'mistral-vibe', label: 'mistral-vibe', dir: getMistralVibeDir },
+  { flag: 'qwen-code', label: 'qwen-code', dir: getQwenCodeDir },
+  { flag: 'openclaw', label: 'openclaw', dir: getOpenClawDir },
+  { flag: 'codebuddy', label: 'codebuddy', dir: getCodeBuddyDir },
+  { flag: 'mux', label: 'mux', dir: getMuxDir },
+  { flag: 'pi', label: 'pi', dir: getPiDir },
+  { flag: 'autohand-code', label: 'autohand-code', dir: getAutohandCodeDir },
+  { flag: 'rovo', label: 'rovo-dev', dir: getRovoDevDir },
+  { flag: 'firebender', label: 'firebender', dir: getFirebenderDir },
+  { flag: 'bob', label: 'ibm-bob', dir: getBobDir },
+  { flag: 'aider-desk', label: 'aider-desk', dir: getAiderDeskDir },
 ]
 
 export function detectAgents() {
@@ -67,7 +80,7 @@ export async function setupCommand(source, options = {}) {
     console.log('   Install an AI coding agent (opencode, claude-code, cursor,')
     console.log('   windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody,')
     console.log('   continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot,')
-    console.log('   loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory) first.')
+    console.log('   loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo-dev, firebender, ibm-bob, aider-desk) first.')
     return
   }
 

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir } from '../utils/lockfile.js'
+import { readLock, getGlobalLockPath, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -109,6 +109,45 @@ function detectTargets(slug, cwd) {
 
   const factoryDir = join(getFactoryDir(), normSlug)
   if (existsSync(join(factoryDir, 'SKILL.md'))) targets.push('factory')
+
+  const commandCodeDir = join(getCommandCodeDir(), normSlug)
+  if (existsSync(join(commandCodeDir, 'SKILL.md'))) targets.push('command-code')
+
+  const cortexDir = join(getCortexDir(), normSlug)
+  if (existsSync(join(cortexDir, 'SKILL.md'))) targets.push('cortex')
+
+  const mistralVibeDir = join(getMistralVibeDir(), normSlug)
+  if (existsSync(join(mistralVibeDir, 'SKILL.md'))) targets.push('mistral-vibe')
+
+  const qwenCodeDir = join(getQwenCodeDir(), normSlug)
+  if (existsSync(join(qwenCodeDir, 'SKILL.md'))) targets.push('qwen-code')
+
+  const openClawDir = join(getOpenClawDir(), normSlug)
+  if (existsSync(join(openClawDir, 'SKILL.md'))) targets.push('openclaw')
+
+  const codeBuddyDir = join(getCodeBuddyDir(), normSlug)
+  if (existsSync(join(codeBuddyDir, 'SKILL.md'))) targets.push('codebuddy')
+
+  const muxDir = join(getMuxDir(), normSlug)
+  if (existsSync(join(muxDir, 'SKILL.md'))) targets.push('mux')
+
+  const piDir = join(getPiDir(), normSlug)
+  if (existsSync(join(piDir, 'SKILL.md'))) targets.push('pi')
+
+  const autohandCodeDir = join(getAutohandCodeDir(), normSlug)
+  if (existsSync(join(autohandCodeDir, 'SKILL.md'))) targets.push('autohand-code')
+
+  const rovoDevDir = join(getRovoDevDir(), normSlug)
+  if (existsSync(join(rovoDevDir, 'SKILL.md'))) targets.push('rovo')
+
+  const firebenderDir = join(getFirebenderDir(), normSlug)
+  if (existsSync(join(firebenderDir, 'SKILL.md'))) targets.push('firebender')
+
+  const bobDir = join(getBobDir(), normSlug)
+  if (existsSync(join(bobDir, 'SKILL.md'))) targets.push('bob')
+
+  const aiderDeskDir = join(getAiderDeskDir(), normSlug)
+  if (existsSync(join(aiderDeskDir, 'SKILL.md'))) targets.push('aider-desk')
 
   const projectDir = join(cwd, '.agents', 'skills', normSlug)
   if (existsSync(join(projectDir, 'SKILL.md'))) targets.push('project')

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,7 +1,7 @@
 import { mkdir, cp, writeFile, readFile, access, stat, symlink, unlink, rm } from 'node:fs/promises'
 import { join, basename, relative, dirname } from 'node:path'
 import { homedir } from 'node:os'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, addSkillToLock, getGlobalLockPath, getProjectLockPath, computeFileHashes } from './lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, addSkillToLock, getGlobalLockPath, getProjectLockPath, computeFileHashes } from './lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -37,6 +37,19 @@ const targetToAgentName = {
   openhands: 'openhands',
   junie: 'junie',
   factory: 'factory',
+  'command-code': 'command-code',
+  cortex: 'cortex',
+  'mistral-vibe': 'mistral-vibe',
+  'qwen-code': 'qwen-code',
+  openclaw: 'openclaw',
+  codebuddy: 'codebuddy',
+  mux: 'mux',
+  pi: 'pi',
+  'autohand-code': 'autohand-code',
+  rovo: 'rovo-dev',
+  firebender: 'firebender',
+  bob: 'ibm-bob',
+  'aider-desk': 'aider-desk',
 }
 
 export async function installSkill(resolved, targets, mode = 'copy') {
@@ -193,6 +206,71 @@ export async function installSkill(resolved, targets, mode = 'copy') {
       case 'factory': {
         baseDir = getFactoryDir()
         label = '~/.factory/skills/'
+        break
+      }
+      case 'command-code': {
+        baseDir = getCommandCodeDir()
+        label = '~/.commandcode/skills/'
+        break
+      }
+      case 'cortex': {
+        baseDir = getCortexDir()
+        label = '~/.snowflake/cortex/skills/'
+        break
+      }
+      case 'mistral-vibe': {
+        baseDir = getMistralVibeDir()
+        label = '~/.vibe/skills/'
+        break
+      }
+      case 'qwen-code': {
+        baseDir = getQwenCodeDir()
+        label = '~/.qwen/skills/'
+        break
+      }
+      case 'openclaw': {
+        baseDir = getOpenClawDir()
+        label = '~/.openclaw/skills/'
+        break
+      }
+      case 'codebuddy': {
+        baseDir = getCodeBuddyDir()
+        label = '~/.codebuddy/skills/'
+        break
+      }
+      case 'mux': {
+        baseDir = getMuxDir()
+        label = '~/.mux/skills/'
+        break
+      }
+      case 'pi': {
+        baseDir = getPiDir()
+        label = '~/.pi/agent/skills/'
+        break
+      }
+      case 'autohand-code': {
+        baseDir = getAutohandCodeDir()
+        label = '~/.autohand/skills/'
+        break
+      }
+      case 'rovo': {
+        baseDir = getRovoDevDir()
+        label = '~/.rovodev/skills/'
+        break
+      }
+      case 'firebender': {
+        baseDir = getFirebenderDir()
+        label = '~/.firebender/skills/'
+        break
+      }
+      case 'bob': {
+        baseDir = getBobDir()
+        label = '~/.bob/skills/'
+        break
+      }
+      case 'aider-desk': {
+        baseDir = getAiderDeskDir()
+        label = '~/.aider-desk/skills/'
         break
       }
       case 'project': {

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -241,6 +241,110 @@ describe('installer', () => {
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
 
+  it('installs skill to command-code directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['command-code'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'command-code')
+    const skillDir = join(process.env.HOME, '.commandcode', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to cortex directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['cortex'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'cortex')
+    const skillDir = join(process.env.HOME, '.snowflake', 'cortex', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to mistral-vibe directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['mistral-vibe'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'mistral-vibe')
+    const skillDir = join(process.env.HOME, '.vibe', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to qwen-code directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['qwen-code'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'qwen-code')
+    const skillDir = join(process.env.HOME, '.qwen', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to openclaw directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['openclaw'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'openclaw')
+    const skillDir = join(process.env.HOME, '.openclaw', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to codebuddy directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['codebuddy'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'codebuddy')
+    const skillDir = join(process.env.HOME, '.codebuddy', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to mux directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['mux'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'mux')
+    const skillDir = join(process.env.HOME, '.mux', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to pi directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['pi'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'pi')
+    const skillDir = join(process.env.HOME, '.pi', 'agent', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to autohand-code directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['autohand-code'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'autohand-code')
+    const skillDir = join(process.env.HOME, '.autohand', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to rovo directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['rovo'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'rovo')
+    const skillDir = join(process.env.HOME, '.rovodev', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to firebender directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['firebender'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'firebender')
+    const skillDir = join(process.env.HOME, '.firebender', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to bob directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['bob'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'bob')
+    const skillDir = join(process.env.HOME, '.bob', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to aider-desk directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['aider-desk'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'aider-desk')
+    const skillDir = join(process.env.HOME, '.aider-desk', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
   it('installs skill to project directory', async () => {
     const origCwd = process.cwd
     process.cwd = () => tempDir

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -126,6 +126,58 @@ export function getFactoryDir() {
   return home('.factory', 'skills')
 }
 
+export function getCommandCodeDir() {
+  return home('.commandcode', 'skills')
+}
+
+export function getCortexDir() {
+  return home('.snowflake', 'cortex', 'skills')
+}
+
+export function getMistralVibeDir() {
+  return home('.vibe', 'skills')
+}
+
+export function getQwenCodeDir() {
+  return home('.qwen', 'skills')
+}
+
+export function getOpenClawDir() {
+  return home('.openclaw', 'skills')
+}
+
+export function getCodeBuddyDir() {
+  return home('.codebuddy', 'skills')
+}
+
+export function getMuxDir() {
+  return home('.mux', 'skills')
+}
+
+export function getPiDir() {
+  return home('.pi', 'agent', 'skills')
+}
+
+export function getAutohandCodeDir() {
+  return home('.autohand', 'skills')
+}
+
+export function getRovoDevDir() {
+  return home('.rovodev', 'skills')
+}
+
+export function getFirebenderDir() {
+  return home('.firebender', 'skills')
+}
+
+export function getBobDir() {
+  return home('.bob', 'skills')
+}
+
+export function getAiderDeskDir() {
+  return home('.aider-desk', 'skills')
+}
+
 export function getProjectLockPath(cwd) {
   return join(cwd, '.agents', '.skill-lock.json')
 }

--- a/src/utils/lockfile.test.js
+++ b/src/utils/lockfile.test.js
@@ -32,6 +32,58 @@ describe('lockfile', () => {
     assert.equal(lockModule.getClaudeDir(), join(tempDir, '.claude', 'skills'))
   })
 
+  it('getCommandCodeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCommandCodeDir(), join(tempDir, '.commandcode', 'skills'))
+  })
+
+  it('getCortexDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCortexDir(), join(tempDir, '.snowflake', 'cortex', 'skills'))
+  })
+
+  it('getMistralVibeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getMistralVibeDir(), join(tempDir, '.vibe', 'skills'))
+  })
+
+  it('getQwenCodeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getQwenCodeDir(), join(tempDir, '.qwen', 'skills'))
+  })
+
+  it('getOpenClawDir returns path inside homedir', () => {
+    assert.equal(lockModule.getOpenClawDir(), join(tempDir, '.openclaw', 'skills'))
+  })
+
+  it('getCodeBuddyDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCodeBuddyDir(), join(tempDir, '.codebuddy', 'skills'))
+  })
+
+  it('getMuxDir returns path inside homedir', () => {
+    assert.equal(lockModule.getMuxDir(), join(tempDir, '.mux', 'skills'))
+  })
+
+  it('getPiDir returns path inside homedir', () => {
+    assert.equal(lockModule.getPiDir(), join(tempDir, '.pi', 'agent', 'skills'))
+  })
+
+  it('getAutohandCodeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getAutohandCodeDir(), join(tempDir, '.autohand', 'skills'))
+  })
+
+  it('getRovoDevDir returns path inside homedir', () => {
+    assert.equal(lockModule.getRovoDevDir(), join(tempDir, '.rovodev', 'skills'))
+  })
+
+  it('getFirebenderDir returns path inside homedir', () => {
+    assert.equal(lockModule.getFirebenderDir(), join(tempDir, '.firebender', 'skills'))
+  })
+
+  it('getBobDir returns path inside homedir', () => {
+    assert.equal(lockModule.getBobDir(), join(tempDir, '.bob', 'skills'))
+  })
+
+  it('getAiderDeskDir returns path inside homedir', () => {
+    assert.equal(lockModule.getAiderDeskDir(), join(tempDir, '.aider-desk', 'skills'))
+  })
+
   it('readLock returns default when no file exists', async () => {
     const lock = await lockModule.readLock()
     assert.deepEqual(lock, {


### PR DESCRIPTION
## Changes

### 13 New Agent Targets
- command-code (~/.commandcode/skills/)
- cortex (~/.snowflake/cortex/skills/)
- mistral-vibe (~/.vibe/skills/)
- qwen-code (~/.qwen/skills/)
- openclaw (~/.openclaw/skills/)
- codebuddy (~/.codebuddy/skills/)
- mux (~/.mux/skills/)
- pi (~/.pi/agent/skills/)
- autohand-code (~/.autohand/skills/)
- rovo (~/.rovodev/skills/)
- firebender (~/.firebender/skills/)
- bob (~/.bob/skills/)
- aider-desk (~/.aider-desk/skills/)

### Documentation
- ANALYSIS.md updated: 30 -> 43 agent count, roadmap updated
- agents.md, install.md updated with new entries
- All CLI help text, completions, and flags updated

### Tests
- 26 new tests added (13 installer + 13 lockfile)
- 199 total tests, all passing