### PR TITLE
fix: use mkdtempSync for npm temp dir (CodeQL insecure-temporary-file)

### DIFF
--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -3,7 +3,7 @@ import { join, dirname, basename } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import { execSync as defaultExecSync, spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, mkdtempSync } from 'node:fs'
 import { get as defaultHttpsGet } from 'node:https'
 import { computeContentHash } from './lockfile.js'
 
@@ -356,11 +356,10 @@ async function resolveNpm(source) {
   const tarballUrl = pkgVersionData.dist?.tarball
   if (!tarballUrl) throw new Error(`No tarball URL found for ${pkgName}@${ver}`)
 
-  const tmpDir = join(tmpdir(), `rolecraft-npm-${randomUUID().slice(0, 8)}`)
+  const tmpDir = mkdtempSync(join(tmpdir(), 'rolecraft-npm-'))
   const tarballPath = join(tmpDir, 'package.tgz')
 
   try {
-    mkdirSync(tmpDir, { recursive: true })
     await downloadFile(tarballUrl, tarballPath)
     const tarResult = runSpawn('tar', ['-xzf', tarballPath, '-C', tmpDir], { stdio: 'pipe', timeout: 30000 })
     if (tarResult.error) throw tarResult.error


### PR DESCRIPTION
Fixes CodeQL alert #41 (Insecure temporary file) in src/utils/resolver.js.

- Replaced `join(tmpdir(), ...)` + `mkdirSync` with `mkdtempSync` — atomically creates the temp directory, eliminating the TOCTOU race condition.
- Also dismissed alerts #37 (File data in outbound network request) and #40 (Network data written to file) as by-design — these are core behaviors of the npm package resolution feature.
