### PR TITLE
fix: support SSH signing key in release-prep workflow

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -41,18 +41,29 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Import GPG signing key
+      - name: Import signing key (SSH or GPG)
         env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
         run: |
-          if [ -z "$GPG_PRIVATE_KEY" ]; then
-            echo "No GPG key configured — tag will not be re-signed"
-            exit 0
+          if [ -n "$SSH_PRIVATE_KEY" ]; then
+            mkdir -p ~/.ssh
+            echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_signing
+            chmod 600 ~/.ssh/id_signing
+            ssh-keygen -y -f ~/.ssh/id_signing > ~/.ssh/id_signing.pub
+            eval "$(ssh-agent -s)" > /dev/null
+            ssh-add ~/.ssh/id_signing
+            git config gpg.format ssh
+            git config user.signingkey ~/.ssh/id_signing.pub
+            git config tag.gpgsign true
+          elif [ -n "$GPG_PRIVATE_KEY" ]; then
+            echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+            git config user.signingkey "$GPG_KEY_ID"
+            git config tag.gpgsign true
+          else
+            echo "No signing key configured — tag will not be re-signed"
           fi
-          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-          git config user.signingkey "$GPG_KEY_ID"
-          git config tag.gpgsign true
 
       - name: Run release preparation script
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,24 +50,45 @@ chore: bump dependencies
 
 Only maintainers can create releases:
 
-### 1. Prerequisites — GPG Key in CI
+### 1. Prerequisites — Signing Key in CI
 
-The release workflow re-signs the tag when moving it to the changelog commit. For the tag to show a **Verified** badge on GitHub, the GPG private key must be added as a GitHub secret.
+The release workflow re-signs the tag when moving it to the changelog commit. For the tag to show a **Verified** badge on GitHub, a signing key must be added as a GitHub secret.
 
-First, find your GPG key ID:
+The workflow supports both **SSH** and **GPG** signing keys. SSH is recommended if you already have it configured.
+
+#### Option A: SSH (recommended)
+
+Use your existing SSH private key. First verify you have one:
+
+```bash
+ls ~/.ssh/id_ed25519   # or ~/.ssh/id_rsa
+```
+
+If you already sign commits (check with `git config --global gpg.format`), use that same key. Export the private key:
+
+```bash
+cat ~/.ssh/id_ed25519 | pbcopy
+# or on Linux: cat ~/.ssh/id_ed25519 | xclip -sel clip
+```
+
+Add these secrets to the repository at `https://github.com/sametcelikbicak/rolecraft/settings/secrets/actions`:
+
+| Secret | Value |
+|--------|-------|
+| `SSH_PRIVATE_KEY` | The SSH private key (starts with `-----BEGIN OPENSSH PRIVATE KEY-----`) |
+
+Also add your SSH **public** key (`~/.ssh/id_ed25519.pub`) to GitHub as a **Signing Key** at `https://github.com/settings/ssh/new` — select "Signing Key" as the key type.
+
+#### Option B: GPG
+
+If you prefer GPG, find your key ID and export it:
+
 ```bash
 gpg --list-secret-keys --keyid-format=long | grep sec
 # e.g. sec   ed25519/3AA5C34371567BD2  ...
 # Key ID: 3AA5C34371567BD2
-```
-
-Export the private key (you'll be prompted for your passphrase):
-```bash
 gpg --armor --export-secret-keys 3AA5C34371567BD2 | pbcopy
-# or on Linux:  gpg --armor --export-secret-keys 3AA5C34371567BD2 | xclip -sel clip
 ```
-
-Add these secrets to the repository at `https://github.com/sametcelikbicak/rolecraft/settings/secrets/actions`:
 
 | Secret | Value |
 |--------|-------|
@@ -87,7 +108,7 @@ git push origin v0.X.Y
 
 GitHub Actions:
 - Generates the changelog and bumps the version
-- Re-signs the tag on the new commit (uses the GPG key from secrets)
+- Re-signs the tag on the new commit (uses the SSH or GPG key from secrets)
 - Creates a release PR
 - After the PR is merged, the package is published to npm
 


### PR DESCRIPTION
## Problem

The release-prep workflow only supported GPG signing keys (`GPG_PRIVATE_KEY` + `GPG_KEY_ID` secrets). The maintainer uses **SSH** signing (`gpg.format = ssh`), which the workflow didn't handle.

## Solution

- Added SSH key support to the signing key import step
- Workflow detects `SSH_PRIVATE_KEY` first, falls back to `GPG_PRIVATE_KEY`
- SSH key is imported into `ssh-agent` and git is configured with `gpg.format ssh`
- Updated `CONTRIBUTING.md` — release prerequisites now document both SSH and GPG options

## Usage

Requires adding `SSH_PRIVATE_KEY` as a GitHub secret and the SSH public key as a signing key on GitHub.