### PR TITLE
feat: add rolecraft upgrade self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ rolecraft remove my-skill
 | `rolecraft list`             | Show all installed skills                           | [docs](docs/commands/list.md)    |
 | `rolecraft verify`           | Check installed skill integrity via content hash    | [docs](docs/commands/verify.md)  |
 | `rolecraft ci`               | Re-install all skills from lockfile (CI mode)       | [docs](docs/commands/ci.md)      |
+| `rolecraft upgrade`          | Upgrade rolecraft to the latest version              | [docs](docs/commands/upgrade.md) |
 | `rolecraft remove <slug>`    | Uninstall a skill                                   | [docs](docs/commands/remove.md)  |
 | `rolecraft update <slug>`    | Re-install a skill to latest                        | [docs](docs/commands/update.md)  |
 | `rolecraft --version`        | Show version                                        |                                  |

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -15,6 +15,7 @@ import { verifyCommand } from '../src/commands/verify.js'
 import { ciCommand } from '../src/commands/ci.js'
 import { bundleCommand, bundleCreateCommand } from '../src/commands/bundle.js'
 import { completionsCommand } from '../src/commands/completions.js'
+import { upgradeCommand } from '../src/commands/upgrade.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -40,10 +41,14 @@ Usage:
   rolecraft verify               Verify installed skill integrity
   rolecraft ci                   Install all skills from lockfile
   rolecraft completions <shell>  Generate shell completions (bash|zsh|fish)
+  rolecraft upgrade              Upgrade rolecraft to the latest version
   rolecraft help                 Show this help
 
 Options:
-  --dry-run      Preview installation without copying files (install, setup, bundle)
+  --dry-run      Preview installation without copying files (install, setup, bundle, upgrade)
+
+Options for upgrade:
+  --dry-run      Check for updates without actually upgrading
 
 Options for install:
   --global       Install to ~/.agents/skills/
@@ -222,6 +227,12 @@ export async function main() {
       const source = args[0]
       const flags = args.slice(1)
       await setupCommand(source, { dryRun: flags.includes('--dry-run') })
+      break
+    }
+
+    case 'upgrade': {
+      const flags = args
+      await upgradeCommand({ dryRun: flags.includes('--dry-run') })
       break
     }
 

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -466,4 +466,14 @@ describe('rolecraft CLI', () => {
     assert.ok(logs.some(l => l.includes('dry-run-cli')))
     restore()
   })
+
+  it('runs upgrade command with dry-run', async () => {
+    process.argv = ['node', 'rolecraft', 'upgrade', '--dry-run']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('rolecraft') || l.includes('rolecraft')))
+    restore()
+  })
 })

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -95,7 +95,7 @@
 
 - [x] Shell completions (bash, zsh, fish)
 - [x] Color-highlighted interactive search (`search --interactive` with styled cards)
-- [ ] `rolecraft upgrade` — self-update command
+- [x] `rolecraft upgrade` — self-update command
 - [ ] npm package source support (`npx rolecraft install some-package`)
 - [ ] AGENTS.md XML injection for non-Claude agents
 - [ ] Skill bundle / skillset hub

--- a/docs/commands/upgrade.md
+++ b/docs/commands/upgrade.md
@@ -1,0 +1,19 @@
+# `rolecraft upgrade`
+
+Upgrade rolecraft itself to the latest version.
+
+## Usage
+
+```bash
+rolecraft upgrade
+rolecraft upgrade --dry-run
+```
+
+## Description
+
+Checks the npm registry for the latest version of rolecraft and
+upgrades if a newer version is available.
+
+Uses `npm install -g rolecraft` under the hood.
+
+Use `--dry-run` to check for updates without actually upgrading.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -26,5 +26,5 @@
 | npm provenance                           | ✅               | ❌                | ❌                   |
 | Shell completions                        | ✅               | ❌                | ❌                   |
 | `doctor` command                         | ❌               | ❌                | ❌                   |
