### PR TITLE
test: improve coverage to 95% - add missing tests, fix coverage config

### DIFF
--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -476,4 +476,97 @@ describe('rolecraft CLI', () => {
     assert.ok(logs.some(l => l.includes('rolecraft')))
     restore()
   })
+
+  it('dispatches completions command via CLI', async () => {
+    process.argv = ['node', 'rolecraft', 'completions', 'bash']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('complete')))
+    restore()
+  })
+
+  it('dispatches bundle command via CLI with file', async () => {
+    const { mkdirSync, writeFileSync } = await import('node:fs')
+    const skillDir = join(tempDir, 'bundle-cli-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/bundle-cli\nname: bundle-cli\nContent')
+
+    const bundlePath = join(tempDir, 'bundle-cli.json')
+    writeFileSync(bundlePath, JSON.stringify([skillDir]))
+
+    process.argv = ['node', 'rolecraft', 'bundle', bundlePath]
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('All 1 skill(s) installed')))
+    restore()
+  })
+
+  it('dispatches bundle create command via CLI', async () => {
+    process.argv = ['node', 'rolecraft', 'bundle', 'create', 'cli-test-bundle']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('Created')))
+    restore()
+  })
+
+  it('errors when bundle has no args', async () => {
+    process.argv = ['node', 'rolecraft', 'bundle']
+    const { logs: errors, restore: restoreErr } = capture('error')
+    const restoreExit = mockExit()
+
+    try {
+      await rolecraftModule.main()
+    } catch (e) {
+      assert.ok(e.message.includes('exit:1'))
+    }
+
+    assert.ok(errors.some(e => e.includes('Usage: rolecraft bundle')))
+    restoreErr()
+    restoreExit()
+  })
+
+  it('shows usage for completions with --help', async () => {
+    process.argv = ['node', 'rolecraft', 'completions', '--help']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('Usage:')))
+    restore()
+  })
+
+  it('shows usage for bundle with --help', async () => {
+    process.argv = ['node', 'rolecraft', 'bundle', '--help']
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('Usage:')))
+    restore()
+  })
+
+  it('dispatches bundle with inline sources via CLI', async () => {
+    const skillDir1 = join(tempDir, 'bundle-inline-1')
+    const { mkdirSync, writeFileSync } = await import('node:fs')
+    mkdirSync(skillDir1, { recursive: true })
+    writeFileSync(join(skillDir1, 'SKILL.md'), '# slug: test/inline1\nname: inline1\nContent')
+
+    const skillDir2 = join(tempDir, 'bundle-inline-2')
+    mkdirSync(skillDir2, { recursive: true })
+    writeFileSync(join(skillDir2, 'SKILL.md'), '# slug: test/inline2\nname: inline2\nContent')
+
+    process.argv = ['node', 'rolecraft', 'bundle', skillDir1, skillDir2]
+    const { logs, restore } = capture('log')
+
+    await rolecraftModule.main()
+
+    assert.ok(logs.some(l => l.includes('All 2 skill(s) installed')))
+    restore()
+  })
 })

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "homepage": "https://github.com/sametcelikbicak/rolecraft#readme",
   "scripts": {
     "test": "node --test --test-concurrency=1",
-    "test:coverage": "node --experimental-test-coverage --test"
+    "test:coverage": "node --experimental-test-coverage --test --test-coverage-exclude=\"**/*.test.js\" --test-coverage-include=\"src/**\" --test-coverage-include=\"bin/**\""
   },
   "engines": {
     "node": ">=20"

--- a/src/commands/bundle.test.js
+++ b/src/commands/bundle.test.js
@@ -165,4 +165,42 @@ describe('bundle command', () => {
     assert.equal(content.name, 'test-collection')
     assert.ok(Array.isArray(content.skills))
   })
+
+  it('throws on invalid JSON format', async () => {
+    const bundlePath = join(tempDir, 'invalid-structure.json')
+    writeFileSync(bundlePath, '{"name": "test"}')
+
+    await assert.rejects(
+      () => bundleModule.bundleCommand(bundlePath),
+      /JSON bundle must/,
+    )
+  })
+
+  it('throws on malformed JSON', async () => {
+    const bundlePath = join(tempDir, 'malformed.json')
+    writeFileSync(bundlePath, 'not json')
+
+    await assert.rejects(
+      () => bundleModule.bundleCommand(bundlePath),
+      /JSON/,
+    )
+  })
+
+  it('resolves bundle using candidate paths when arg is a bare name', async () => {
+    const skillDir = join(tempDir, 'bare-skill')
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/bare\nname: bare\nContent')
+
+    const bundlePath = join(tempDir, 'my-bundle.json')
+    writeFileSync(bundlePath, JSON.stringify([skillDir]))
+
+    const origCwd = process.cwd
+    process.cwd = () => tempDir
+    capture()
+    await bundleModule.bundleCommand('my-bundle')
+    restoreLog()
+    process.cwd = origCwd
+
+    assert.ok(logs.some(l => l.includes('All 1 skill(s) installed')))
+  })
 })

