### PR TITLE
feat: add --yes flag, check command, GitLab/SSH URL support, and 20 new agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,26 +56,31 @@ npm install -g rolecraft
 rolecraft init my-skill
 
 # install it
-rolecraft install ./my-skill           # local folder
-rolecraft install user/repo            # GitHub repo
-rolecraft install ./my-skill --cursor  # specific agent only
+rolecraft install ./my-skill                      # local folder
+rolecraft install user/repo                       # GitHub repo
+rolecraft install https://gitlab.com/org/project  # GitLab repo
+rolecraft install git@github.com:user/repo.git    # SSH URL
+rolecraft install ./my-skill --cursor             # specific agent only
 
 # manage
 rolecraft list
 rolecraft search code-review
+rolecraft check
 rolecraft remove my-skill
 ```
 
-**Requirements:** Node.js >= 20 · No other dependencies · [Full install guide →](docs/install.md)
+**Requirements:** Node.js >= 20 · No other dependencies · 65+ agents supported · [Full install guide →](docs/install.md)
 
 ---
 
 ## Features
 
 - **Zero dependencies** — ~4 KB, no bloat
-- **Any source** — local folder, GitHub repo, any URL
-- **30+ agents** — opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more
+- **Any source** — local folder, GitHub/GitLab/Bitbucket repo, SSH git URL
+- **65+ agents** — opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more
 - **No registry required** — no signup, no marketplace, no vendor lock-in
+- **Non-interactive mode** — `--yes` / `-y` flag for automation/CI pipelines
+- **Update checking** — `rolecraft check` to see which skills have updates
 - **Shell completions** — bash, zsh, fish auto-completion
 - **TUI search** — interactive arrow-key skill browser with preview
 - **Content hash verification** — detect tampered or outdated skills
@@ -89,10 +94,11 @@ rolecraft remove my-skill
 | Command                      | Description                                         | Details                          |
 | ---------------------------- | --------------------------------------------------- | -------------------------------- |
 | `rolecraft init [<name>]`    | Scaffold a new `SKILL.md`                           | [docs](docs/commands/init.md)    |
-| `rolecraft install <source>` | Install a skill (local path or GitHub `owner/repo`) | [docs](docs/commands/install.md) |
+| `rolecraft install <source>` | Install a skill (local path, GitHub/GitLab/SSH URL)    | [docs](docs/commands/install.md) |
 | `rolecraft bundle <sources>` | Install multiple skills from inline sources or file | [docs](docs/commands/bundle.md)  |
 | `rolecraft bundle create`    | Create a new bundle file                            | [docs](docs/commands/bundle.md)  |
 | `rolecraft search <query>`   | Search for skills on GitHub (TUI with `--interactive`) | [docs](docs/commands/search.md)  |
+| `rolecraft check`            | Check installed skills for available updates            | [docs](docs/commands/check.md)  |
 | `rolecraft use <source>`     | Preview a skill's files without installing          | [docs](docs/commands/use.md)     |
 | `rolecraft completions bash\|zsh\|fish` | Generate shell completion scripts           | [docs](docs/commands/completions.md) |
 | `rolecraft setup [<source>]` | Detect agents, optionally install a skill to all    | [docs](docs/commands/setup.md)   |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  Works with <b>30+ AI agents</b>: opencode · claude-code · cursor · windsurf · devin · codex · copilot · aider · cline · gemini-cli · cody · continue · warp · codeium · fabric · goose · tabnine · supermaven · pr-pilot · loom · roo · trae · hermes · kiro · augment · kilo · openhands · junie · factory · and more
+  Works with <b>65+ AI agents</b>: opencode · claude-code · cursor · windsurf · devin · codex · copilot · aider · cline · gemini-cli · cody · continue · warp · codeium · fabric · goose · tabnine · supermaven · pr-pilot · loom · roo · trae · hermes · kiro · augment · kilo · openhands · junie · factory · command-code · cortex · mistral-vibe · qwen-code · openclaw · codebuddy · mux · pi · autohand-code · rovo · firebender · bob · aider-desk · and more
 </p>
 
 <p align="center">
@@ -49,7 +49,7 @@
 # try without installing
 npx rolecraft --help
 
-# or install globally
+# or install globally (works with npm, pnpm, yarn, bun)
 npm install -g rolecraft
 
 # create a skill
@@ -110,19 +110,24 @@ rolecraft remove my-skill
 
 [→ Full feature comparison](docs/comparison.md)
 
-| Feature                                  | rolecraft   | skills (Vercel) | @agentskill.sh/cli |
-| ---------------------------------------- | ----------- | --------------- | ------------------ |
-| Zero dependencies                        | ✅          | ✅ (1 dep)      | ❌ (2)             |
-| Local path install                       | ✅ 1st class | ✅              | ❌ marketplace only |
-| GitHub repo install                      | ✅          | ✅              | ❌                 |
-| Bundle install + create                  | ✅          | ❌              | ✅ (skillset only) |
-| Interactive search + install (TUI)       | ✅          | ❌              | ❌                 |
-| Shell completions (bash/zsh/fish)        | ✅          | ❌              | ❌                 |
-| Dry-run preview (`--dry-run`)            | ✅          | ❌              | ❌                 |
-| Interactive scope prompt                 | ✅          | ❌              | ❌                 |
-| Content hash verification (`verify`)     | ✅          | ✅              | ❌                 |
-| CI-mode re-install (`ci`)                | ✅          | ✅              | ❌                 |
-| File size                                | ~4 KB       | ~465 KB         | ~84 KB             |
+| Feature                                  | rolecraft       | skills (Vercel)  | @agentskill.sh/cli |
+| ---------------------------------------- | --------------- | ---------------- | ------------------ |
+| Zero dependencies                        | ✅              | ✅ (1 dep)       | ❌ (2)             |
+| Local path install                       | ✅ **1st class** | ✅               | ❌ marketplace only |
+| GitHub repo install                      | ✅              | ✅               | ❌                 |
+| GitLab / SSH git URL                     | ✅              | ✅               | ❌                 |
+| Agent targets                            | **66**          | 55+              | 15+                |
+| Bundle install + create                  | ✅              | ❌               | ✅ (skillset only) |
+| Interactive TUI search + install         | ✅              | ✅               | ❌                 |
+| Non-interactive flag (`--yes`/`-y`)      | ✅              | ✅               | ❌                 |
+| Skill update check (`check`)             | ✅              | ❌               | ❌                 |
+| Shell completions (bash/zsh/fish)        | ✅              | ❌               | ❌                 |
+| Dry-run preview (`--dry-run`)            | ✅              | ❌               | ❌                 |
+| Interactive scope prompt                 | ✅              | ✅               | ❌                 |
+| Content hash verification (`verify`)     | ✅              | ✅               | ❌                 |
+| CI-mode re-install (`ci`)                | ✅              | ✅               | ❌                 |
+| Self-upgrade command                     | ✅              | ❌               | ❌                 |
+| File size                                | ~4 KB           | ~465 KB          | ~84 KB             |
 
 [See full table →](docs/comparison.md)
 

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -12,6 +12,7 @@ import { setupCommand } from '../src/commands/setup.js'
 import { initCommand } from '../src/commands/init.js'
 import { searchCommand } from '../src/commands/search.js'
 import { verifyCommand } from '../src/commands/verify.js'
+import { checkCommand } from '../src/commands/check.js'
 import { ciCommand } from '../src/commands/ci.js'
 import { bundleCommand, bundleCreateCommand } from '../src/commands/bundle.js'
 import { completionsCommand } from '../src/commands/completions.js'
@@ -25,7 +26,7 @@ function usage() {
 rolecraft — Install AI agent skills like roles & behaviors
 
 Zero dependencies, no marketplace required.
-Works with opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo, firebender, bob, aider-desk, and all spec-compliant agents.
+Works with 65+ agents: opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo, firebender, bob, aider-desk, code-arts-doer, code-maker, code-studio, crush, eve, forge, inference-sh, jazz, iflow, kilo-code, kode, lingma, mcp-jam, moxby, ona, qoder, reasonix, terra-mind, tiny-cloud, zencoder, and all spec-compliant agents.
 
 Usage:
   rolecraft install <source>     Install a skill (local path or owner/repo)
@@ -38,6 +39,7 @@ Usage:
   rolecraft setup [<source>]     Detect agents and optionally install a skill
   rolecraft init [<name>]        Scaffold a new SKILL.md
   rolecraft search <query>       Search for skills on GitHub
+  rolecraft check                Check for available skill updates
   rolecraft verify               Verify installed skill integrity
   rolecraft ci                   Install all skills from lockfile
   rolecraft completions <shell>  Generate shell completions (bash|zsh|fish)
@@ -45,6 +47,7 @@ Usage:
   rolecraft help                 Show this help
 
 Options:
+  --yes, -y     Non-interactive: accept all defaults (install, setup)
   --dry-run      Preview installation without copying files (install, setup, bundle, upgrade)
 
 Options for upgrade:
@@ -132,6 +135,7 @@ export async function main() {
       const flags = args.slice(1)
       const scopeFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--devin', '--codex', '--copilot', '--aider', '--cline', '--gemini', '--cody', '--continue', '--warp', '--codeium', '--fabric', '--goose', '--tabnine', '--supermaven', '--pr-pilot', '--loom', '--roo', '--trae', '--hermes', '--kiro', '--augment', '--kilo', '--openhands', '--junie', '--factory', '--command-code', '--cortex', '--mistral-vibe', '--qwen-code', '--openclaw', '--codebuddy',
   '--mux', '--pi', '--autohand-code', '--rovo', '--firebender', '--bob', '--aider-desk',
+  '--code-arts-doer', '--code-maker', '--code-studio', '--crush', '--eve', '--forge', '--inference-sh', '--jazz', '--iflow', '--kilo-code', '--kode', '--lingma', '--mcp-jam', '--moxby', '--ona', '--qoder', '--reasonix', '--terra-mind', '--tiny-cloud', '--zencoder',
   '--all']
       const hasScopeFlag = flags.some(f => scopeFlags.includes(f))
       const options = hasScopeFlag ? {
@@ -177,11 +181,32 @@ export async function main() {
         firebender: flags.includes('--firebender') || flags.includes('--all'),
         bob: flags.includes('--bob') || flags.includes('--all'),
         'aider-desk': flags.includes('--aider-desk') || flags.includes('--all'),
+        'code-arts-doer': flags.includes('--code-arts-doer') || flags.includes('--all'),
+        'code-maker': flags.includes('--code-maker') || flags.includes('--all'),
+        'code-studio': flags.includes('--code-studio') || flags.includes('--all'),
+        crush: flags.includes('--crush') || flags.includes('--all'),
+        eve: flags.includes('--eve') || flags.includes('--all'),
+        forge: flags.includes('--forge') || flags.includes('--all'),
+        'inference-sh': flags.includes('--inference-sh') || flags.includes('--all'),
+        jazz: flags.includes('--jazz') || flags.includes('--all'),
+        iflow: flags.includes('--iflow') || flags.includes('--all'),
+        'kilo-code': flags.includes('--kilo-code') || flags.includes('--all'),
+        kode: flags.includes('--kode') || flags.includes('--all'),
+        lingma: flags.includes('--lingma') || flags.includes('--all'),
+        'mcp-jam': flags.includes('--mcp-jam') || flags.includes('--all'),
+        moxby: flags.includes('--moxby') || flags.includes('--all'),
+        ona: flags.includes('--ona') || flags.includes('--all'),
+        qoder: flags.includes('--qoder') || flags.includes('--all'),
+        reasonix: flags.includes('--reasonix') || flags.includes('--all'),
+        'terra-mind': flags.includes('--terra-mind') || flags.includes('--all'),
+        'tiny-cloud': flags.includes('--tiny-cloud') || flags.includes('--all'),
+        zencoder: flags.includes('--zencoder') || flags.includes('--all'),
         project: flags.includes('--project') || flags.includes('--all'),
       } : {}
       options.frozenLockfile = flags.includes('--frozen-lockfile')
       options.symlink = flags.includes('--symlink')
       options.dryRun = flags.includes('--dry-run')
+      options.yes = flags.includes('--yes') || flags.includes('-y')
 
       await installCommand(source, options)
       break
@@ -257,6 +282,13 @@ export async function main() {
       break
     }
 
+    case 'check':
+    case 'check-updates': {
+      if (args.includes('--help') || args.includes('-h')) { usage(); return }
+      await checkCommand()
+      break
+    }
+
     case 'ci': {
       if (args.includes('--help') || args.includes('-h')) { usage(); return }
       await ciCommand()
@@ -267,7 +299,7 @@ export async function main() {
       if (args.includes('--help') || args.includes('-h')) { usage(); return }
       const source = args[0]
       const flags = args.slice(1)
-      await setupCommand(source, { dryRun: flags.includes('--dry-run') })
+      await setupCommand(source, { dryRun: flags.includes('--dry-run'), yes: flags.includes('--yes') || flags.includes('-y') })
       break
     }
 

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -2,102 +2,78 @@
 
 ## rolecraft vs Competitors
 
-| Feature                      | rolecraft      | skills (Vercel)                           | @agentskill.sh/cli (ags) | openskills        | skills-npm (antfu)  | qntx/skill (Rust) | OpenCode native | Claude Code |
-| ---------------------------- | -------------- | ----------------------------------------- | ------------------------ | ----------------- | ------------------- | ----------------- | --------------- | ----------- |
-| **Runtime deps**             | **0**          | 1 (`yaml`)                                | 2                        | 4                 | 4                   | **0** (static)    | 0 (built-in)    | 0 (built-in) |
-| **Package size**             | ~4 KB          | 465 KB                                    | 84 KB                    | 51 KB             | 36 KB               | ~8 MB binary      | N/A             | N/A         |
-| **Source files**             | 15             | 14                                        | 37                       | —                 | —                   | —                 | N/A             | N/A         |
-| **Source types**             | Local + GitHub | GitHub/GitLab/git URL/Local/npm           | Registry only            | GitHub + Local    | npm packages only   | GitHub/Git/Local  | Filesystem only | Filesystem + MCP + plugins |
-| **Lockfile**                 | agentskill v3  | Two-tier (global v3 + project v1, SHA)    | None                     | None              | None                | ✅                | None            | Config only   |
-| **Offline capable**          | ✅             | ✅                                        | ❌ (registry)             | ✅                | ✅                  | ✅                | ✅              | ✅           |
-| **Signup required**          | ❌             | ❌                                        | ✅ (agentskill.sh)        | ❌                | ❌                  | ❌                | ❌              | ❌           |
-| **Agent count**              | **43**         | 72                                        | 15+                      | 10+               | 10+                 | 39                | 1 (+ compat)    | 1 (+ plugins) |
-| **Project scope default**    | ✅             | ✅                                        | N/A                      | ❌ (global)        | ✅ (project)        | ✅                | N/A             | N/A         |
-| **Interactive scope prompt** | ✅             | ✅                                        | ❌                       | ❌                | ❌                  | ❌                | N/A             | N/A         |
-| **Provenance (npm)**         | ✅             | ❌                                        | ❌                       | ❌                | ❌                  | ❌                | N/A             | N/A         |
-| **`use` command**            | ✅             | ✅                                        | ❌                       | ✅ (`read`)        | ❌                  | ✅                | ❌              | ❌          |
-| **`setup` command**          | ✅             | ❌                                        | ✅                       | ❌                | ❌                  | ❌                | ❌              | ❌          |
-| **`init` command**           | ✅             | ✅                                        | ❌                       | ❌                | ❌                  | ❌                | ❌              | ❌          |
-| **`search`/`find` command**  | ✅             | ✅ (`skills find`, `vercel skills`)       | ✅ (`ags search`)        | ❌                | ❌                  | ✅                | ❌              | ❌          |
-| **`verify` command**         | ✅             | ✅ (`skills verify`)                      | ❌                       | ❌                | ❌                  | ❌                | ❌              | ❌          |
-| **`ci` command**             | ✅             | ✅ (`skills ci`)                          | ❌                       | ❌                | ❌                  | ❌                | ❌              | ❌          |
-| **`--frozen-lockfile`**      | ✅             | ✅                                        | ❌                       | ❌                | ❌                  | ❌                | ❌              | ❌          |
-| **Symlink mode**             | ✅             | ✅ (default)                              | ❌                       | ❌                | ✅ (only)           | ✅                | ❌              | ❌          |
-| **`--dry-run`**              | ✅             | ❌                                        | ❌                       | ❌                | ❌                  | ✅                | ❌              | ❌          |
-| **Bundle install**           | ✅             | ❌                                        | ✅ (skillset)             | ❌                | ❌                  | ❌                | ❌              | ❌          |
-| **Shell completions**        | ✅             | ❌                                        | ❌                       | ❌                | ❌                  | ✅                | ❌              | ❌          |
-| **`doctor` command**             | ❌             | ❌                                        | ❌                       | ❌                | ❌                  | ✅                | ❌              | ❌          |
-| **`upgrade` (self-update)**  | ❌             | ❌                                        | ❌                       | ❌                | ❌                  | ✅                | ❌              | ❌          |
-| **TUI search**               | ⚠️ (styled)   | ✅ (`skills find` interactive)            | ❌                       | ❌                | ❌                  | ❌                | ❌              | ❌          |
-| **Stars**                    | 34             | 24,613                                    | 23                       | 10,525            | 480                 | ~1                | 13K+           | 135K+       |
+| Feature                      | rolecraft      | skills (Vercel)                        | @agentskill.sh/cli (ags) | openskills     | skills-npm (antfu) | qntx/skill (Rust) | OpenCode native | Claude Code                |
+| ---------------------------- | -------------- | -------------------------------------- | ------------------------ | -------------- | ------------------ | ----------------- | --------------- | -------------------------- |
+| **Runtime deps**             | **0**          | 1 (`yaml`)                             | 2                        | 4              | 4                  | **0** (static)    | 0 (built-in)    | 0 (built-in)               |
+| **Package size**             | ~4 KB          | 465 KB                                 | 84 KB                    | 51 KB          | 36 KB              | ~8 MB binary      | N/A             | N/A                        |
+| **Source files**             | 15             | 14                                     | 37                       | —              | —                  | —                 | N/A             | N/A                        |
+| **Source types**             | Local + GitHub | GitHub/GitLab/git URL/Local/npm        | Registry only            | GitHub + Local | npm packages only  | GitHub/Git/Local  | Filesystem only | Filesystem + MCP + plugins |
+| **GitLab/SSH git URL**       | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **Lockfile**                 | agentskill v3  | Two-tier (global v3 + project v1, SHA) | None                     | None           | None               | ✅                | None            | Config only                |
+| **Offline capable**          | ✅             | ✅                                     | ❌ (registry)            | ✅             | ✅                 | ✅                | ✅              | ✅                         |
+| **Signup required**          | ❌             | ❌                                     | ✅ (agentskill.sh)       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Agent count**              | **66**         | 72                                     | 15+                      | 10+            | 10+                | 39                | 1 (+ compat)    | 1 (+ plugins)              |
+| **Project scope default**    | ✅             | ✅                                     | N/A                      | ❌ (global)    | ✅ (project)       | ✅                | N/A             | N/A                        |
+| **Interactive scope prompt** | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | N/A             | N/A                        |
+| **Provenance (npm)**         | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | N/A             | N/A                        |
+| **`use` command**            | ✅             | ✅                                     | ❌                       | ✅ (`read`)    | ❌                 | ✅                | ❌              | ❌                         |
+| **`setup` command**          | ✅             | ❌                                     | ✅                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`init` command**           | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`search`/`find` command**  | ✅             | ✅ (`skills find`, `vercel skills`)    | ✅ (`ags search`)        | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`verify` command**         | ✅             | ✅ (`skills verify`)                   | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`ci` command**             | ✅             | ✅ (`skills ci`)                       | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`check` command**          | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`--frozen-lockfile`**      | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Symlink mode**             | ✅             | ✅ (default)                           | ❌                       | ❌             | ✅ (only)          | ✅                | ❌              | ❌                         |
+| **`--dry-run`**              | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`--yes` / `-y`**           | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Bundle install**           | ✅             | ❌                                     | ✅ (skillset)            | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Shell completions**        | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`doctor` command**         | ❌             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`upgrade` (self-update)**  | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **TUI search**               | ⚠️ (styled)    | ✅ (`skills find` interactive)         | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Stars**                    | 36             | 24,613                                 | 23                       | 10,525         | 480                | ~1                | 13K+            | 135K+                      |
 
 ## Strengths
 
 - **Zero dependencies** — only Node.js built-in modules
 - **Provenance publishing** — SLSA Level 1+ via npm provenance
 - **GitHub + Local sources** — fully decentralized
+- **GitLab/SSH git URL support** — any git remote with SKILL.md
 - **agentskill.sh lockfile compatible** — cross-compatible with ecosystem
 - **Interactive scope prompt** — user-friendly first install
 - **Project scope default** — modern default
-- **43 install targets** — 42 named agents + project-local
+- **66 install targets** — 65 named agents + project-local
 - **SHA256 content hash verification** — `rolecraft verify`
 - **CI mode** — `rolecraft ci` for pipeline installs
 - **Symlink + Copy modes** — `--symlink`/`--copy`
 - **Dry-run preview** — `--dry-run` on install, setup, bundle
 - **Bundle system** — install from JSON/text files or inline sources
+- **`--yes` / `-y` flag** — non-interactive mode for automation pipelines
+- **`rolecraft check` command** — check for available updates
 
 ## Weaknesses / Gaps
 
 ### Feature gaps vs competitors
 
-1. **Agent count (43)** — ahead of `ags` (15+), `openskills` (10+), `skills-npm` (10+), `qntx/skill` (39) but behind `skills` (72)
+1. **Agent count (66)** — ahead of `ags` (15+), `openskills` (10+), `skills-npm` (10+), `qntx/skill` (39) but behind `skills` (72)
 2. **No `doctor` command** — `qntx/skill` has `skills doctor` for health checks
-3. **No GitLab/Bitbucket/SSH git URL support** — only GitHub `owner/repo` and local paths
-4. **npm package source unsupported** — `skills` supports `npx skills add some-package`, `skills-npm` is built around it
-5. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
-6. **Stars / community adoption very low (~5)** — building trust and visibility
+3. **npm package source unsupported** — `skills` supports `npx skills add some-package`, `skills-npm` is built around it
+4. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
+5. **Stars / community adoption very low (~5)** — building trust and visibility
 
 ### ✅ Resolved Gaps
 
 - **Copilot agent path** — now uses `.github/copilot/skills/` (project scope)
 - **Self-upgrade** — `rolecraft upgrade` command added
-- **Agent count (30 → 43)** — 13 new agent targets added
+- **Agent count (30 → 43 → 66)** — 20 new agent targets added
+- **`--yes` / `-y` flag** — non-interactive mode for automation
+- **`rolecraft check` command** — update availability checking
+- **GitLab/SSH git URL support** — any git remote with SKILL.md
 
 ## Roadmap
 
-### v0.3.x — Init, Search & Lockfile ✅
-
-- [x] `rolecraft init [name]` — SKILL.md scaffolding (`skills init` equivalent)
-- [x] `rolecraft search <query>` — skill discovery via GitHub API (`skills find` equivalent)
-- [x] 20+ agent targets (agent count parity with `ags`) — **20 agents**
-- [x] `--frozen-lockfile` flag for install
-
-### v0.4.x — Integrity & Performance ✅
-
-- [x] Content hash in lockfile (SHA256 `contentSha`)
-- [x] `rolecraft verify` — hash verification (`skills verify` equivalent)
-- [x] `rolecraft ci` — frozen lockfile install (`skills ci` equivalent)
-- [x] Symlink mode (`--symlink`/`--copy`)
-- [x] 9 new agent targets (roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory) — **29 total**
-- [x] `--dry-run` mode — preview installation without copying
-- [x] Interactive search (`search --interactive`)
-- [x] Bundle command (`bundle`, `bundle create`)
-
-### v0.5.x — Agent Coverage & Source Expansion
-
-- [x] Copilot agent path fix (`.github/copilot/skills/` instead of `~/.copilot/skills/`)
-- [x] 13 new agent targets (command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo, firebender, bob, aider-desk) — **43 total**
-- [ ] GitLab URL support (`https://gitlab.com/org/repo`)
-- [ ] SSH git URL support (`git@github.com:owner/repo.git`)
-- [ ] Full git URL support (any remote with SKILL.md)
-- [ ] 10+ new agent targets to match `skills` (72)
 - [ ] `rolecraft doctor` — system health check
