### PR TITLE
feat: add SKILL.md for skills.sh leaderboard visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 <p align="center">
   <a href="https://awesome.re"><img src="https://awesome.re/badge.svg" alt="Awesome"></a>
+  <a href="https://skills.sh/sametcelikbicak/rolecraft"><img src="https://skills.sh/b/sametcelikbicak/rolecraft" alt="skills.sh"></a>
   <a href="https://www.npmjs.com/package/rolecraft"><img src="https://img.shields.io/npm/v/rolecraft" alt="npm"></a>
   <a href="https://www.npmjs.com/package/rolecraft"><img src="https://img.shields.io/npm/dm/rolecraft" alt="npm downloads"></a>
   <a href="https://github.com/sametcelikbicak/rolecraft/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/sametcelikbicak/rolecraft/test.yml?label=tests" alt="Tests"></a>
@@ -62,6 +63,9 @@ rolecraft install https://gitlab.com/org/project  # GitLab repo
 rolecraft install git@github.com:user/repo.git    # SSH URL
 rolecraft install ./my-skill --cursor             # specific agent only
 
+# or install the rolecraft skill (teaches AI agents to use rolecraft)
+npx skills add sametcelikbicak/rolecraft
+
 # manage
 rolecraft list
 rolecraft search code-review
@@ -77,7 +81,8 @@ rolecraft remove my-skill
 
 - **Zero dependencies** — ~4 KB, no bloat
 - **Any source** — local folder, GitHub/GitLab/Bitbucket repo, SSH git URL
-- **65+ agents** — opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more
+- **66+ agents** — opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more
+- **skills.sh compatible** — installable via `npx skills add sametcelikbicak/rolecraft`
 - **No registry required** — no signup, no marketplace, no vendor lock-in
 - **Non-interactive mode** — `--yes` / `-y` flag for automation/CI pipelines
 - **Update checking** — `rolecraft check` to see which skills have updates
@@ -122,7 +127,8 @@ rolecraft remove my-skill
 | Local path install                       | ✅ **1st class** | ✅               | ❌ marketplace only |
 | GitHub repo install                      | ✅              | ✅               | ❌                 |
 | GitLab / SSH git URL                     | ✅              | ✅               | ❌                 |
-| Agent targets                            | **66**          | 55+              | 15+                |
+| Agent targets                            | **66**          | 72               | 15+                |
+| Skills.sh listed                         | ✅             | ✅               | ⚠️ (registry only) |
 | Bundle install + create                  | ✅              | ❌               | ✅ (skillset only) |
 | Interactive TUI search + install         | ✅              | ✅               | ❌                 |
 | Non-interactive flag (`--yes`/`-y`)      | ✅              | ✅               | ❌                 |
@@ -159,6 +165,7 @@ rolecraft install ./my-skill --cursor --devin --copilot --gemini --cody
 3. Computes a SHA256 content hash and stores it in the lockfile
 4. Updates `~/.agents/.skill-lock.json` so agents can discover the skill
 5. Compatible with skills installed by `@agentskill.sh/cli`, `add-skill`, or manual installs
+6. Installable as a skill itself via `npx skills add sametcelikbicak/rolecraft`
 
 [→ Full architecture & project structure](docs/architecture.md)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: rolecraft