-| Self-upgrade command                     | ❌               | ❌                | ❌                   |
+| Self-upgrade command                     | ✅               | ❌                | ❌                   |
 | File size                                | ~4 KB            | ~465 KB           | ~84 KB               |

--- a/src/commands/completions.js
+++ b/src/commands/completions.js
@@ -8,7 +8,7 @@ const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'),
 const COMMANDS = [
   'install', 'bundle', 'use', 'list', 'remove', 'update',
   'setup', 'init', 'search', 'verify', 'ci', 'completions',
-  'help', 'version',
+  'upgrade', 'help', 'version',
 ]
 
 const SCOPE_FLAGS = [
@@ -47,7 +47,7 @@ _rolecraft() {
   fi
 
   case "\${COMP_WORDS[1]}" in
-    install|bundle|use|setup)
+    install|bundle|use|setup|upgrade)
       COMPREPLY=($(compgen -W "$scope_flags $option_flags" -- "$cur"))
       ;;
     search)
@@ -85,6 +85,7 @@ _rolecraft() {
     'verify:Verify installed skill integrity'
     'ci:Install all skills from lockfile'
     'completions:Generate shell completion scripts'
+    'upgrade:Upgrade rolecraft to latest version'
     'help:Show help'
     'version:Show version'
   )
@@ -99,7 +100,7 @@ _rolecraft() {
       ;;
     args)
       case $words[1] in
-        install|bundle|use|setup)
+        install|bundle|use|setup|upgrade)
           _arguments \\
             '--global[Install to ~/.agents/skills/]' \\
             '--project[Install to ./.agents/skills/]' \\
@@ -198,11 +199,12 @@ complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a search    -d 'Se
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a verify    -d 'Verify skill integrity'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a ci        -d 'CI mode install'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a completions -d 'Generate completions'
+complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a upgrade    -d 'Upgrade to latest version'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a help      -d 'Show help'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a version   -d 'Show version'
 
 # scope flags for install/bundle/use/setup
-for cmd in install bundle use setup
+for cmd in install bundle use setup upgrade
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l global         -d 'Install to ~/.agents/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l project        -d 'Install to ./.agents/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l claude         -d 'Install to ~/.claude/skills/'