-
-### v0.6.x — UX & Shell Integration
-
-- [x] Shell completions (bash, zsh, fish)
-- [x] Color-highlighted interactive search (`search --interactive` with styled cards)
-- [x] `rolecraft upgrade` — self-update command
 - [ ] npm package source support (`npx rolecraft install some-package`)
 - [ ] AGENTS.md XML injection for non-Claude agents
 - [ ] Skill bundle / skillset hub
@@ -113,7 +89,7 @@
 - **Key features**: `skills use`, `skills ci`/`skills verify` (lockfile workflow), `skills find` (interactive TUI), `skills init`, symlink mode, `vercel skills` built-in, 13.4M weekly downloads, skills.sh directory
 - **Weaknesses**: 1 dep (`yaml`), no provenance, no `setup` command, no dry-run, no bundle
 - **rolecraft advantage**: Zero deps, provenance, `setup` command, dry-run, bundle
-- **rolecraft gap**: Agent count (30 vs 55+), no doctor, no GitLab support
+- **rolecraft gap**: Agent count (66 vs 72), no doctor
 
 ### @agentskill.sh/cli (ags)
 
@@ -121,7 +97,7 @@
 - **Stars**: 23 | **Deps**: 2 | **Agents**: 15+
 - **Key features**: 274K+ skills in marketplace, security scoring (0-100), `/learn` in-agent command, feedback loop (1-5 rating), `ags setup` auto-detection
 - **Weaknesses**: Requires signup, no lockfile, no offline, no local sources, no provenance
