### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.2.0] - 2026-07-06
+
+### Added
+- add SKILL.md for skills.sh leaderboard visibility (#50)
+- add --yes flag, check command, GitLab/SSH URL support, and 20 new agents
+
+### Fixed
+- remaining 5 code scanning alerts (unused vars, file-system-race)
+- resolve remaining CodeQL alerts
+- allow workflow_dispatch in publish job condition
+- add workflow_dispatch to release-publish workflow (#43)
+
+### Changed
+- improve coverage to 95% - add missing tests, fix coverage config (#46)
+- upgrade Node to 24, migrate CodeQL to v4, fix code scanning alerts
+- update changelog and version for v1.1.0 [skip ci] (#42)
+
+### Documentation
+- add startup checklist to AGENTS.md (#51)
+- update AGENTS.md workflow instructions
+- add AGENTS.md with development guidelines
 ## [v1.1.0] - 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolecraft",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Install AI agent skills as roles & behaviors directly from any source — zero-dependency CLI for opencode, claude-code, cursor, and more",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This PR updates the changelog and version for `v1.2.0`.

## Changes
- Updated CHANGELOG.md with changes since the previous tag
- Updated package.json version to `v1.2.0`

> Auto-generated by the release-prep workflow.