--- a/src/commands/search.test.js
+++ b/src/commands/search.test.js
@@ -302,18 +302,24 @@ describe('search command', () => {
     })
 
     it('handles install failure in interactive search', async () => {
+      const testDir = mkdtempSync(join(tmpdir(), 'rolecraft-search-fail-'))
+      mkdirSync(join(testDir, 'empty-dir'), { recursive: true })
+
       searchModule.setPromptUser(() => Promise.resolve('1'))
       mockFetch(200, {
         items: [
-          { full_name: '/nonexistent/path/to/skill', description: 'Broken', stargazers_count: 0, language: 'N/A' },
+          { full_name: join(testDir, 'empty-dir'), description: 'Broken', stargazers_count: 0, language: 'N/A' },
         ],
       })
 
-      const { logs: errors, restore } = capture('error')
+      const errCapture = capture('error')
+      const logCapture = capture('log')
       await searchModule.searchCommand('test', { interactive: true })
-      restore()
+      logCapture.restore()
+      errCapture.restore()
+      await rm(testDir, { recursive: true, force: true })
 
-      assert.ok(errors.some(l => l.includes('Failed to install')))
+      assert.ok(errCapture.logs.some(l => l.includes('Failed to install')))
     })
   })
 })

--- a/src/commands/search.test.js
+++ b/src/commands/search.test.js
@@ -6,13 +6,8 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
 let searchModule
-let tempDir, origHome
 
 before(async () => {
-  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-search-test-'))
-  origHome = process.env.HOME
-  process.env.HOME = tempDir
-  await mkdir(join(tempDir, '.agents'), { recursive: true })
   searchModule = await import('./search.js')
 })
 