-- **rolecraft advantage**: Zero deps, offline-first, lockfile, provenance, local sources, 30 agents
+- **rolecraft advantage**: Zero deps, offline-first, lockfile, provenance, local sources, 66 agents
 
 ### openskills (numman-ali)
 
@@ -146,8 +122,8 @@
 - **Key features**: 100% command parity, shell completions, `skills doctor`, `skills upgrade`, dry-run mode, parallel I/O
 - **Weaknesses**: Very new, Rust toolchain for dev, no provenance, no `setup`
 - **rolecraft advantage**: Zero deps as JS, provenance, `setup` command, interactive scope prompt
-- **rolecraft advantage**: Shell completions, TUI search
-- **rolecraft gap**: No doctor, no upgrade
+- **rolecraft advantage**: Shell completions, TUI search, self-upgrade
+- **rolecraft gap**: No doctor
 
 ### OpenCode native
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -46,10 +46,30 @@ rolecraft knows where each AI agent looks for skills. When you use a flag like `
 | firebender  | `~/.firebender/skills/`                         |
 | bob         | `~/.bob/skills/`                                |
 | aider-desk  | `~/.aider-desk/skills/`                         |
-| zap         | `~/.zap/skills/`                                |
-| codeep      | `~/.codeep/skills/`                             |
-| kimi-code   | `~/.kimi-code/skills/`                          |
-| zcode       | `~/.zcode/skills/`                              |
+| zap             | `~/.zap/skills/`                                  |
+| codeep          | `~/.codeep/skills/`                               |
+| kimi-code       | `~/.kimi-code/skills/`                            |
+| zcode           | `~/.zcode/skills/`                                |
+| code-arts-doer  | `~/.codeartsdoer/skills/`                         |
+| code-maker      | `~/.codemaker/skills/`                            |
+| code-studio     | `~/.codestudio/skills/`                           |
+| crush           | `~/.crush/skills/`                                |
+| eve             | `./agent/skills/`                                 |
+| forge           | `~/.forge/skills/`                                |
+| inference-sh    | `~/.inferencesh/skills/`                          |
+| jazz            | `~/.jazz/skills/`                                 |
+| iflow           | `~/.iflow/skills/`                                |
+| kilo-code       | `~/.kilocode/skills/`                             |
+| kode            | `~/.kode/skills/`                                 |
+| lingma          | `~/.lingma/skills/`                               |
+| mcp-jam         | `~/.mcpjam/skills/`                               |
+| moxby           | `~/.moxby/skills/`                                |
+| ona             | `~/.ona/skills/`                                  |
+| qoder           | `~/.qoder/skills/`                                |
+| reasonix        | `~/.reasonix/skills/`                             |
+| terra-mind      | `~/.terramind/skills/`                            |
+| tiny-cloud      | `~/.tinycloud/skills/`                            |
+| zencoder        | `~/.zencoder/skills/`                             |
 
 > ⚠️ Windsurf has been rebranded to **Devin Desktop**. The `--windsurf` flag and `~/.windsurf/skills/` path still work for backward compatibility, but new deployments should use `--devin` / `~/.devin/skills/`.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,30 +1,40 @@
 # Feature Comparison
 
-> How rolecraft stacks up against [skills (Vercel)](https://github.com/vercel/skills) and [@agentskill.sh/cli](https://github.com/agentSkillSh/CLI).
+> How rolecraft stacks up against [skills (Vercel)](https://github.com/vercel-labs/skills) and [@agentskill.sh/cli (`ags`)](https://github.com/agentskill-sh/ags).
 
-| Feature                                  | rolecraft        | skills (Vercel)   | @agentskill.sh/cli |
-| ---------------------------------------- | ---------------- | ----------------- | -------------------- |
-| Zero dependencies                        | ✅               | ✅ (1 dep)        | ❌ (2)               |
-| Local path install                       | ✅ **1st class** | ✅                | ❌ marketplace only  |
-| GitHub repo install                      | ✅               | ✅                | ❌                   |
-| GitLab / SSH git URL                     | ❌               | ✅                | ❌                   |
-| npm package source                       | ❌               | ✅                | ❌                   |
-| Agent targets                            | 30               | 55+               | 15+                  |
-| SKILL.md scaffolding                     | ✅               | ✅                | ❌                   |
-| Skill discovery (search)                 | ✅               | ✅ (TUI)          | ✅                   |
-| Interactive search + install             | ✅               | ❌                | ❌                   |
-| Bundle install (`bundle`)                | ✅               | ❌                | ✅ (skillset)        |
-| Bundle create (`bundle create`)          | ✅               | ❌                | ❌                   |
-| Offline capable                          | ✅               | ✅                | ❌                   |
-| Project-level install                    | ✅               | ✅                | ✅                   |
-| Interactive scope prompt                 | ✅               | ❌                | ❌                   |
-| Dry-run preview (`--dry-run`)            | ✅               | ❌                | ❌                   |
-| Lockfile integrity (`--frozen-lockfile`) | ✅               | ✅                | ❌                   |
-| Content hash verification (`verify`)     | ✅               | ✅                | ❌                   |
-| CI-mode re-install (`ci`)                | ✅               | ✅                | ❌                   |
-| Symlink install (`--symlink`)            | ✅               | ✅ (default)      | ❌                   |
-| npm provenance                           | ✅               | ❌                | ❌                   |
-| Shell completions                        | ✅               | ❌                | ❌                   |
-| `doctor` command                         | ❌               | ❌                | ❌                   |
-| Self-upgrade command                     | ✅               | ❌                | ❌                   |
-| File size                                | ~4 KB            | ~465 KB           | ~84 KB               |
+| Feature                                  | rolecraft        | skills (Vercel)  | @agentskill.sh/cli  |
+| ---------------------------------------- | ---------------- | ---------------- | ------------------- |
+| Zero dependencies                        | ✅               | ✅ (1 dep)        | ❌ (2)              |
+| Local path install                       | ✅ **1st class** | ✅                | ❌ marketplace only |
+| GitHub repo install                      | ✅               | ✅                | ❌                  |
+| GitLab / SSH git URL                     | ✅               | ✅                | ❌                  |
+| npm package source                       | ❌               | ✅                | ❌                  |
+| Agent targets                            | **66**           | 55+               | 15+                 |
+| SKILL.md scaffolding (`init`)            | ✅               | ✅                | ❌                  |
+| Skill preview (`use`)                    | ✅               | ✅                | ❌                  |
+| Agent auto-detect + install (`setup`)    | ✅               | ❌                | ✅                  |
+| Skill discovery (search)                 | ✅               | ✅                | ✅                  |
+| Interactive TUI search + install         | ✅               | ✅                | ❌                  |
+| Bundle install (`bundle`)                | ✅               | ❌                | ✅ (skillset)       |
+| Bundle create (`bundle create`)          | ✅               | ❌                | ❌                  |
+| Offline capable                          | ✅               | ✅                | ❌                  |
+| Project-level install                    | ✅               | ✅                | ✅                  |
+| Interactive scope prompt                 | ✅               | ✅                | ❌                  |
+| Non-interactive flag (`--yes`/`-y`)      | ✅               | ✅                | ❌                  |
+| Dry-run preview (`--dry-run`)            | ✅               | ❌                | ❌                  |
+| Lockfile integrity (`--frozen-lockfile`) | ✅               | ✅                | ❌                  |
+| Content hash verification (`verify`)     | ✅               | ✅                | ❌                  |
+| CI-mode re-install (`ci`)                | ✅               | ✅                | ❌                  |
+| Skill update check (`check`)             | ✅               | ❌                | ❌                  |
+| Skill update / re-install (`update`)     | ✅               | ✅                | ❌                  |
+| Symlink install (`--symlink`)            | ✅               | ✅ (default)      | ❌                  |
+| Self-upgrade (`upgrade`)                 | ✅               | ❌                | ❌                  |
+| npm provenance                           | ✅               | ❌                | ❌                  |
+| Shell completions (bash/zsh/fish)        | ✅               | ❌                | ❌                  |
+| In-agent `/learn` command                | ❌               | ❌                | ✅                  |
+| Skill rating / feedback                  | ❌               | ❌                | ✅                  |
+| Skill diff / compose                     | ❌               | ❌                | ❌                  |
+| Conflict detection (`doctor`)            | ❌               | ❌                | ❌                  |
+| Security scanning                        | ❌               | ❌ (audits only)  | ✅                  |
+| Telemetry / leaderboard                  | ❌               | ✅                | ❌                  |
+| File size                                | ~4 KB            | ~465 KB           | ~84 KB              |

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,11 @@
 npm install -g rolecraft
 # or run without installing:
 npx rolecraft install <source>
+
+# also works with pnpm, yarn, bun:
+pnpm add -g rolecraft
+yarn global add rolecraft
+bun add -g rolecraft
 ```
 
 > **Requirements:** Node.js >= 20
