### PR TITLE
fix: remove unused mkdirSync import (CodeQL #42) + AGENTS.md merge rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 9. `git add ... && git commit -m "type: message"` — commit
 10. `git push -u origin <branch>` — push
 11. `gh pr create` — open PR
+12. Before merging, wait for all GitHub Actions checks to pass (`gh run watch` or check PR status). Never merge while checks are running.
 
 ## Workflow
 - Before starting any task, ensure you're on `main` with latest changes (`git checkout main && git pull`), then create a new branch specific to the task (`git checkout -b feat/my-feature` or `fix/my-bug`)
@@ -23,6 +24,7 @@
 - Update documentation (README, CONTRIBUTING, docs/) when needed
 - Test the `--dry-run` flag if the feature supports it
 - After tests pass, commit the changes, push the branch, and open a PR
+- Before merging, wait for all GitHub Actions checks to pass (`gh run watch` or check PR status). Never merge while checks are running.
 
 ## Code style
 - Keep the zero-dependency principle (don't add new dependencies to package.json)

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -3,7 +3,7 @@ import { join, dirname, basename } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import { execSync as defaultExecSync, spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { readdirSync, readFileSync, writeFileSync, mkdirSync, mkdtempSync } from 'node:fs'
+import { readdirSync, readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
 import { get as defaultHttpsGet } from 'node:https'
 import { computeContentHash } from './lockfile.js'
 

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -3,7 +3,7 @@ import { join, dirname, basename } from 'node:path'
 import { tmpdir, homedir } from 'node:os'
 import { execSync as defaultExecSync, spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, mkdtempSync } from 'node:fs'
 import { get as defaultHttpsGet } from 'node:https'
 import { computeContentHash } from './lockfile.js'
 
@@ -356,11 +356,10 @@ async function resolveNpm(source) {
   const tarballUrl = pkgVersionData.dist?.tarball
   if (!tarballUrl) throw new Error(`No tarball URL found for ${pkgName}@${ver}`)
 
-  const tmpDir = join(tmpdir(), `rolecraft-npm-${randomUUID().slice(0, 8)}`)
+  const tmpDir = mkdtempSync(join(tmpdir(), 'rolecraft-npm-'))
   const tarballPath = join(tmpDir, 'package.tgz')
 
   try {
-    mkdirSync(tmpDir, { recursive: true })
     await downloadFile(tarballUrl, tarballPath)
     const tarResult = runSpawn('tar', ['-xzf', tarballPath, '-C', tmpDir], { stdio: 'pipe', timeout: 30000 })
     if (tarResult.error) throw tarResult.error


### PR DESCRIPTION
Fixes CodeQL alert #42 (Unused import mkdirSync).

- Removed unused `mkdirSync` from import in `src/utils/resolver.js` (was replaced by `mkdtempSync` in the previous fix)
- Added merge rule to AGENTS.md: wait for GitHub Actions checks before merging

Closes #42