--- a/src/commands/upgrade.js
+++ b/src/commands/upgrade.js
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { execSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'))
+
+export function compareVersions(a, b) {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i]
+  }
+  return 0
+}
+
+async function fetchLatestVersion() {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${pkg.name}/latest`)
+    if (!res.ok) throw new Error(`npm registry returned ${res.status}`)
+    const data = await res.json()
+    return data.version
+  } catch {
+    return null
+  }
+}
+
+export async function upgradeCommand(options = {}) {
+  const current = pkg.version
+
+  console.log(`\n📦 rolecraft v${current}`)
+  console.log('   Checking for updates...\n')
+
+  const latest = await fetchLatestVersion()
+
+  if (options.dryRun) {
+    console.log('📋 Dry-run — upgrade check:\n')
+    console.log(`   Current: v${current}`)
+    if (latest) {
+      console.log(`   Latest:  v${latest}`)
+      if (compareVersions(latest, current) > 0) {
+        console.log(`   Would install: npm install -g ${pkg.name}@${latest}`)
+      } else {
+        console.log('   Status: already up to date')
+      }
+    } else {
+      console.log('   (could not fetch latest version)')
+    }
+    console.log()
+    return
+  }
+
+  if (!latest) {
+    console.log('   ⚠️  Could not check for updates. Check your internet connection.')
+    console.log('   Latest: https://www.npmjs.com/package/rolecraft\n')
+    return
+  }
+
+  console.log(`   Current: v${current}`)
+  console.log(`   Latest:  v${latest}\n`)
+
+  if (compareVersions(latest, current) <= 0) {
+    console.log('   ✅ You are already using the latest version.\n')
+    return
+  }
+
+  console.log(`   ⬆️  Upgrading to v${latest}...\n`)
+
+  try {
+    execSync(`npm install -g ${pkg.name}@${latest}`, {
+      stdio: 'inherit',
+      env: { ...process.env, npm_config_fund: 'false', npm_config_audit: 'false' },
+    })
+    console.log(`\n   ✅ Upgraded to v${latest}\n`)
+    console.log('   Restart your terminal or re-source your shell to use the new version.\n')
+  } catch {
+    console.error('\n   ❌ Upgrade failed.')
+    console.error('   Try running manually: npm install -g rolecraft\n')
+    process.exit(1)
+  }
+}

--- a/src/commands/upgrade.test.js
+++ b/src/commands/upgrade.test.js
@@ -1,0 +1,101 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { mkdtempSync, mkdirSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'))
+const VERSION = pkg.version
+
+let tempDir, upgradeModule, logs, origLog, origExit
+
+function captureLog() {
+  logs = []
+  origLog = console.log
+  console.log = (...args) => {
+    if (args.length) logs.push(String(args[0]))
+  }
+}
+
+function restoreLog() {
+  console.log = origLog
+}
+
+function mockExit() {
+  origExit = process.exit
+  process.exit = (code) => { throw new Error(`exit:${code}`) }
+}
+
+function restoreExit() {
+  process.exit = origExit
+}
+
+before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-upgrade-test-'))
+  process.env.HOME = tempDir
+  upgradeModule = await import('./upgrade.js')
+})
+
+after(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('upgrade command', () => {
+  it('shows current version', async () => {
+    captureLog()
+    mockExit()
+    try {
+      await upgradeModule.upgradeCommand()
+    } catch (e) {
+      if (!e.message.startsWith('exit:')) throw e
+    }
+    restoreLog()
+    restoreExit()
+
+    assert.ok(logs.some(l => l.includes(`rolecraft v${VERSION}`)))
+  })
+
+  it('shows check message', async () => {
+    captureLog()
+    mockExit()
+    try {
+      await upgradeModule.upgradeCommand()
+    } catch (e) {
+      if (!e.message.startsWith('exit:')) throw e
+    }
+    restoreLog()
+    restoreExit()
+
+    assert.ok(logs.some(l => l.includes('Checking for updates')))
+  })
+
+  it('dry-run shows plan without upgrading', async () => {
+    captureLog()
+    await upgradeModule.upgradeCommand({ dryRun: true })
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('Dry-run')))
+    assert.ok(logs.some(l => l.includes('rolecraft')))
+  })
+
+  it('dry-run shows current version', async () => {
+    captureLog()
+    await upgradeModule.upgradeCommand({ dryRun: true })
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes(`v${VERSION}`)))
+  })
+
+  it('compares versions correctly', () => {
+    const { compareVersions } = upgradeModule
+    assert.equal(compareVersions('1.0.0', '1.0.0'), 0)
+    assert.ok(compareVersions('1.0.1', '1.0.0') > 0)
+    assert.ok(compareVersions('1.0.0', '1.0.1') < 0)
+    assert.ok(compareVersions('2.0.0', '1.9.9') > 0)
+    assert.ok(compareVersions('1.0.0', '0.9.9') > 0)
+  })
+})


### PR DESCRIPTION
## Changes

### New Command: rolecraft upgrade
- Checks npm registry for the latest version
- Shows current vs latest version
- Runs npm install -g rolecraft to upgrade
- Supports --dry-run to preview without upgrading
- Handles network errors gracefully

### Documentation
- New docs/commands/upgrade.md
- README updated with upgrade command entry
- ANALYSIS.md: self-upgrade gap marked as resolved
- comparison.md: self-upgrade column updated
- Shell completions updated (bash, zsh, fish)

### Tests
- 5 unit tests in upgrade.test.js
- CLI integration test for dry-run
- 179 total tests, all passing