### PR TITLE
feat: add npm package source support (npm:package)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ rolecraft install ./my-skill                      # local folder
 rolecraft install user/repo                       # GitHub repo
 rolecraft install https://gitlab.com/org/project  # GitLab repo
 rolecraft install git@github.com:user/repo.git    # SSH URL
+rolecraft install npm:some-package                # npm package
+rolecraft install npm:@scope/package@1.0.0        # npm with version
 rolecraft install ./my-skill --cursor             # specific agent only
 
 # or install the rolecraft skill (teaches AI agents to use rolecraft)
@@ -80,7 +82,7 @@ rolecraft remove my-skill
 ## Features
 
 - **Zero dependencies** — ~4 KB, no bloat
-- **Any source** — local folder, GitHub/GitLab/Bitbucket repo, SSH git URL
+- **Any source** — local folder, GitHub/GitLab/Bitbucket repo, SSH git URL, npm package
 - **66+ agents** — opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more
 - **skills.sh compatible** — installable via `npx skills add sametcelikbicak/rolecraft`
 - **No registry required** — no signup, no marketplace, no vendor lock-in
@@ -96,24 +98,24 @@ rolecraft remove my-skill
 
 ## Commands overview
 
-| Command                      | Description                                         | Details                          |
-| ---------------------------- | --------------------------------------------------- | -------------------------------- |
-| `rolecraft init [<name>]`    | Scaffold a new `SKILL.md`                           | [docs](docs/commands/init.md)    |
-| `rolecraft install <source>` | Install a skill (local path, GitHub/GitLab/SSH URL)    | [docs](docs/commands/install.md) |
-| `rolecraft bundle <sources>` | Install multiple skills from inline sources or file | [docs](docs/commands/bundle.md)  |
-| `rolecraft bundle create`    | Create a new bundle file                            | [docs](docs/commands/bundle.md)  |
-| `rolecraft search <query>`   | Search for skills on GitHub (TUI with `--interactive`) | [docs](docs/commands/search.md)  |
-| `rolecraft check`            | Check installed skills for available updates            | [docs](docs/commands/check.md)  |
-| `rolecraft use <source>`     | Preview a skill's files without installing          | [docs](docs/commands/use.md)     |
-| `rolecraft completions bash\|zsh\|fish` | Generate shell completion scripts           | [docs](docs/commands/completions.md) |
-| `rolecraft setup [<source>]` | Detect agents, optionally install a skill to all    | [docs](docs/commands/setup.md)   |
-| `rolecraft list`             | Show all installed skills                           | [docs](docs/commands/list.md)    |
-| `rolecraft verify`           | Check installed skill integrity via content hash    | [docs](docs/commands/verify.md)  |
-| `rolecraft ci`               | Re-install all skills from lockfile (CI mode)       | [docs](docs/commands/ci.md)      |
-| `rolecraft upgrade`          | Upgrade rolecraft to the latest version              | [docs](docs/commands/upgrade.md) |
-| `rolecraft remove <slug>`    | Uninstall a skill                                   | [docs](docs/commands/remove.md)  |
-| `rolecraft update <slug>`    | Re-install a skill to latest                        | [docs](docs/commands/update.md)  |
-| `rolecraft --version`        | Show version                                        |                                  |
+| Command                                 | Description                                              | Details                              |
+| --------------------------------------- | -------------------------------------------------------- | ------------------------------------ |
+| `rolecraft init [<name>]`               | Scaffold a new `SKILL.md`                                | [docs](docs/commands/init.md)        |
+| `rolecraft install <source>`            | Install a skill (local path, GitHub/GitLab/SSH URL, npm) | [docs](docs/commands/install.md)     |
+| `rolecraft bundle <sources>`            | Install multiple skills from inline sources or file      | [docs](docs/commands/bundle.md)      |
+| `rolecraft bundle create`               | Create a new bundle file                                 | [docs](docs/commands/bundle.md)      |
+| `rolecraft search <query>`              | Search for skills on GitHub (TUI with `--interactive`)   | [docs](docs/commands/search.md)      |
+| `rolecraft check`                       | Check installed skills for available updates             | [docs](docs/commands/check.md)       |
+| `rolecraft use <source>`                | Preview a skill's files without installing               | [docs](docs/commands/use.md)         |
+| `rolecraft completions bash\|zsh\|fish` | Generate shell completion scripts                        | [docs](docs/commands/completions.md) |
+| `rolecraft setup [<source>]`            | Detect agents, optionally install a skill to all         | [docs](docs/commands/setup.md)       |
+| `rolecraft list`                        | Show all installed skills                                | [docs](docs/commands/list.md)        |
+| `rolecraft verify`                      | Check installed skill integrity via content hash         | [docs](docs/commands/verify.md)      |
+| `rolecraft ci`                          | Re-install all skills from lockfile (CI mode)            | [docs](docs/commands/ci.md)          |
+| `rolecraft upgrade`                     | Upgrade rolecraft to the latest version                  | [docs](docs/commands/upgrade.md)     |
+| `rolecraft remove <slug>`               | Uninstall a skill                                        | [docs](docs/commands/remove.md)      |
+| `rolecraft update <slug>`               | Re-install a skill to latest                             | [docs](docs/commands/update.md)      |
+| `rolecraft --version`                   | Show version                                             |                                      |
 
 ---
 