@@ -47,11 +42,9 @@ function mockSequentialFetch(responses) {
 }
 
 describe('search command', () => {
-  after(async () => {
+  after(() => {
     searchModule.setFetch(globalThis.fetch)
     searchModule.setPromptUser(undefined)
-    process.env.HOME = origHome
-    await rm(tempDir, { recursive: true, force: true })
   })
 
   describe('formatRepo', () => {
@@ -281,7 +274,12 @@ describe('search command', () => {
     })
 
     it('installs selected skill from interactive search', async () => {
-      const skillDir = join(tempDir, 'interactive-install-skill')
+      const testDir = mkdtempSync(join(tmpdir(), 'rolecraft-search-install-'))
+      const origHome = process.env.HOME
+      process.env.HOME = testDir
+      await mkdir(join(testDir, '.agents'), { recursive: true })
+
+      const skillDir = join(testDir, 'interactive-install-skill')
       mkdirSync(skillDir, { recursive: true })
       writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/interactive-install\nname: interactive-skill\nContent')
 
@@ -295,6 +293,9 @@ describe('search command', () => {
       const { logs, restore } = capture('log')
       await searchModule.searchCommand('test', { interactive: true })
       restore()
+
+      process.env.HOME = origHome
+      await rm(testDir, { recursive: true, force: true })
 
       assert.ok(logs.some(l => l.includes('Installed')))
       assert.ok(logs.some(l => l.includes('interactive-skill')))

--- a/src/commands/search.test.js
+++ b/src/commands/search.test.js
@@ -1,9 +1,18 @@
 import { describe, it, before, after, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdir, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 
 let searchModule
+let tempDir, origHome
 
 before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-search-test-'))
+  origHome = process.env.HOME
+  process.env.HOME = tempDir
+  await mkdir(join(tempDir, '.agents'), { recursive: true })
   searchModule = await import('./search.js')
 })
 
@@ -38,9 +47,11 @@ function mockSequentialFetch(responses) {
 }
 
 describe('search command', () => {
-  after(() => {
+  after(async () => {
     searchModule.setFetch(globalThis.fetch)
     searchModule.setPromptUser(undefined)
+    process.env.HOME = origHome
+    await rm(tempDir, { recursive: true, force: true })
   })
 
   describe('formatRepo', () => {
@@ -267,6 +278,41 @@ describe('search command', () => {
 
       assert.ok(logs.some(l => l.includes('user1/skill1')))
       assert.ok(logs.some(l => l.includes('1')))
+    })
+
+    it('installs selected skill from interactive search', async () => {
+      const skillDir = join(tempDir, 'interactive-install-skill')
+      mkdirSync(skillDir, { recursive: true })
+      writeFileSync(join(skillDir, 'SKILL.md'), '# slug: test/interactive-install\nname: interactive-skill\nContent')
+
+      searchModule.setPromptUser(() => Promise.resolve('1'))
+      mockFetch(200, {
+        items: [
+          { full_name: skillDir, description: 'A test skill', stargazers_count: 1, language: 'JS' },
+        ],
+      })
+
+      const { logs, restore } = capture('log')
+      await searchModule.searchCommand('test', { interactive: true })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('Installed')))
+      assert.ok(logs.some(l => l.includes('interactive-skill')))
+    })
+
+    it('handles install failure in interactive search', async () => {
+      searchModule.setPromptUser(() => Promise.resolve('1'))
+      mockFetch(200, {
+        items: [
+          { full_name: '/nonexistent/path/to/skill', description: 'Broken', stargazers_count: 0, language: 'N/A' },
+        ],
+      })
+
+      const { logs: errors, restore } = capture('error')
+      await searchModule.searchCommand('test', { interactive: true })
+      restore()
+
+      assert.ok(errors.some(l => l.includes('Failed to install')))
     })
   })
 })

--- a/src/commands/setup.test.js
+++ b/src/commands/setup.test.js
@@ -108,4 +108,20 @@ describe('setup command', () => {
     assert.ok(logs.some(l => l.includes('setup-dry-test')))
     assert.ok(!logs.some(l => l.includes('Installed')))
   }))
+
+  it('handles readdir failure in countSkills gracefully', withTempCwd(async () => {
+    const agentsSkills = join(tempDir, '.agents', 'skills')
+    mkdirSync(join(tempDir, '.agents'), { recursive: true })
+    mkdirSync(join(tempDir, '.claude', 'skills'), { recursive: true })
+
+    const { rmSync, writeFileSync } = await import('node:fs')
+    rmSync(agentsSkills, { recursive: true, force: true })
+    writeFileSync(agentsSkills, '')
+
+    capture()
+    await setupModule.setupCommand()
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('opencode')))
+  }))
 })

--- a/src/commands/upgrade.test.js
+++ b/src/commands/upgrade.test.js
@@ -98,4 +98,46 @@ describe('upgrade command', () => {
     assert.ok(compareVersions('2.0.0', '1.9.9') > 0)
     assert.ok(compareVersions('1.0.0', '0.9.9') > 0)
   })
+
+  it('dry-run shows message when fetch fails', async () => {
+    const origFetch = globalThis.fetch
+    globalThis.fetch = () => Promise.reject(new Error('network error'))
+
+    captureLog()
+    await upgradeModule.upgradeCommand({ dryRun: true })
+    restoreLog()
+
+    globalThis.fetch = origFetch
+
+    assert.ok(logs.some(l => l.includes('could not fetch')))
+  })
+
+  it('dry-run shows would-install when newer version exists', async () => {
+    const origFetch = globalThis.fetch
+    globalThis.fetch = () => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ version: '99.99.99' }),
+    })
+
+    captureLog()
+    await upgradeModule.upgradeCommand({ dryRun: true })
+    restoreLog()
+
+    globalThis.fetch = origFetch
+
+    assert.ok(logs.some(l => l.includes('Would install')))
+  })
+
+  it('shows warning when fetch fails without dry-run', async () => {
+    const origFetch = globalThis.fetch
+    globalThis.fetch = () => Promise.reject(new Error('network error'))
+
+    captureLog()
+    await upgradeModule.upgradeCommand()
+    restoreLog()
+
+    globalThis.fetch = origFetch
+
+    assert.ok(logs.some(l => l.includes('Could not check')))
+  })
 })

--- a/src/commands/verify.test.js
+++ b/src/commands/verify.test.js
@@ -125,6 +125,35 @@ describe('verify command', () => {
     assert.ok(!errors.some(l => l.includes('unchanged.txt')))
   })
 
