### PR TITLE
fix: preserve GPG signature when release-prep moves tag to changelog commit

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -41,6 +41,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Import GPG signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        run: |
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "No GPG key configured — tag will not be re-signed"
+            exit 0
+          fi
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          git config user.signingkey "$GPG_KEY_ID"
+          git config tag.gpgsign true
+
       - name: Run release preparation script
         run: |
           bash .github/scripts/release-prep.sh "${{ github.ref_name }}"
@@ -54,10 +67,16 @@ jobs:
           git commit -m "chore: update changelog and version for ${{ github.ref_name }} [skip ci]"
           git push origin "$BRANCH_NAME"
 
-      - name: Update tag to release commit
+      - name: Update tag to release commit (re-signed)
         run: |
-          git tag -f "${{ github.ref_name }}"
-          git push origin "${{ github.ref_name }}" --force
+          TAG_NAME="${{ github.ref_name }}"
+          TAG_MESSAGE="chore: release $TAG_NAME"
+          if git config tag.gpgsign | grep -q true; then
+            git tag -f -s "$TAG_NAME" -m "$TAG_MESSAGE"
+          else
+            git tag -f "$TAG_NAME"
+          fi
+          git push origin "$TAG_NAME" --force
 
       - name: Create Pull Request
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,46 @@ chore: bump dependencies
 
 Only maintainers can create releases:
 
-1. Ensure all desired changes are merged to `main`
-2. Create and push a version tag: `git tag v0.X.Y && git push origin v0.X.Y`
-3. GitHub Actions handles the rest:
-   - Changelog is generated automatically
-   - A release PR is created
-   - After PR merge, the package is published to npm
+### 1. Prerequisites — GPG Key in CI
+
+The release workflow re-signs the tag when moving it to the changelog commit. For the tag to show a **Verified** badge on GitHub, the GPG private key must be added as a GitHub secret.
+
+First, find your GPG key ID:
+```bash
+gpg --list-secret-keys --keyid-format=long | grep sec
+# e.g. sec   ed25519/3AA5C34371567BD2  ...
+# Key ID: 3AA5C34371567BD2
+```
+
+Export the private key (you'll be prompted for your passphrase):
+```bash
+gpg --armor --export-secret-keys 3AA5C34371567BD2 | pbcopy
+# or on Linux:  gpg --armor --export-secret-keys 3AA5C34371567BD2 | xclip -sel clip
+```
+
+Add these secrets to the repository at `https://github.com/sametcelikbicak/rolecraft/settings/secrets/actions`:
+
+| Secret | Value |
+|--------|-------|
+| `GPG_PRIVATE_KEY` | The armored private key (starts with `-----BEGIN PGP PRIVATE KEY BLOCK-----`) |
+| `GPG_KEY_ID` | Your key ID, e.g. `3AA5C34371567BD2` |
+
+### 2. Create and Push a Signed Tag
+
+```bash
+git tag -s v0.X.Y -m "chore: release v0.X.Y"
+git push origin v0.X.Y
+```
+
+> ⚠️ Always use `git tag -s` (signed tag) instead of `git tag`. Unsigned tags will not show a "Verified" badge on GitHub. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-tags) if GPG is not configured.
+
+### 3. CI Handles the Rest
+
+GitHub Actions:
+- Generates the changelog and bumps the version
+- Re-signs the tag on the new commit (uses the GPG key from secrets)
+- Creates a release PR
+- After the PR is merged, the package is published to npm
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Problem

The `release-prep.yml` workflow uses `git tag -f` to move the version tag to the changelog/version-bump commit. This drops the GPG signature, so the tag no longer shows a **Verified** badge on GitHub.

## Solution

1. **Import GPG key into runner** — reads `GPG_PRIVATE_KEY` and `GPG_KEY_ID` secrets
2. **Re-sign the tag** — uses `git tag -f -s` instead of `git tag -f`
3. **Graceful fallback** — if no GPG secret is configured, falls back to unsigned `git tag -f`

## Files

- `.github/workflows/release-prep.yml` — added GPG import step, switched to `git tag -f -s`
- `CONTRIBUTING.md` — added GPG export/setup instructions in the Release Process section

## Verification

- Tag starts signed (maintainer pushes `git tag -s`)
- Workflow re-signs on the new commit with the same GPG key
- Tag shows ✅ **Verified** on GitHub