+description: >-
+  Install AI agent skills as roles & behaviors from any source — local folder,
+  GitHub, GitLab, SSH git URL. Zero-dependency CLI with 66+ agent targets.
+---
+
+# rolecraft
+
+Install and manage AI agent skills across 66+ agents with a single command. Zero dependencies. No registry required.
+
+## When to use
+
+- **Install skills** — from local folders, GitHub repos, GitLab projects, or SSH git URLs
+- **Manage skills** — list, update, remove, and verify installed skills
+- **CI/CD pipelines** — lockfile-based re-install with `rolecraft ci`
+- **Team onboarding** — bundle install with a single command
+- **Cross-agent setup** — install the same skill to multiple agents at once
+
+## Quick start
+
+```bash
+# Try without installing
+npx rolecraft --help
+
+# Create a skill
+npx rolecraft init my-skill
+
+# Install from any source
+npx rolecraft install ./my-skill
+npx rolecraft install user/repo
+npx rolecraft install https://gitlab.com/org/project
+npx rolecraft install git@github.com:user/repo.git
+
+# Install to specific agents
+npx rolecraft install user/repo --cursor --devin
+
+# Check for updates
+npx rolecraft check
+
+# List installed skills
+npx rolecraft list
+```
+
+## Install commands
+
+| Command | Purpose |
+|---------|---------|
+| `rolecraft install <source>` | Install a skill (local, GitHub, GitLab, SSH) |
+| `rolecraft init [name]` | Scaffold a new `SKILL.md` |
+| `rolecraft list` | Show installed skills |
+| `rolecraft check` | Check for available updates |
+| `rolecraft remove <slug>` | Uninstall a skill |
+| `rolecraft update <slug>` | Re-install to latest version |
+| `rolecraft bundle <sources>` | Install multiple skills from file or inline |
+| `rolecraft ci` | Re-install from lockfile (CI mode) |
+| `rolecraft verify` | Check skill integrity via content hash |
+| `rolecraft search <query>` | Search skills on GitHub |
+| `rolecraft use <source>` | Preview without installing |
+| `rolecraft completions bash\|zsh\|fish` | Generate shell completions |
+
+## Common flags
+
+| Flag | Purpose |
+|------|---------|
+| `--cursor`, `--devin`, `--claude`, `--codex` | Target specific agents |
+| `--all` | Install to every supported agent |
+| `--yes` / `-y` | Non-interactive mode (CI/CD) |
+| `--dry-run` | Preview without making changes |
+| `--symlink` | Symlink instead of copy |
+| `--global` / `--project` | Scope selection |
+
+## Supported agents (66+)
+
+`opencode`, `claude-code`, `cursor`, `windsurf`, `devin`, `codex`, `copilot`, `aider`, `cline`, `gemini-cli`, `cody`, `continue`, `warp`, `codeium`, `fabric`, `goose`, `tabnine`, `supermaven`, `pr-pilot`, `loom`, `roo`, `trae`, `hermes`, `kiro`, `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, `cortex`, `mistral-vibe`, `qwen-code`, `openclaw`, `codebuddy`, `mux`, `pi`, `autohand-code`, `rovo`, `firebender`, `bob`, `aider-desk`, and 25+ more.
+
+## Examples
+
+### Install from GitHub
+```
+rolecraft install vercel-labs/agent-skills --skill frontend-design
+```
+
+### Install to multiple agents
+```
+rolecraft install ./my-team-rules --cursor --devin --copilot --all
+```
+
+### CI pipeline install
+```
+rolecraft ci --yes
+```
+
+### Create and install your own skill
+```
+rolecraft init my-skill
+rolecraft install ./my-skill --all
+```
+
+## Links
+
+- GitHub: https://github.com/sametcelikbicak/rolecraft
+- npm: https://www.npmjs.com/package/rolecraft
+- Docs: https://github.com/sametcelikbicak/rolecraft#readme

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -33,6 +33,7 @@
 | **`upgrade` (self-update)**  | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
 | **TUI search**               | ⚠️ (styled)    | ✅ (`skills find` interactive)         | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
 | **Stars**                    | 36             | 24,613                                 | 23                       | 10,525         | 480                | ~1                | 13K+            | 135K+                      |
+| **skills.sh listed**         | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
 
 ## Strengths
 
@@ -62,7 +63,12 @@
 4. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
 5. **Stars / community adoption very low (~5)** — building trust and visibility
 
-### ✅ Resolved Gaps
+### ✅ Resolved Gaps (Phase 2)
+
+- **SKILL.md created** — `npx skills add sametcelikbicak/rolecraft` works; rolecraft listed on skills.sh leaderboard
+- **skills.sh badge** — README now shows install count badge from skills.sh
+
+### ✅ Resolved Gaps (Phase 1)
 
 - **Copilot agent path** — now uses `.github/copilot/skills/` (project scope)
 - **Self-upgrade** — `rolecraft upgrade` command added
@@ -73,12 +79,21 @@
 
 ## Roadmap
 
+### ✅ Done
+
+- [x] **SKILL.md published** — `npx skills add sametcelikbicak/rolecraft` live on skills.sh
+- [x] **skills.sh badge** — install count visible in README
+
+### ❌ Next
+
 - [ ] `rolecraft doctor` — system health check
 - [ ] npm package source support (`npx rolecraft install some-package`)
+- [ ] **PR to vercel-labs/skills** — add rolecraft as recognized agent in `src/agents.ts`
 - [ ] AGENTS.md XML injection for non-Claude agents
 - [ ] Skill bundle / skillset hub
 - [ ] Security scoring for installed skills
 - [ ] Watch mode — auto-sync skills on file change
+- [ ] **skills.sh telemetry** — optional reporting when `rolecraft install` runs
 
 ## Competitor Analysis
 

--- a/docs/commands/check.md
+++ b/docs/commands/check.md
@@ -1,0 +1,19 @@
+# `rolecraft check`
+
+Check installed skills for available updates.
+
+## Usage
+
+```bash
+rolecraft check
+```
+
+## Description
+
+Reads the lockfile and compares each skill's stored content hash against the current source. Skills whose content hash differs from the lockfile are flagged as having updates available. Works with both global and project-scoped skills.
+
+## Example
+
+```bash
+rolecraft check
+```

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "skill-installer",
     "skill-manager",
     "agent-skills",
+    "skills-sh",
+    "skills.sh",
     "mcp",
     "gemini-cli",
     "codex",


### PR DESCRIPTION
## Summary

Adds `SKILL.md` to make rolecraft installable via `npx skills add sametcelikbicak/rolecraft`, putting it on the skills.sh leaderboard.

## Changes

- **SKILL.md** (new) — teaches AI agents how to use rolecraft; enables skills.sh discovery
- **README.md** — added skills.sh install count badge, updated quick start with `npx skills add`
- **docs/ANALYSIS.md** — updated roadmap with skills.sh integration status
- **package.json** — added `skills-sh`, `skills.sh` keywords

## Testing

- `npx skills add` successfully discovers and installs rolecraft as a skill
- All 232 tests pass