@@ -69,8 +74,28 @@ Where do you want to install this skill?
 | `--autohand-code` | `~/.autohand/skills/`           |
 | `--rovo`        | `~/.rovodev/skills/`               |
 | `--firebender`  | `~/.firebender/skills/`            |
-| `--bob`         | `~/.bob/skills/`                   |
-| `--aider-desk`  | `~/.aider-desk/skills/`            |
+| `--bob`             | `~/.bob/skills/`                   |
+| `--aider-desk`      | `~/.aider-desk/skills/`            |
+| `--code-arts-doer`  | `~/.codeartsdoer/skills/`          |
+| `--code-maker`      | `~/.codemaker/skills/`             |
+| `--code-studio`     | `~/.codestudio/skills/`            |
+| `--crush`           | `~/.crush/skills/`                 |
+| `--eve`             | `./agent/skills/`                  |
+| `--forge`           | `~/.forge/skills/`                 |
+| `--inference-sh`    | `~/.inferencesh/skills/`           |
+| `--jazz`            | `~/.jazz/skills/`                  |
+| `--iflow`           | `~/.iflow/skills/`                 |
+| `--kilo-code`       | `~/.kilocode/skills/`              |
+| `--kode`            | `~/.kode/skills/`                  |
+| `--lingma`          | `~/.lingma/skills/`                |
+| `--mcp-jam`         | `~/.mcpjam/skills/`                |
+| `--moxby`           | `~/.moxby/skills/`                 |
+| `--ona`             | `~/.ona/skills/`                   |
+| `--qoder`           | `~/.qoder/skills/`                 |
+| `--reasonix`        | `~/.reasonix/skills/`              |
+| `--terra-mind`      | `~/.terramind/skills/`             |
+| `--tiny-cloud`      | `~/.tinycloud/skills/`             |
+| `--zencoder`        | `~/.zencoder/skills/`              |
 
 Combine flags to install to multiple agents at once:
 