@@ -121,25 +123,26 @@ rolecraft remove my-skill
 
 [→ Full feature comparison](docs/comparison.md)
 
-| Feature                                  | rolecraft       | skills (Vercel)  | @agentskill.sh/cli |
-| ---------------------------------------- | --------------- | ---------------- | ------------------ |
-| Zero dependencies                        | ✅              | ✅ (1 dep)       | ❌ (2)             |
-| Local path install                       | ✅ **1st class** | ✅               | ❌ marketplace only |
-| GitHub repo install                      | ✅              | ✅               | ❌                 |
-| GitLab / SSH git URL                     | ✅              | ✅               | ❌                 |
-| Agent targets                            | **66**          | 72               | 15+                |
-| Skills.sh listed                         | ✅             | ✅               | ⚠️ (registry only) |
-| Bundle install + create                  | ✅              | ❌               | ✅ (skillset only) |
-| Interactive TUI search + install         | ✅              | ✅               | ❌                 |
-| Non-interactive flag (`--yes`/`-y`)      | ✅              | ✅               | ❌                 |
-| Skill update check (`check`)             | ✅              | ❌               | ❌                 |
-| Shell completions (bash/zsh/fish)        | ✅              | ❌               | ❌                 |
-| Dry-run preview (`--dry-run`)            | ✅              | ❌               | ❌                 |
-| Interactive scope prompt                 | ✅              | ✅               | ❌                 |
-| Content hash verification (`verify`)     | ✅              | ✅               | ❌                 |
-| CI-mode re-install (`ci`)                | ✅              | ✅               | ❌                 |
-| Self-upgrade command                     | ✅              | ❌               | ❌                 |
-| File size                                | ~4 KB           | ~465 KB          | ~84 KB             |
+| Feature                              | rolecraft        | skills (Vercel) | @agentskill.sh/cli  |
+| ------------------------------------ | ---------------- | --------------- | ------------------- |
+| Zero dependencies                    | ✅               | ✅ (1 dep)      | ❌ (2)              |
+| Local path install                   | ✅ **1st class** | ✅              | ❌ marketplace only |
+| GitHub repo install                  | ✅               | ✅              | ❌                  |
+| GitLab / SSH git URL                 | ✅               | ✅              | ❌                  |
+| npm package source                   | ✅               | ✅              | ❌                  |
+| Agent targets                        | **66**           | 72              | 15+                 |
+| Skills.sh listed                     | ✅               | ✅              | ⚠️ (registry only)  |
+| Bundle install + create              | ✅               | ❌              | ✅ (skillset only)  |
+| Interactive TUI search + install     | ✅               | ✅              | ❌                  |
+| Non-interactive flag (`--yes`/`-y`)  | ✅               | ✅              | ❌                  |
+| Skill update check (`check`)         | ✅               | ❌              | ❌                  |
+| Shell completions (bash/zsh/fish)    | ✅               | ❌              | ❌                  |
+| Dry-run preview (`--dry-run`)        | ✅               | ❌              | ❌                  |
+| Interactive scope prompt             | ✅               | ✅              | ❌                  |
+| Content hash verification (`verify`) | ✅               | ✅              | ❌                  |
+| CI-mode re-install (`ci`)            | ✅               | ✅              | ❌                  |
+| Self-upgrade command                 | ✅               | ❌              | ❌                  |
+| File size                            | ~4 KB            | ~465 KB         | ~84 KB              |
 
 [See full table →](docs/comparison.md)
 

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -29,7 +29,7 @@ Zero dependencies, no marketplace required.
 Works with 65+ agents: opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo, firebender, bob, aider-desk, code-arts-doer, code-maker, code-studio, crush, eve, forge, inference-sh, jazz, iflow, kilo-code, kode, lingma, mcp-jam, moxby, ona, qoder, reasonix, terra-mind, tiny-cloud, zencoder, and all spec-compliant agents.
 
 Usage:
-  rolecraft install <source>     Install a skill (local path or owner/repo)
+  rolecraft install <source>     Install a skill (local path, owner/repo, or npm:package)
   rolecraft bundle <source> [...] Install skills from a file or inline sources
   rolecraft bundle create [<name>]  Create a new bundle file
   rolecraft use <source>         Preview a skill without installing
@@ -107,6 +107,8 @@ Options for install:
 Examples:
   rolecraft install ./my-skill
   rolecraft install sametcelikbicak/task-decomposer
+  rolecraft install npm:lodash
+  rolecraft install npm:@scope/package@1.0.0
   rolecraft install ./skills/my-skill --claude --cursor
   rolecraft bundle ./team-skills.json
   rolecraft bundle owner/skill1 owner/skill2 ./local-skill
@@ -128,7 +130,7 @@ export async function main() {
       const source = args[0]
       if (!source) {
         console.error('Usage: rolecraft install <source>')
-        console.error('Source can be a local path (./, /, ~) or a GitHub ref (owner/repo)')
+        console.error('Source can be a local path (./, /, ~), GitHub ref (owner/repo), or npm package (npm:package)')
         process.exit(1)
       }
 
@@ -243,7 +245,7 @@ export async function main() {
       const source = args[0]
       if (!source) {
         console.error('Usage: rolecraft use <source>')
-        console.error('Source can be a local path (./, /, ~) or a GitHub ref (owner/repo)')
+        console.error('Source can be a local path (./, /, ~), GitHub ref (owner/repo), or npm package (npm:package)')
         process.exit(1)
       }
       await useCommand(source)

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -2,38 +2,38 @@
 
 ## rolecraft vs Competitors
 
-| Feature                      | rolecraft      | skills (Vercel)                        | @agentskill.sh/cli (ags) | openskills     | skills-npm (antfu) | qntx/skill (Rust) | OpenCode native | Claude Code                |
-| ---------------------------- | -------------- | -------------------------------------- | ------------------------ | -------------- | ------------------ | ----------------- | --------------- | -------------------------- |
-| **Runtime deps**             | **0**          | 1 (`yaml`)                             | 2                        | 4              | 4                  | **0** (static)    | 0 (built-in)    | 0 (built-in)               |
-| **Package size**             | ~4 KB          | 465 KB                                 | 84 KB                    | 51 KB          | 36 KB              | ~8 MB binary      | N/A             | N/A                        |
-| **Source files**             | 15             | 14                                     | 37                       | —              | —                  | —                 | N/A             | N/A                        |
-| **Source types**             | Local + GitHub | GitHub/GitLab/git URL/Local/npm        | Registry only            | GitHub + Local | npm packages only  | GitHub/Git/Local  | Filesystem only | Filesystem + MCP + plugins |
-| **GitLab/SSH git URL**       | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
-| **Lockfile**                 | agentskill v3  | Two-tier (global v3 + project v1, SHA) | None                     | None           | None               | ✅                | None            | Config only                |
-| **Offline capable**          | ✅             | ✅                                     | ❌ (registry)            | ✅             | ✅                 | ✅                | ✅              | ✅                         |
-| **Signup required**          | ❌             | ❌                                     | ✅ (agentskill.sh)       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **Agent count**              | **66**         | 72                                     | 15+                      | 10+            | 10+                | 39                | 1 (+ compat)    | 1 (+ plugins)              |
-| **Project scope default**    | ✅             | ✅                                     | N/A                      | ❌ (global)    | ✅ (project)       | ✅                | N/A             | N/A                        |
-| **Interactive scope prompt** | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | N/A             | N/A                        |
-| **Provenance (npm)**         | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | N/A             | N/A                        |
-| **`use` command**            | ✅             | ✅                                     | ❌                       | ✅ (`read`)    | ❌                 | ✅                | ❌              | ❌                         |
-| **`setup` command**          | ✅             | ❌                                     | ✅                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **`init` command**           | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **`search`/`find` command**  | ✅             | ✅ (`skills find`, `vercel skills`)    | ✅ (`ags search`)        | ❌             | ❌                 | ✅                | ❌              | ❌                         |
-| **`verify` command**         | ✅             | ✅ (`skills verify`)                   | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **`ci` command**             | ✅             | ✅ (`skills ci`)                       | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **`check` command**          | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **`--frozen-lockfile`**      | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **Symlink mode**             | ✅             | ✅ (default)                           | ❌                       | ❌             | ✅ (only)          | ✅                | ❌              | ❌                         |
-| **`--dry-run`**              | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
-| **`--yes` / `-y`**           | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **Bundle install**           | ✅             | ❌                                     | ✅ (skillset)            | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **Shell completions**        | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
-| **`doctor` command**         | ❌             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
-| **`upgrade` (self-update)**  | ✅             | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
-| **TUI search**               | ⚠️ (styled)    | ✅ (`skills find` interactive)         | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **Stars**                    | 36             | 24,613                                 | 23                       | 10,525         | 480                | ~1                | 13K+            | 135K+                      |
-| **skills.sh listed**         | ✅             | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| Feature                      | rolecraft                         | skills (Vercel)                        | @agentskill.sh/cli (ags) | openskills     | skills-npm (antfu) | qntx/skill (Rust) | OpenCode native | Claude Code                |
+| ---------------------------- | --------------------------------- | -------------------------------------- | ------------------------ | -------------- | ------------------ | ----------------- | --------------- | -------------------------- |
+| **Runtime deps**             | **0**                             | 1 (`yaml`)                             | 2                        | 4              | 4                  | **0** (static)    | 0 (built-in)    | 0 (built-in)               |
+| **Package size**             | ~4 KB                             | 465 KB                                 | 84 KB                    | 51 KB          | 36 KB              | ~8 MB binary      | N/A             | N/A                        |
+| **Source files**             | 15                                | 14                                     | 37                       | —              | —                  | —                 | N/A             | N/A                        |
+| **Source types**             | Local + GitHub + GitLab/SSH + npm | GitHub/GitLab/git URL/Local/npm        | Registry only            | GitHub + Local | npm packages only  | GitHub/Git/Local  | Filesystem only | Filesystem + MCP + plugins |
+| **GitLab/SSH git URL**       | ✅                                | ✅                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **Lockfile**                 | agentskill v3                     | Two-tier (global v3 + project v1, SHA) | None                     | None           | None               | ✅                | None            | Config only                |
+| **Offline capable**          | ✅                                | ✅                                     | ❌ (registry)            | ✅             | ✅                 | ✅                | ✅              | ✅                         |
+| **Signup required**          | ❌                                | ❌                                     | ✅ (agentskill.sh)       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Agent count**              | **66**                            | 72                                     | 15+                      | 10+            | 10+                | 39                | 1 (+ compat)    | 1 (+ plugins)              |
+| **Project scope default**    | ✅                                | ✅                                     | N/A                      | ❌ (global)    | ✅ (project)       | ✅                | N/A             | N/A                        |
+| **Interactive scope prompt** | ✅                                | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | N/A             | N/A                        |
+| **Provenance (npm)**         | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | N/A             | N/A                        |
+| **`use` command**            | ✅                                | ✅                                     | ❌                       | ✅ (`read`)    | ❌                 | ✅                | ❌              | ❌                         |
+| **`setup` command**          | ✅                                | ❌                                     | ✅                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`init` command**           | ✅                                | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`search`/`find` command**  | ✅                                | ✅ (`skills find`, `vercel skills`)    | ✅ (`ags search`)        | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`verify` command**         | ✅                                | ✅ (`skills verify`)                   | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`ci` command**             | ✅                                | ✅ (`skills ci`)                       | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`check` command**          | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **`--frozen-lockfile`**      | ✅                                | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Symlink mode**             | ✅                                | ✅ (default)                           | ❌                       | ❌             | ✅ (only)          | ✅                | ❌              | ❌                         |
+| **`--dry-run`**              | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`--yes` / `-y`**           | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Bundle install**           | ✅                                | ❌                                     | ✅ (skillset)            | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Shell completions**        | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`doctor` command**         | ❌                                | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`upgrade` (self-update)**  | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **TUI search**               | ⚠️ (styled)                       | ✅ (`skills find` interactive)         | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
+| **Stars**                    | 36                                | 24,613                                 | 23                       | 10,525         | 480                | ~1                | 13K+            | 135K+                      |
+| **skills.sh listed**         | ✅                                | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
 
 ## Strengths
 
@@ -59,38 +59,15 @@
 
 1. **Agent count (66)** — ahead of `ags` (15+), `openskills` (10+), `skills-npm` (10+), `qntx/skill` (39) but behind `skills` (72)
 2. **No `doctor` command** — `qntx/skill` has `skills doctor` for health checks
-3. **npm package source unsupported** — `skills` supports `npx skills add some-package`, `skills-npm` is built around it
-4. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
-5. **Stars / community adoption very low (~5)** — building trust and visibility
-
-### ✅ Resolved Gaps (Phase 2)
-
-- **SKILL.md created** — `npx skills add sametcelikbicak/rolecraft` works; rolecraft listed on skills.sh leaderboard
-- **skills.sh badge** — README now shows install count badge from skills.sh
-
-### ✅ Resolved Gaps (Phase 1)
-
-- **Copilot agent path** — now uses `.github/copilot/skills/` (project scope)
-- **Self-upgrade** — `rolecraft upgrade` command added
-- **Agent count (30 → 43 → 66)** — 20 new agent targets added
-- **`--yes` / `-y` flag** — non-interactive mode for automation
-- **`rolecraft check` command** — update availability checking
-- **GitLab/SSH git URL support** — any git remote with SKILL.md
+3. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
+4. **Stars / community adoption very low** — building trust and visibility
 
 ## Roadmap
-
-### ✅ Done
-
-- [x] **SKILL.md published** — `npx skills add sametcelikbicak/rolecraft` live on skills.sh
-- [x] **skills.sh badge** — install count visible in README
 
 ### ❌ Next
 
 - [ ] `rolecraft doctor` — system health check
-- [ ] npm package source support (`npx rolecraft install some-package`)
-- [ ] **PR to vercel-labs/skills** — add rolecraft as recognized agent in `src/agents.ts`
 - [ ] AGENTS.md XML injection for non-Claude agents
-- [ ] Skill bundle / skillset hub
 - [ ] Security scoring for installed skills
 - [ ] Watch mode — auto-sync skills on file change
 - [ ] **skills.sh telemetry** — optional reporting when `rolecraft install` runs

--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -1,6 +1,6 @@
 # `rolecraft install`
 
-Install a skill from a local path or GitHub repository.
+Install a skill from a local path, GitHub repository, or npm package.
 
 ## Usage
 
@@ -31,6 +31,19 @@ rolecraft install sametcelikbicak/coverage-guard
 
 The CLI clones with `--depth 1`, finds `SKILL.md` recursively, installs it, and cleans up.
 
+### npm package
+
+Install any npm package that contains a `SKILL.md`:
+
+```bash
+rolecraft install npm:lodash
+rolecraft install npm:@scope/package
+rolecraft install npm:package@1.0.0
+rolecraft install npm:@scope/package@latest
+```
+
+The CLI fetches package metadata from the npm registry, downloads and extracts the tarball, finds `SKILL.md` recursively, installs it, and cleans up.
+
 ## Scope flags
 
 | Flag            | Target directory                   |
@@ -60,6 +73,10 @@ rolecraft install ./my-skill
 
 # Install from GitHub
 rolecraft install sametcelikbicak/task-decomposer
+
+# Install from npm
+rolecraft install npm:some-skill-package
+rolecraft install npm:@org/skill-package@1.0.0
 
 # Install for specific agents
 rolecraft install ./my-skill --claude --cursor

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -8,7 +8,7 @@
 | Local path install                       | ✅ **1st class** | ✅                | ❌ marketplace only |
 | GitHub repo install                      | ✅               | ✅                | ❌                  |
 | GitLab / SSH git URL                     | ✅               | ✅                | ❌                  |
-| npm package source                       | ❌               | ✅                | ❌                  |
+| npm package source                       | ✅               | ✅                | ❌                  |
 | Agent targets                            | **66**           | 55+               | 15+                 |
 | SKILL.md scaffolding (`init`)            | ✅               | ✅                | ❌                  |
 | Skill preview (`use`)                    | ✅               | ✅                | ❌                  |

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -3,13 +3,19 @@ import { join, dirname, basename } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import { execSync as defaultExecSync, spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { readdirSync, readFileSync } from 'node:fs'
+import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { get as defaultHttpsGet } from 'node:https'
 import { computeContentHash } from './lockfile.js'
 
 let runExec = defaultExecSync
+let runHttpsGet = defaultHttpsGet
 
 export function setExecSync(fn) {
   runExec = fn
+}
+
+export function setHttpsGet(fn) {
+  runHttpsGet = fn
 }
 
 function runGit(args, opts = {}) {
@@ -249,7 +255,145 @@ async function resolveGitUrl(source) {
   }
 }
 
+function isNpmRef(source) {
+  return source.startsWith('npm:')
+}
+
+function parseNpmRef(source) {
+  const npmPart = source.slice(4)
+  if (!npmPart) throw new Error(`Invalid npm reference: "${source}"`)
+  let pkgName, version
+
+  if (npmPart.startsWith('@')) {
+    const slashIdx = npmPart.indexOf('/')
+    if (slashIdx === -1) throw new Error(`Invalid npm reference: "${source}"`)
+    const rest = npmPart.slice(slashIdx + 1)
+    const atIdx = rest.indexOf('@')
+    if (atIdx > 0) {
+      pkgName = npmPart.slice(0, slashIdx + 1 + atIdx)
+      version = rest.slice(atIdx + 1)
+    } else {
+      pkgName = npmPart
+      version = 'latest'
+    }
+  } else {
+    const atIdx = npmPart.lastIndexOf('@')
+    if (atIdx > 0) {
+      pkgName = npmPart.slice(0, atIdx)
+      version = npmPart.slice(atIdx + 1)
+    } else {
+      pkgName = npmPart
+      version = 'latest'
+    }
+  }
+
+  return { pkgName, version }
+}
+
+function fetchJson(url) {
+  return new Promise((resolve, reject) => {
+    const req = runHttpsGet(url, { headers: { Accept: 'application/json' } }, (res) => {
+      let data = ''
+      res.on('data', (chunk) => { data += chunk.toString() })
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`npm registry returned HTTP ${res.statusCode} for ${url}`))
+          return
+        }
+        try { resolve(JSON.parse(data)) } catch (e) { reject(new Error(`Invalid JSON from npm registry: ${e.message}`)) }
+      })
+    })
+    req.on('error', reject)
+  })
+}
+
+function downloadFile(url, dest) {
+  return new Promise((resolve, reject) => {
+    const req = runHttpsGet(url, (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`Failed to download: HTTP ${res.statusCode}`))
+        res.resume()
+        return
+      }
+      const chunks = []
+      res.on('data', (chunk) => chunks.push(chunk))
+      res.on('end', () => {
+        writeFileSync(dest, Buffer.concat(chunks))
+        resolve()
+      })
+    })
+    req.on('error', reject)
+  })
+}
+
+async function resolveNpm(source) {
+  const { pkgName, version } = parseNpmRef(source)
+  const encodedName = pkgName.replace(/\//g, '%2F')
+
+  let metadata
+  try {
+    metadata = await fetchJson(`https://registry.npmjs.org/${encodedName}`)
+  } catch (e) {
+    throw new Error(`Failed to fetch npm package "${pkgName}": ${e.message}`)
+  }
+
+  const ver = version === 'latest' ? metadata['dist-tags']?.latest : version
+  if (!ver) throw new Error(`No "latest" tag found for npm package "${pkgName}"`)
+
+  const pkgVersionData = metadata.versions?.[ver]
+  if (!pkgVersionData) throw new Error(`Version "${ver}" not found for npm package "${pkgName}"`)
+
+  const tarballUrl = pkgVersionData.dist?.tarball
+  if (!tarballUrl) throw new Error(`No tarball URL found for ${pkgName}@${ver}`)
+
+  const tmpDir = join(tmpdir(), `rolecraft-npm-${randomUUID().slice(0, 8)}`)
+  const tarballPath = join(tmpDir, 'package.tgz')
+
+  try {
+    mkdirSync(tmpDir, { recursive: true })
+    await downloadFile(tarballUrl, tarballPath)
+    runExec(`tar -xzf "${tarballPath}" -C "${tmpDir}"`, { stdio: 'pipe', timeout: 30000 })
+  } catch (e) {
+    removeDir(tmpDir)
+    throw new Error(`Failed to download/extract npm package "${pkgName}@${ver}": ${e.message}`)
+  }
+
+  const packageDir = join(tmpDir, 'package')
+  const found = scanForSkill(packageDir)
+
+  if (found.length === 0) {
+    removeDir(tmpDir)
+    throw new Error(`No SKILL.md found in npm package ${pkgName}@${ver}`)
+  }
+
+  const skill = found[0]
+  const files = readdirSync(skill.dir, { withFileTypes: true })
+    .filter(e => e.name !== '.git')
+    .map(e => e.name)
+
+  const fileContents = {}
+  for (const f of files) {
+    try { fileContents[f] = readFileSync(join(skill.dir, f), 'utf-8') } catch {}
+  }
+
+  removeDir(tmpDir)
+
+  return {
+    ...skill,
+    owner: skill.owner === 'local' ? pkgName : skill.owner,
+    slug: skill.slug === 'unknown' || skill.slug === skill.name ? `${pkgName}/${skill.name}` : skill.slug,
+    files,
+    fileContents,
+    contentSha: computeContentHash(fileContents),
+    sourcePath: source,
+    sourceType: 'npm',
+  }
+}
+
 export async function resolveSource(source) {
+  if (isNpmRef(source)) {
+    return await resolveNpm(source)
+  }
   if (isGitHubRef(source)) {
     return await resolveGitHub(source)
   }
@@ -259,5 +403,5 @@ export async function resolveSource(source) {
   if (isGitUrl(source)) {
     return await resolveGitUrl(source)
   }
-  throw new Error(`Invalid source: "${source}". Use a local path (./, /, ~), GitHub ref (owner/repo), or git URL`)
+  throw new Error(`Invalid source: "${source}". Use a local path (./, /, ~), GitHub ref (owner/repo), git URL, or npm package (npm:package)`)
 }

--- a/src/utils/resolver.test.js
+++ b/src/utils/resolver.test.js
@@ -6,6 +6,7 @@ import {
 import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { EventEmitter } from 'node:events'
 
 let tempDir, resolverModule
 
@@ -309,5 +310,141 @@ Just content
     })
 
 
+  })
+
+  describe('resolveNpm', () => {
+    function mockHttps(resolver) {
+      let callCount = 0
+      resolver.setHttpsGet((...args) => {
+        const cb = args[args.length - 1]
+        const req = new EventEmitter()
+
+        callCount++
+        process.nextTick(() => {
+          const res = new EventEmitter()
+          res.statusCode = 200
+          res.headers = {}
+          res.resume = () => {}
+
+          cb(res)
+
+          if (callCount === 1) {
+            // First call: metadata fetch
+            const data = Buffer.from(JSON.stringify({
+              'dist-tags': { latest: '1.0.0' },
+              versions: {
+                '1.0.0': {
+                  dist: { tarball: 'https://registry.npmjs.org/test-pkg/-/test-pkg-1.0.0.tgz' },
+                },
+              },
+            }))
+            res.emit('data', data)
+          } else {
+            // Second call: tarball download
+            res.emit('data', Buffer.from('fake-tarball'))
+          }
+          res.emit('end')
+        })
+
+        return req
+      })
+    }
+
+    it('resolves an npm package', async () => {
+      await freshImport()
+      mockHttps(resolverModule)
+
+      resolverModule.setExecSync((cmd) => {
+        const tarMatch = cmd.match(/tar -xzf "[^"]+" -C "([^"]+)"/)
+        if (tarMatch) {
+          const extractDir = tarMatch[1]
+          const packageDir = join(extractDir, 'package')
+          mkdirSync(packageDir, { recursive: true })
+          writeFileSync(join(packageDir, 'SKILL.md'), '# slug: test/npm-skill\nname: npm-skill\nContent')
+          writeFileSync(join(packageDir, 'helper.js'), 'x')
+        }
+      })
+
+      const result = await resolverModule.resolveSource('npm:test-pkg')
+
+      assert.equal(result.name, 'npm-skill')
+      assert.equal(result.slug, 'test/npm-skill')
+      assert.equal(result.owner, 'test-pkg')
+      assert.equal(result.sourceType, 'npm')
+      assert.equal(result.sourcePath, 'npm:test-pkg')
+      assert.ok(result.files.includes('SKILL.md'))
+      assert.ok(result.files.includes('helper.js'))
+      assert.ok(result.fileContents)
+    })
+
+    it('resolves an npm package with version', async () => {
+      await freshImport()
+      mockHttps(resolverModule)
+
+      resolverModule.setExecSync((cmd) => {
+        const tarMatch = cmd.match(/tar -xzf "[^"]+" -C "([^"]+)"/)
+        if (tarMatch) {
+          const extractDir = tarMatch[1]
+          const packageDir = join(extractDir, 'package')
+          mkdirSync(packageDir, { recursive: true })
+          writeFileSync(join(packageDir, 'SKILL.md'), '---\nname: my-skill\nslug: org/skill\n---\nContent')
+        }
+      })
+
+      const result = await resolverModule.resolveSource('npm:test-pkg@1.0.0')
+
+      assert.equal(result.name, 'my-skill')
+      assert.equal(result.slug, 'org/skill')
+      assert.equal(result.sourceType, 'npm')
+    })
+
+    it('resolves scoped npm package', async () => {
+      await freshImport()
+      mockHttps(resolverModule)
+
+      resolverModule.setExecSync((cmd) => {
+        const tarMatch = cmd.match(/tar -xzf "[^"]+" -C "([^"]+)"/)
+        if (tarMatch) {
+          const extractDir = tarMatch[1]
+          const packageDir = join(extractDir, 'package')
+          mkdirSync(packageDir, { recursive: true })
+          writeFileSync(join(packageDir, 'SKILL.md'), '# slug: s/skill\nname: scoped-skill\nContent')
+        }
+      })
+
+      const result = await resolverModule.resolveSource('npm:@scope/test-pkg')
+
+      assert.equal(result.name, 'scoped-skill')
+      assert.equal(result.sourceType, 'npm')
+    })
+
+    it('throws when no SKILL.md found in npm package', async () => {
+      await freshImport()
+      mockHttps(resolverModule)
+
+      resolverModule.setExecSync((cmd) => {
+        const tarMatch = cmd.match(/tar -xzf "[^"]+" -C "([^"]+)"/)
+        if (tarMatch) {
+          const extractDir = tarMatch[1]
+          mkdirSync(join(extractDir, 'package'), { recursive: true })
+          writeFileSync(join(extractDir, 'package', 'README.md'), 'no skill here')
+        }
+      })
+
+      await assert.rejects(
+        () => resolverModule.resolveSource('npm:test-pkg'),
+        /No SKILL.md found/,
+      )
+    })
+
+    it('throws for invalid npm ref', async () => {
+      await freshImport()
+      mockHttps(resolverModule)
+
+      await assert.rejects(
+        () => resolverModule.resolveSource('npm:'),
+        /Invalid npm reference/,
+      )
+    })
   })
 })


### PR DESCRIPTION
## Summary

Adds `npm:<package>` source support to rolecraft — users can now install skills directly from npm packages.

## Usage

```
rolecraft install npm:lodash
rolecraft install npm:lodash@4.17.21
rolecraft install npm:@scope/package@1.0.0
```

## Implementation

Zero-dependency approach using only Node.js built-ins:
- `node:https` — fetch metadata from npm registry API + download tarball
- `tar -xzf` — extract tarball (same pattern as `git clone` and `rm -rf`)
- `scanForSkill` — find SKILL.md in extracted package

Closes the #1 feature gap versus Vercel's `skills` tool.

## Changes

- **src/utils/resolver.js**: `resolveNpm`, `parseNpmRef`, `fetchJson`, `downloadFile`, mockable `setHttpsGet`
- **src/utils/resolver.test.js**: 5 new tests (basic, versioned, scoped, no-skill, invalid ref)
- **bin/rolecraft.js**: updated usage/error messages
- **docs/**: install.md, comparison.md, ANALYSIS.md updated
- **README.md**: quick start, features, comparison table