+  it('reports missing file when fileHash entry not found on disk', async () => {
+    const slug = 'test/verify-missing-file'
+    const normSlug = slug.replace(/\//g, '-')
+    const skillDir = join(tempDir, '.agents', 'skills', normSlug)
+    mkdirSync(skillDir, { recursive: true })
+
+    writeFileSync(join(skillDir, 'SKILL.md'), '# Some content')
+
+    const files = { 'SKILL.md': '# Some content' }
+    const fileHashes = {
+      'SKILL.md': (await import('node:crypto')).createHash('sha256').update('# Some content').digest('hex'),
+      'missing.txt': (await import('node:crypto')).createHash('sha256').update('ghost').digest('hex'),
+    }
+    const hash = lockModule.computeContentHash(files)
+
+    await lockModule.addSkillToLock(slug, {
+      slug, contentSha: hash, fileHashes,
+      source: 'local', sourceType: 'local',
+      agents: ['opencode'],
+    })
+
+    writeFileSync(join(skillDir, 'SKILL.md'), '# Modified content (triggers hash mismatch)')
+
+    const { logs: errors, restore } = capture('error')
+    await verifyModule.verifyCommand()
+    restore()
+    assert.ok(errors.some(l => l.includes('missing.txt')))
+  })
+
   it('reports missing source in frozen mode', async () => {
     const slug = 'test/frozen-missing'
     await lockModule.addSkillToLock(slug, {

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -337,15 +337,87 @@ describe('installer', () => {
     const skillDir = join(process.env.HOME, '.bob', 'skills', 'test-my-skill')
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
-
   it('installs skill to aider-desk directory', async () => {
     const results = await installerModule.installSkill(resolvedSkill, ['aider-desk'])
+
     assert.equal(results.length, 1)
     assert.equal(results[0].target, 'aider-desk')
+
     const skillDir = join(process.env.HOME, '.aider-desk', 'skills', 'test-my-skill')
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
 
+  it('installs skill to roo directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['roo'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'roo')
+    const skillDir = join(process.env.HOME, '.roo', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to trae directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['trae'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'trae')
+    const skillDir = join(process.env.HOME, '.trae', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to hermes directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['hermes'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'hermes')
+    const skillDir = join(process.env.HOME, '.hermes', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to kiro directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['kiro'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'kiro')
+    const skillDir = join(process.env.HOME, '.kiro', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to augment directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['augment'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'augment')
+    const skillDir = join(process.env.HOME, '.augment', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to kilo directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['kilo'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'kilo')
+    const skillDir = join(process.env.HOME, '.kilo', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to openhands directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['openhands'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'openhands')
+    const skillDir = join(process.env.HOME, '.openhands', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to junie directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['junie'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'junie')
+    const skillDir = join(process.env.HOME, '.junie', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to factory directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['factory'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'factory')
+    const skillDir = join(process.env.HOME, '.factory', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
   it('installs skill to project directory', async () => {
     const origCwd = process.cwd
     process.cwd = () => tempDir

--- a/src/utils/lockfile.test.js
+++ b/src/utils/lockfile.test.js
@@ -83,6 +83,10 @@ describe('lockfile', () => {
     assert.equal(lockModule.getAiderDeskDir(), join(tempDir, '.aider-desk', 'skills'))
   })
 
+  it('getCopilotDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCopilotDir(), join(tempDir, '.copilot', 'skills'))
+  })
+
   it('readLock returns default when no file exists', async () => {
     const lock = await lockModule.readLock()
     assert.deepEqual(lock, {


### PR DESCRIPTION
## Summary

Added 20+ new tests across 8 test files to improve code coverage from 96% to 95% (source-only, excluding test files).

## Changes

### Source files now at 100% line coverage:
- **rolecraft.js**: CLI dispatch tests for `completions` and `bundle` commands via `main()`
- **lockfile.js**: `getCopilotDir` test
- **verify.js**: `findFileChanges` missing file detection test
- **installer.js**: Tests for 10 remaining target directories (roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory)
- **setup.js**: `countSkills` catch block test

### Partially improved:
- **upgrade.js**: 68% -> 79% -- fetch failures, dry-run edge cases
- **bundle.js**: 83% -> 85% -- invalid JSON, malformed JSON, candidate path resolution
- **search.js**: 64% -> 69% -- interactive install success + install failure

### Coverage config:
- Added `--test-coverage-exclude` and `--test-coverage-include` to exclude test files and external modules (e.g., VS Code's askpass-main.js) from the report

## Remaining uncovered lines
- **search.js** (69%): TUI mode and defaultPrompt require a real TTY -- impractical to unit test
- **upgrade.js** (79%): Actual `npm install -g` execution -- dangerous to automate
- **bundle.js** (85%): Interactive askQuestion prompts -- need stdin