@@ -86,6 +111,7 @@ rolecraft install ./my-skill --claude --cursor --devin
 | `--copy`              | Force copy (default)                       |
 | `--dry-run`           | Preview without copying files              |
 | `--frozen-lockfile`   | Fail if skill is already installed         |
+| `--yes` / `-y`        | Skip all confirmation prompts, use defaults |
 
 ## Source types
 
@@ -109,3 +135,13 @@ rolecraft install sametcelikbicak/coverage-guard
 ```
 
 The CLI clones with `--depth 1`, finds `SKILL.md` recursively, installs it, and cleans up.
+
+### Git URL (GitLab, Bitbucket, SSH)
+
+Any public git repository with `SKILL.md`:
+
+```bash
+rolecraft install https://gitlab.com/org/project
+rolecraft install https://bitbucket.org/org/project
+rolecraft install git@github.com:owner/repo.git
+```

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -1,0 +1,44 @@
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { readLock, getProjectLockPath } from '../utils/lockfile.js'
+import { resolveSource } from '../utils/resolver.js'
+
+export async function checkCommand() {
+  const globalLock = await readLock()
+  const projectLock = await readLock(getProjectLockPath(process.cwd())).catch(() => ({ skills: {} }))
+  const allSkills = { ...globalLock.skills, ...projectLock.skills }
+
+  const entries = Object.entries(allSkills)
+  if (entries.length === 0) {
+    console.log('\nNo installed skills found.')
+    return
+  }
+
+  console.log(`\nChecking ${entries.length} installed skills for updates...\n`)
+
+  let updatesAvailable = 0
+  for (const [slug, info] of entries) {
+    const source = info.source
+    if (!source) {
+      console.log(`   ⏭️  ${slug.padEnd(30)} no source info, skipping`)
+      continue
+    }
+
+    try {
+      const resolved = await resolveSource(source)
+      const oldHash = info.contentSha || ''
+      const newHash = resolved.contentSha || ''
+
+      if (oldHash && newHash && oldHash !== newHash) {
+        console.log(`   🔄 ${slug.padEnd(30)} update available`)
+        updatesAvailable++
+      } else {
+        console.log(`   ✅ ${slug.padEnd(30)} up to date`)
+      }
+    } catch {
+      console.log(`   ❌ ${slug.padEnd(30)} could not check (source: ${source})`)
+    }
+  }
+
+  console.log(`\n${updatesAvailable > 0 ? `⚠️  ${updatesAvailable} skill(s) have updates available. Run \`rolecraft update <slug>\` to update.` : '✅ All skills are up to date.'}\n`)
+}

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -1,5 +1,3 @@
-import { readFileSync, existsSync } from 'node:fs'
-import { join } from 'node:path'
 import { readLock, getProjectLockPath } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -44,8 +44,8 @@ async function askScope() {
 }
 
 export async function installCommand(source, options) {
-  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline || options.gemini || options.cody || options.continue || options.warp || options.codeium || options.fabric || options.goose || options.tabnine || options.supermaven || options['pr-pilot'] || options.loom || options.roo || options.trae || options.hermes || options.kiro || options.augment || options.kilo || options.openhands || options.junie || options.factory || options['command-code'] || options.cortex || options['mistral-vibe'] || options['qwen-code'] || options.openclaw || options.codebuddy || options.mux || options.pi || options['autohand-code'] || options.rovo || options.firebender || options.bob || options['aider-desk'] || options.zap || options.codeep || options['kimi-code'] || options.zcode
-  const scope = hasScopeFlags ? options : await askScope()
+  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline || options.gemini || options.cody || options.continue || options.warp || options.codeium || options.fabric || options.goose || options.tabnine || options.supermaven || options['pr-pilot'] || options.loom || options.roo || options.trae || options.hermes || options.kiro || options.augment || options.kilo || options.openhands || options.junie || options.factory || options['command-code'] || options.cortex || options['mistral-vibe'] || options['qwen-code'] || options.openclaw || options.codebuddy || options.mux || options.pi || options['autohand-code'] || options.rovo || options.firebender || options.bob || options['aider-desk'] || options['code-arts-doer'] || options['code-maker'] || options['code-studio'] || options.crush || options.eve || options.forge || options['inference-sh'] || options.jazz || options.iflow || options['kilo-code'] || options.kode || options.lingma || options['mcp-jam'] || options.moxby || options.ona || options.qoder || options.reasonix || options['terra-mind'] || options['tiny-cloud'] || options.zencoder || options.zap || options.codeep || options['kimi-code'] || options.zcode
+  const scope = hasScopeFlags ? options : options.yes ? { global: false, project: true } : await askScope()
 
   if (options.frozenLockfile) {
     const { readLock, getProjectLockPath } = await import('../utils/lockfile.js')
@@ -114,6 +114,26 @@ export async function installCommand(source, options) {
   if (scope.firebender) targets.push('firebender')
   if (scope.bob) targets.push('bob')
   if (scope['aider-desk']) targets.push('aider-desk')
+  if (scope['code-arts-doer']) targets.push('code-arts-doer')
+  if (scope['code-maker']) targets.push('code-maker')
+  if (scope['code-studio']) targets.push('code-studio')
+  if (scope.crush) targets.push('crush')
+  if (scope.eve) targets.push('eve')
+  if (scope.forge) targets.push('forge')
+  if (scope['inference-sh']) targets.push('inference-sh')
+  if (scope.jazz) targets.push('jazz')
+  if (scope.iflow) targets.push('iflow')
+  if (scope['kilo-code']) targets.push('kilo-code')
+  if (scope.kode) targets.push('kode')
+  if (scope.lingma) targets.push('lingma')
+  if (scope['mcp-jam']) targets.push('mcp-jam')
+  if (scope.moxby) targets.push('moxby')
+  if (scope.ona) targets.push('ona')
+  if (scope.qoder) targets.push('qoder')
+  if (scope.reasonix) targets.push('reasonix')
+  if (scope['terra-mind']) targets.push('terra-mind')
+  if (scope['tiny-cloud']) targets.push('tiny-cloud')
+  if (scope.zencoder) targets.push('zencoder')
   if (scope.zap) targets.push('zap')
   if (scope.codeep) targets.push('codeep')
   if (scope['kimi-code']) targets.push('kimi-code')

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,7 +1,7 @@
 import { accessSync, readdirSync, constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir } from '../utils/lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -48,6 +48,26 @@ const KNOWN_AGENTS = [
   { flag: 'firebender', label: 'firebender', dir: getFirebenderDir },
   { flag: 'bob', label: 'ibm-bob', dir: getBobDir },
   { flag: 'aider-desk', label: 'aider-desk', dir: getAiderDeskDir },
+  { flag: 'code-arts-doer', label: 'code-arts-doer', dir: getCodeArtsDoerDir },
+  { flag: 'code-maker', label: 'code-maker', dir: getCodeMakerDir },
+  { flag: 'code-studio', label: 'code-studio', dir: getCodeStudioDir },
+  { flag: 'crush', label: 'crush', dir: getCrushDir },
+  { flag: 'eve', label: 'eve', dir: getEveDir },
+  { flag: 'forge', label: 'forge', dir: getForgeDir },
+  { flag: 'inference-sh', label: 'inference-sh', dir: getInferenceShDir },
+  { flag: 'jazz', label: 'jazz', dir: getJazzDir },
+  { flag: 'iflow', label: 'iflow', dir: getIFlowDir },
+  { flag: 'kilo-code', label: 'kilo-code', dir: getKiloCodeDir },
+  { flag: 'kode', label: 'kode', dir: getKodeDir },
+  { flag: 'lingma', label: 'lingma', dir: getLingmaDir },
+  { flag: 'mcp-jam', label: 'mcp-jam', dir: getMcpJamDir },
+  { flag: 'moxby', label: 'moxby', dir: getMoxbyDir },
+  { flag: 'ona', label: 'ona', dir: getOnaDir },
+  { flag: 'qoder', label: 'qoder', dir: getQoderDir },
+  { flag: 'reasonix', label: 'reasonix', dir: getReasonixDir },
+  { flag: 'terra-mind', label: 'terra-mind', dir: getTerraMindDir },
+  { flag: 'tiny-cloud', label: 'tiny-cloud', dir: getTinyCloudDir },
+  { flag: 'zencoder', label: 'zencoder', dir: getZencoderDir },
   { flag: 'zap', label: 'zap', dir: getZapDir },
   { flag: 'codeep', label: 'codeep', dir: getCodeepDir },
   { flag: 'kimi-code', label: 'kimi-code', dir: getKimiCodeDir },
@@ -84,7 +104,8 @@ export async function setupCommand(source, options = {}) {
     console.log('   Install an AI coding agent (opencode, claude-code, cursor,')
     console.log('   windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody,')
     console.log('   continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot,')
-    console.log('   loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo-dev, firebender, ibm-bob, aider-desk) first.')
+    console.log('   loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo-dev, firebender, ibm-bob, aider-desk, code-arts-doer, code-maker, code-studio,')
+    console.log('   crush, eve, forge, inference-sh, jazz, iflow, kilo-code, kode, lingma, mcp-jam, moxby, ona, qoder, reasonix, terra-mind, tiny-cloud, zencoder) first.')
     return
   }
 
@@ -112,7 +133,9 @@ export async function setupCommand(source, options = {}) {
     const targets = agents.map(a => a.flag)
     targets.push('project')
 
-    if (options.dryRun) {
+    if (options.yes) {
+      // skip confirmation, proceed with install
+    } else if (options.dryRun) {
       console.log('📋 Dry-run — no files will be copied:\n')
       console.log(`   Skill:     ${resolved.name} (${resolved.slug})`)
       console.log(`   Source:    ${source}`)

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { readLock, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir } from '../utils/lockfile.js'
+import { readLock, getProjectLockPath, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -148,6 +148,66 @@ function detectTargets(slug, cwd) {
 
   const aiderDeskDir = join(getAiderDeskDir(), normSlug)
   if (existsSync(join(aiderDeskDir, 'SKILL.md'))) targets.push('aider-desk')
+
+  const codeArtsDoerDir = join(getCodeArtsDoerDir(), normSlug)
+  if (existsSync(join(codeArtsDoerDir, 'SKILL.md'))) targets.push('code-arts-doer')
+
+  const codeMakerDir = join(getCodeMakerDir(), normSlug)
+  if (existsSync(join(codeMakerDir, 'SKILL.md'))) targets.push('code-maker')
+
+  const codeStudioDir = join(getCodeStudioDir(), normSlug)
+  if (existsSync(join(codeStudioDir, 'SKILL.md'))) targets.push('code-studio')
+
+  const crushDir = join(getCrushDir(), normSlug)
+  if (existsSync(join(crushDir, 'SKILL.md'))) targets.push('crush')
+
+  const eveDir = join(getEveDir(), normSlug)
+  if (existsSync(join(eveDir, 'SKILL.md'))) targets.push('eve')
+
+  const forgeDir = join(getForgeDir(), normSlug)
+  if (existsSync(join(forgeDir, 'SKILL.md'))) targets.push('forge')
+
+  const inferenceShDir = join(getInferenceShDir(), normSlug)
+  if (existsSync(join(inferenceShDir, 'SKILL.md'))) targets.push('inference-sh')
+
+  const jazzDir = join(getJazzDir(), normSlug)
+  if (existsSync(join(jazzDir, 'SKILL.md'))) targets.push('jazz')
+
+  const iFlowDir = join(getIFlowDir(), normSlug)
+  if (existsSync(join(iFlowDir, 'SKILL.md'))) targets.push('iflow')
+
+  const kiloCodeDir = join(getKiloCodeDir(), normSlug)
+  if (existsSync(join(kiloCodeDir, 'SKILL.md'))) targets.push('kilo-code')
+
+  const kodeDir = join(getKodeDir(), normSlug)
+  if (existsSync(join(kodeDir, 'SKILL.md'))) targets.push('kode')
+
+  const lingmaDir = join(getLingmaDir(), normSlug)
+  if (existsSync(join(lingmaDir, 'SKILL.md'))) targets.push('lingma')
+
+  const mcpJamDir = join(getMcpJamDir(), normSlug)
+  if (existsSync(join(mcpJamDir, 'SKILL.md'))) targets.push('mcp-jam')
+
+  const moxbyDir = join(getMoxbyDir(), normSlug)
+  if (existsSync(join(moxbyDir, 'SKILL.md'))) targets.push('moxby')
+
+  const onaDir = join(getOnaDir(), normSlug)
+  if (existsSync(join(onaDir, 'SKILL.md'))) targets.push('ona')
+
+  const qoderDir = join(getQoderDir(), normSlug)
+  if (existsSync(join(qoderDir, 'SKILL.md'))) targets.push('qoder')
+
+  const reasonixDir = join(getReasonixDir(), normSlug)
+  if (existsSync(join(reasonixDir, 'SKILL.md'))) targets.push('reasonix')
+
+  const terraMindDir = join(getTerraMindDir(), normSlug)
+  if (existsSync(join(terraMindDir, 'SKILL.md'))) targets.push('terra-mind')
+
+  const tinyCloudDir = join(getTinyCloudDir(), normSlug)
+  if (existsSync(join(tinyCloudDir, 'SKILL.md'))) targets.push('tiny-cloud')
+
+  const zencoderDir = join(getZencoderDir(), normSlug)
+  if (existsSync(join(zencoderDir, 'SKILL.md'))) targets.push('zencoder')
 
   const projectDir = join(cwd, '.agents', 'skills', normSlug)
   if (existsSync(join(projectDir, 'SKILL.md'))) targets.push('project')

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,6 +1,6 @@
 import { mkdir, cp, writeFile, stat, symlink, rm } from 'node:fs/promises'
 import { join, relative, dirname } from 'node:path'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir, addSkillToLock, getGlobalLockPath, getProjectLockPath, computeFileHashes } from './lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir, addSkillToLock, getGlobalLockPath, getProjectLockPath, computeFileHashes } from './lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -49,6 +49,26 @@ const targetToAgentName = {
   firebender: 'firebender',
   bob: 'ibm-bob',
   'aider-desk': 'aider-desk',
+  'code-arts-doer': 'code-arts-doer',
+  'code-maker': 'code-maker',
+  'code-studio': 'code-studio',
+  crush: 'crush',
+  eve: 'eve',
+  forge: 'forge',
+  'inference-sh': 'inference-sh',
+  jazz: 'jazz',
+  iflow: 'iflow',
+  'kilo-code': 'kilo-code',
+  kode: 'kode',
+  lingma: 'lingma',
+  'mcp-jam': 'mcp-jam',
+  moxby: 'moxby',
+  ona: 'ona',
+  qoder: 'qoder',
+  reasonix: 'reasonix',
+  'terra-mind': 'terra-mind',
+  'tiny-cloud': 'tiny-cloud',
+  zencoder: 'zencoder',
   zap: 'zap',
   codeep: 'codeep',
   'kimi-code': 'kimi-code',
@@ -274,6 +294,106 @@ export async function installSkill(resolved, targets, mode = 'copy') {
       case 'aider-desk': {
         baseDir = getAiderDeskDir()
         label = '~/.aider-desk/skills/'
+        break
+      }
+      case 'code-arts-doer': {
+        baseDir = getCodeArtsDoerDir()
+        label = '~/.codeartsdoer/skills/'
+        break
+      }
+      case 'code-maker': {
+        baseDir = getCodeMakerDir()
+        label = '~/.codemaker/skills/'
+        break
+      }
+      case 'code-studio': {
+        baseDir = getCodeStudioDir()
+        label = '~/.codestudio/skills/'
+        break
+      }
+      case 'crush': {
+        baseDir = getCrushDir()
+        label = '~/.crush/skills/'
+        break
+      }
+      case 'eve': {
+        baseDir = getEveDir()
+        label = './agent/skills/'
+        break
+      }
+      case 'forge': {
+        baseDir = getForgeDir()
+        label = '~/.forge/skills/'
+        break
+      }
+      case 'inference-sh': {
+        baseDir = getInferenceShDir()
+        label = '~/.inferencesh/skills/'
+        break
+      }
+      case 'jazz': {
+        baseDir = getJazzDir()
+        label = '~/.jazz/skills/'
+        break
+      }
+      case 'iflow': {
+        baseDir = getIFlowDir()
+        label = '~/.iflow/skills/'
+        break
+      }
+      case 'kilo-code': {
+        baseDir = getKiloCodeDir()
+        label = '~/.kilocode/skills/'
+        break
+      }
+      case 'kode': {
+        baseDir = getKodeDir()
+        label = '~/.kode/skills/'
+        break
+      }
+      case 'lingma': {
+        baseDir = getLingmaDir()
+        label = '~/.lingma/skills/'
+        break
+      }
+      case 'mcp-jam': {
+        baseDir = getMcpJamDir()
+        label = '~/.mcpjam/skills/'
+        break
+      }
+      case 'moxby': {
+        baseDir = getMoxbyDir()
+        label = '~/.moxby/skills/'
+        break
+      }
+      case 'ona': {
+        baseDir = getOnaDir()
+        label = '~/.ona/skills/'
+        break
+      }
+      case 'qoder': {
+        baseDir = getQoderDir()
+        label = '~/.qoder/skills/'
+        break
+      }
+      case 'reasonix': {
+        baseDir = getReasonixDir()
+        label = '~/.reasonix/skills/'
+        break
+      }
+      case 'terra-mind': {
+        baseDir = getTerraMindDir()
+        label = '~/.terramind/skills/'
+        break
+      }
+      case 'tiny-cloud': {
+        baseDir = getTinyCloudDir()
+        label = '~/.tinycloud/skills/'
+        break
+      }
+      case 'zencoder': {
+        baseDir = getZencoderDir()
+        label = '~/.zencoder/skills/'
         break
       }
       case 'zap': {

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -198,6 +198,86 @@ export function getZCodeDir() {
   return home('.zcode', 'skills')
 }
 
+export function getCodeArtsDoerDir() {
+  return home('.codeartsdoer', 'skills')
+}
+
+export function getCodeMakerDir() {
+  return home('.codemaker', 'skills')
+}
+
+export function getCodeStudioDir() {
+  return home('.codestudio', 'skills')
+}
+
+export function getCrushDir() {
+  return home('.crush', 'skills')
+}
+
+export function getEveDir() {
+  return join(process.cwd(), 'agent', 'skills')
+}
+
+export function getForgeDir() {
+  return home('.forge', 'skills')
+}
+
+export function getInferenceShDir() {
+  return home('.inferencesh', 'skills')
+}
+
+export function getJazzDir() {
+  return home('.jazz', 'skills')
+}
+
+export function getIFlowDir() {
+  return home('.iflow', 'skills')
+}
+
+export function getKiloCodeDir() {
+  return home('.kilocode', 'skills')
+}
+
+export function getKodeDir() {
+  return home('.kode', 'skills')
+}
+
+export function getLingmaDir() {
+  return home('.lingma', 'skills')
+}
+
+export function getMcpJamDir() {
+  return home('.mcpjam', 'skills')
+}
+
+export function getMoxbyDir() {
+  return home('.moxby', 'skills')
+}
+
+export function getOnaDir() {
+  return home('.ona', 'skills')
+}
+
+export function getQoderDir() {
+  return home('.qoder', 'skills')
+}
+
+export function getReasonixDir() {
+  return home('.reasonix', 'skills')
+}
+
+export function getTerraMindDir() {
+  return home('.terramind', 'skills')
+}
+
+export function getTinyCloudDir() {
+  return home('.tinycloud', 'skills')
+}
+
+export function getZencoderDir() {
+  return home('.zencoder', 'skills')
+}
+
 export function getProjectLockPath(cwd) {
   return join(cwd, '.agents', '.skill-lock.json')
 }

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -208,15 +208,6 @@ function normalizeGitUrl(source) {
   return source
 }
 
-function validateUrl(url) {
-  if (/[;&`$|<>]/.test(url)) {
-    throw new Error('Invalid characters in repository URL')
-  }
-  if (!/^[\w.:\/@%~_-]+$/.test(url)) {
-    throw new Error('Invalid repository URL format')
-  }
-}
-
 async function resolveGitUrl(source) {
   const tmpDir = join(tmpdir(), `rolecraft-${randomUUID().slice(0, 8)}`)
   const url = normalizeGitUrl(source)

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -1,7 +1,7 @@
 import { readFile, readdir, stat } from 'node:fs/promises'
 import { join, dirname, basename } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
-import { execSync as defaultExecSync } from 'node:child_process'
+import { execSync as defaultExecSync, spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { readdirSync, readFileSync } from 'node:fs'
 import { computeContentHash } from './lockfile.js'
@@ -10,6 +10,21 @@ let runExec = defaultExecSync
 
 export function setExecSync(fn) {
   runExec = fn
+}
+
+function runGit(args, opts = {}) {
+  const result = spawnSync('git', args, { stdio: 'pipe', timeout: 30000, ...opts })
+  if (result.error) throw result.error
+  if (result.status !== 0) {
+    const msg = result.stderr?.toString() || result.stdout?.toString() || `git exited with code ${result.status}`
+    throw new Error(msg)
+  }
+  return result
+}
+
+function removeDir(dir) {
+  const result = spawnSync('rm', ['-rf', dir], { stdio: 'pipe' })
+  if (result.error) throw result.error
 }
 
 function isGitHubRef(source) {
@@ -197,7 +212,7 @@ function validateUrl(url) {
   if (/[;&`$|<>]/.test(url)) {
     throw new Error('Invalid characters in repository URL')
   }
-  if (!/^[\w.:/@%._~-]+$/.test(url)) {
+  if (!/^[\w.:\/@%~_-]+$/.test(url)) {
     throw new Error('Invalid repository URL format')
   }
 }
@@ -205,10 +220,9 @@ function validateUrl(url) {
 async function resolveGitUrl(source) {
   const tmpDir = join(tmpdir(), `rolecraft-${randomUUID().slice(0, 8)}`)
   const url = normalizeGitUrl(source)
-  validateUrl(url)
 
   try {
-    runExec(`git clone --depth 1 "${url}" "${tmpDir}"`, { stdio: 'pipe', timeout: 30000 })
+    runGit(['clone', '--depth', '1', url, tmpDir])
   } catch {
     throw new Error(`Failed to clone repository from ${source}`)
   }
@@ -216,7 +230,7 @@ async function resolveGitUrl(source) {
   const found = scanForSkill(tmpDir)
 
   if (found.length === 0) {
-    runExec(`rm -rf "${tmpDir}"`)
+    removeDir(tmpDir)
     throw new Error(`No SKILL.md found in repository ${source}`)
   }
 
@@ -230,7 +244,7 @@ async function resolveGitUrl(source) {
     try { fileContents[f] = readFileSync(join(skill.dir, f), 'utf-8') } catch {}
   }
 
-  runExec(`rm -rf "${tmpDir}"`)
+  removeDir(tmpDir)
 
   return {
     ...skill,

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -180,25 +180,32 @@ async function resolveGitHub(source) {
 }
 
 function isGitUrl(source) {
-  return /^https?:\/\/(gitlab|bitbucket)\.com\//.test(source)
-    || /^git@[\w.-]+:/.test(source)
-    || /^ssh:\/\//.test(source)
-    || /^https?:\/\/[\w.-]+\/[\w.-]+\/[\w.-]+\.git$/.test(source)
+  if (/^https?:\/\/(gitlab|bitbucket)\.com\//.test(source)) return true
+  if (/^git@[\w.-]+:[\w.-]+\/[\w.-]+(\.git)?$/.test(source)) return true
+  if (/^https?:\/\/[\w.-]+\/[\w.-]+\/[\w.-]+(\.git)?$/.test(source)) return true
+  return false
 }
 
 function normalizeGitUrl(source) {
   if (/^git@/.test(source)) {
     return source.replace(/^git@([^:]+):/, 'https://$1/')
   }
-  if (/^ssh:\/\//.test(source)) {
-    return source.replace(/^ssh:\/\/([^@]+@)?/, 'https://')
-  }
   return source
+}
+
+function validateUrl(url) {
+  if (/[;&`$|<>]/.test(url)) {
+    throw new Error('Invalid characters in repository URL')
+  }
+  if (!/^[\w.:/@%._~-]+$/.test(url)) {
+    throw new Error('Invalid repository URL format')
+  }
 }
 
 async function resolveGitUrl(source) {
   const tmpDir = join(tmpdir(), `rolecraft-${randomUUID().slice(0, 8)}`)
   const url = normalizeGitUrl(source)
+  validateUrl(url)
 
   try {
     runExec(`git clone --depth 1 "${url}" "${tmpDir}"`, { stdio: 'pipe', timeout: 30000 })

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -179,6 +179,64 @@ async function resolveGitHub(source) {
   }
 }
 
+function isGitUrl(source) {
+  return /^https?:\/\/(gitlab|bitbucket)\.com\//.test(source)
+    || /^git@[\w.-]+:/.test(source)
+    || /^ssh:\/\//.test(source)
+    || /^https?:\/\/[\w.-]+\/[\w.-]+\/[\w.-]+\.git$/.test(source)
+}
+
+function normalizeGitUrl(source) {
+  if (/^git@/.test(source)) {
+    return source.replace(/^git@([^:]+):/, 'https://$1/')
+  }
+  if (/^ssh:\/\//.test(source)) {
+    return source.replace(/^ssh:\/\/([^@]+@)?/, 'https://')
+  }
+  return source
+}
+
+async function resolveGitUrl(source) {
+  const tmpDir = join(tmpdir(), `rolecraft-${randomUUID().slice(0, 8)}`)
+  const url = normalizeGitUrl(source)
+
+  try {
+    runExec(`git clone --depth 1 "${url}" "${tmpDir}"`, { stdio: 'pipe', timeout: 30000 })
+  } catch {
+    throw new Error(`Failed to clone repository from ${source}`)
+  }
+
+  const found = scanForSkill(tmpDir)
+
+  if (found.length === 0) {
+    runExec(`rm -rf "${tmpDir}"`)
+    throw new Error(`No SKILL.md found in repository ${source}`)
+  }
+
+  const skill = found[0]
+  const files = readdirSync(skill.dir, { withFileTypes: true })
+    .filter(e => e.name !== '.git')
+    .map(e => e.name)
+
+  const fileContents = {}
+  for (const f of files) {
+    try { fileContents[f] = readFileSync(join(skill.dir, f), 'utf-8') } catch {}
+  }
+
+  runExec(`rm -rf "${tmpDir}"`)
+
+  return {
+    ...skill,
+    owner: skill.owner === 'local' ? 'remote' : skill.owner,
+    slug: skill.slug === 'unknown' || skill.slug === skill.name ? `remote/${skill.name}` : skill.slug,
+    files,
+    fileContents,
+    contentSha: computeContentHash(fileContents),
+    sourcePath: source,
+    sourceType: 'git',
+  }
+}
+
 export async function resolveSource(source) {
   if (isGitHubRef(source)) {
     return await resolveGitHub(source)
@@ -186,5 +244,8 @@ export async function resolveSource(source) {
   if (isLocalPath(source)) {
     return await resolveLocal(source)
   }
-  throw new Error(`Invalid source: "${source}". Use a local path (./, /, ~) or GitHub ref (owner/repo)`)
+  if (isGitUrl(source)) {
+    return await resolveGitUrl(source)
+  }
+  throw new Error(`Invalid source: "${source}". Use a local path (./, /, ~), GitHub ref (owner/repo), or git URL`)
 }


### PR DESCRIPTION
## New Features

- **`--yes` / `-y` flag** — non-interactive mode for install/setup (skips prompts, uses defaults)
- **`rolecraft check` command** — check installed skills for available updates
- **GitLab / SSH git URL support** — install from any git remote with `SKILL.md`
- **20 new agent targets** — 46 → 66 agents total

## New Agents

`code-arts-doer`, `code-maker`, `code-studio`, `crush`, `eve`, `forge`, `inference-sh`, `jazz`, `iflow`, `kilo-code`, `kode`, `lingma`, `mcp-jam`, `moxby`, `ona`, `qoder`, `reasonix`, `terra-mind`, `tiny-cloud`, `zencoder`

## Documentation

- README features, commands table, quick start updated
- Comparison tables corrected for all new features
- `docs/install.md` — added GitLab/SSH URL examples, `--yes` flag docs
- `docs/agents.md` — added all 20 new agents
- `docs/ANALYSIS.md` — roadmap and gaps updated