### PR TITLE
feat: add rolecraft doctor command for system health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ rolecraft remove my-skill
 - **Content hash verification** — detect tampered or outdated skills
 - **CI-ready** — lockfile-based re-install for pipelines
 - **Dry-run mode** — preview before installing
+- **System health check** — `rolecraft doctor` diagnoses Node.js, agent directories, lockfiles, and skill integrity
 
 ---
 
@@ -113,6 +114,7 @@ rolecraft remove my-skill
 | `rolecraft completions bash\|zsh\|fish` | Generate shell completion scripts                        | [docs](docs/commands/completions.md) |
 | `rolecraft setup [<source>]`            | Detect agents, optionally install a skill to all         | [docs](docs/commands/setup.md)       |
 | `rolecraft list`                        | Show all installed skills                                | [docs](docs/commands/list.md)        |
+| `rolecraft doctor`                      | Run system health check                                  | [docs](docs/commands/doctor.md)      |
 | `rolecraft verify`                      | Check installed skill integrity via content hash         | [docs](docs/commands/verify.md)      |
 | `rolecraft ci`                          | Re-install all skills from lockfile (CI mode)            | [docs](docs/commands/ci.md)          |
 | `rolecraft upgrade`                     | Upgrade rolecraft to the latest version                  | [docs](docs/commands/upgrade.md)     |
@@ -128,7 +130,7 @@ rolecraft remove my-skill
 
 | Feature                              | rolecraft        | skills (Vercel) | @agentskill.sh/cli  |
 | ------------------------------------ | ---------------- | --------------- | ------------------- |
-| Zero dependencies                    | ✅               | ✅ (1 dep)      | ❌ (2)              |
+| Zero dependencies                    | ✅ **0**         | ✅ (1 dep)      | ❌ (2)              |
 | Local path install                   | ✅ **1st class** | ✅              | ❌ marketplace only |
 | GitHub repo install                  | ✅               | ✅              | ❌                  |
 | GitLab / SSH git URL                 | ✅               | ✅              | ❌                  |
@@ -145,6 +147,7 @@ rolecraft remove my-skill
 | Interactive scope prompt             | ✅               | ✅              | ❌                  |
 | Content hash verification (`verify`) | ✅               | ✅              | ❌                  |
 | CI-mode re-install (`ci`)            | ✅               | ✅              | ❌                  |
+| System health check (`doctor`)       | ✅               | ❌              | ❌                  |
 | Self-upgrade command                 | ✅               | ❌              | ❌                  |
 | File size                            | ~4 KB            | ~465 KB         | ~84 KB              |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,6 +14,7 @@ Install and manage AI agent skills across 66+ agents with a single command. Zero
 - **Install skills** — from local folders, GitHub repos, GitLab projects, or SSH git URLs
 - **Manage skills** — list, update, remove, and verify installed skills
 - **CI/CD pipelines** — lockfile-based re-install with `rolecraft ci`
+- **Troubleshooting** — `rolecraft doctor` to diagnose agent detection, lockfile, and Node.js issues
 - **Team onboarding** — bundle install with a single command
 - **Cross-agent setup** — install the same skill to multiple agents at once
 
@@ -38,6 +39,9 @@ npx rolecraft install user/repo --cursor --devin
 # Check for updates
 npx rolecraft check
 
+# Run system health check
+npx rolecraft doctor
+
 # List installed skills
 npx rolecraft list
 ```
@@ -56,6 +60,7 @@ npx rolecraft list
 | `rolecraft ci` | Re-install from lockfile (CI mode) |
 | `rolecraft verify` | Check skill integrity via content hash |
 | `rolecraft search <query>` | Search skills on GitHub |
+| `rolecraft doctor` | Run system health check |
 | `rolecraft use <source>` | Preview without installing |
 | `rolecraft completions bash\|zsh\|fish` | Generate shell completions |
 

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -17,6 +17,7 @@ import { ciCommand } from '../src/commands/ci.js'
 import { bundleCommand, bundleCreateCommand } from '../src/commands/bundle.js'
 import { completionsCommand } from '../src/commands/completions.js'
 import { upgradeCommand } from '../src/commands/upgrade.js'
+import { doctorCommand } from '../src/commands/doctor.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -43,6 +44,7 @@ Usage:
   rolecraft verify               Verify installed skill integrity
   rolecraft ci                   Install all skills from lockfile
   rolecraft completions <shell>  Generate shell completions (bash|zsh|fish)
+  rolecraft doctor               Run system health check
   rolecraft upgrade              Upgrade rolecraft to the latest version
   rolecraft help                 Show this help
 
@@ -311,6 +313,11 @@ export async function main() {
       await upgradeCommand({ dryRun: flags.includes('--dry-run') })
       break
     }
+
+    case 'doctor':
+      if (args.includes('--help') || args.includes('-h')) { usage(); return }
+      await doctorCommand()
+      break
 
     case 'version':
     case '--version':

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -30,7 +30,7 @@
 | **Security scoring**         | ✅                                | ✅ (Snyk audit)                        | ✅ (0–100 server-side)   | ❌             | ❌                 | ❌                | ❌              | ❌                         |
 | **Bundle install**           | ✅                                | ❌                                     | ✅ (skillset)            | ❌             | ❌                 | ❌                | ❌              | ❌                         |
 | **Shell completions**        | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
-| **`doctor` command**         | ❌                                | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
+| **`doctor` command**         | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
 | **`upgrade` (self-update)**  | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ✅                | ❌              | ❌                         |
 | **TUI search**               | ⚠️ (styled)                       | ✅ (`skills find` interactive)         | ❌                       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
 | **Stars**                    | 36                                | 24,613                                 | 23                       | 10,525         | 480                | ~1                | 13K+            | 135K+                      |
@@ -53,6 +53,7 @@
 - **Bundle system** — install from JSON/text files or inline sources
 - **`--yes` / `-y` flag** — non-interactive mode for automation pipelines
 - **`rolecraft check` command** — check for available updates
+- **`rolecraft doctor` command** — system health check: Node.js version, agent detection, lockfile integrity, skill file verification
 - **Security scoring** — 0–100 static analysis scanning for prompt injection, command injection, sensitive file access, credential harvesting, and more; blocks DANGER skills unless `--yes`
 
 ## Weaknesses / Gaps
@@ -60,8 +61,7 @@
 ### Feature gaps vs competitors
 
 1. **Agent count (66)** — ahead of `ags` (15+), `openskills` (10+), `skills-npm` (10+), `qntx/skill` (39) but behind `skills` (72)
-2. **No `doctor` command** — `qntx/skill` has `skills doctor` for health checks
-3. **Security scoring (done)** — matches `ags` 0–100 scoring, `skills` Snyk audit. rolecraft: zero-dep static analysis with prompt injection, command injection, obfuscated code, credential harvesting, and sensitive file access detection.
+2. **Security scoring (done)** — matches `ags` 0–100 scoring, `skills` Snyk audit. rolecraft: zero-dep static analysis with prompt injection, command injection, obfuscated code, credential harvesting, and sensitive file access detection.
 3. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
 4. **Stars / community adoption very low** — building trust and visibility
 
@@ -70,10 +70,10 @@
 ### ✅ Done
 
 - [x] Security scoring for installed skills — `rolecraft install` scans skill files for prompt injection, command injection, obfuscated code, sensitive file access, data exfiltration, and more. Scores 0–100: SAFE (90+), REVIEW (70–89), DANGER (<70). DANGER blocks install unless `--yes`. REVIEW prompts for confirmation. Zero dependencies.
+- [x] `rolecraft doctor` — system health check: Node.js version, agent detection, lockfile integrity, skill directory and hash verification
 
 ### ❌ Next
 
-- [ ] `rolecraft doctor` — system health check
 - [ ] AGENTS.md XML injection for non-Claude agents
 - [ ] Watch mode — auto-sync skills on file change
 - [ ] **skills.sh telemetry** — optional reporting when `rolecraft install` runs
@@ -86,8 +86,8 @@
 - **Stars**: 23.5K | **Deps**: 1 | **Agents**: 55+
 - **Key features**: `skills use`, `skills ci`/`skills verify` (lockfile workflow), `skills find` (interactive TUI), `skills init`, symlink mode, `vercel skills` built-in, 13.4M weekly downloads, skills.sh directory
 - **Weaknesses**: 1 dep (`yaml`), no provenance, no `setup` command, no dry-run, no bundle
-- **rolecraft advantage**: Zero deps, provenance, `setup` command, dry-run, bundle
-- **rolecraft gap**: Agent count (66 vs 72), no doctor
+- **rolecraft advantage**: Zero deps, provenance, `setup` command, dry-run, bundle, doctor
+- **rolecraft gap**: Agent count (66 vs 72)
 
 ### @agentskill.sh/cli (ags)
 
@@ -120,8 +120,7 @@
 - **Key features**: 100% command parity, shell completions, `skills doctor`, `skills upgrade`, dry-run mode, parallel I/O
 - **Weaknesses**: Very new, Rust toolchain for dev, no provenance, no `setup`
 - **rolecraft advantage**: Zero deps as JS, provenance, `setup` command, interactive scope prompt
-- **rolecraft advantage**: Shell completions, TUI search, self-upgrade
-- **rolecraft gap**: No doctor
+- **rolecraft advantage**: Shell completions, TUI search, self-upgrade, doctor
 
 ### OpenCode native
 
@@ -157,5 +156,5 @@
 2. **npm provenance** — only project with SLSA Level 1+ attestations
 3. **Interactive scope prompt** — best UX for first-time users
 4. **Bundle system** — unique multi-skill install from files/inline
-5. **Dry-run + Verify + CI** — complete integrity workflow unmatched by most competitors
+5. **Dry-run + Verify + CI + Doctor** — complete integrity and health workflow unmatched by most competitors
 6. **Corrected Copilot path** — now uses `.github/copilot/skills/` matching GitHub's official standard

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,12 +3,14 @@
 ## How it works
 
 1. Reads `SKILL.md` from the source and parses metadata (slug, name, owner)
-2. Copies (or symlinks with `--symlink`) all files alongside `SKILL.md` to the target directory
-3. Computes a SHA256 content hash and stores it in the lockfile
-4. Updates `~/.agents/.skill-lock.json` so agents can discover the skill
-5. `rolecraft verify` checks installed files against the stored hash
-6. `rolecraft ci` re-installs all skills from the lockfile (e.g. in CI pipelines)
-7. Compatible with skills installed by `@agentskill.sh/cli`, `add-skill`, or manual installs
+2. Runs a **security scan** on all skill files — checks for prompt injection, command injection, obfuscated code, credential harvesting, and sensitive file access. Scores 0–100. Blocks dangerous skills unless `--yes`
+3. Copies (or symlinks with `--symlink`) all files alongside `SKILL.md` to the target directory
+4. Computes a SHA256 content hash and stores it in the lockfile
+5. Updates `~/.agents/.skill-lock.json` so agents can discover the skill
+6. `rolecraft verify` checks installed files against the stored hash
+7. `rolecraft ci` re-installs all skills from the lockfile (e.g. in CI pipelines)
+8. `rolecraft doctor` runs a system health check across Node.js, agent directories, and lockfiles
+9. Compatible with skills installed by `@agentskill.sh/cli`, `add-skill`, or manual installs
 
 ## Project structure
 
@@ -18,7 +20,10 @@ rolecraft/
 ├── src/
 │   ├── commands/
 │   │   ├── bundle.js          # multi-skill install from bundle file
+│   │   ├── check.js           # skill update checking
 │   │   ├── ci.js              # frozen lockfile install
+│   │   ├── completions.js     # shell completion generation
+│   │   ├── doctor.js          # system health check
 │   │   ├── init.js            # SKILL.md scaffolding
 │   │   ├── install.js         # install logic + interactive scope
 │   │   ├── list.js            # list installed skills
@@ -26,12 +31,14 @@ rolecraft/
 │   │   ├── search.js          # GitHub skill discovery
 │   │   ├── setup.js           # detect agents + install to all
 │   │   ├── update.js          # re-install skill to latest
+│   │   ├── upgrade.js         # self-upgrade
 │   │   ├── use.js             # preview skill without installing
 │   │   └── verify.js          # integrity verification
 │   └── utils/
-│       ├── resolver.js       # source resolver (local / GitHub)
+│       ├── resolver.js       # source resolver (local / GitHub / GitLab / npm)
 │       ├── installer.js      # copy/symlink files to target dirs
-│       └── lockfile.js       # read/write .skill-lock.json + content hash
+│       ├── lockfile.js       # read/write .skill-lock.json + content hash
+│       └── security.js       # static analysis scoring (0–100)
 ├── package.json
 ├── CHANGELOG.md              # Release history
 ├── CONTRIBUTING.md           # Contribution guide

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -1,0 +1,60 @@
+# `rolecraft doctor`
+
+Run a system health check to diagnose common issues.
+
+## Usage
+
+```bash
+rolecraft doctor
+```
+
+## Description
+
+Scans your system and reports on:
+
+- **Node.js version** — verifies >= 20
+- **rolecraft version** — shows current installed version
+- **Home directory** — confirms HOME is set
+- **~/.agents directory** — checks if the global agents directory exists
+- **Global lockfile** — reads the lockfile and counts tracked skills
+- **Project lockfile** — reads the project-scoped lockfile (if any)
+- **Agent detection** — finds all installed AI agents by scanning known skill directories
+- **Skill integrity** — for each skill in the lockfile, verifies the skill directory exists and content hashes match
+
+## Example output
+
+```bash
+$ rolecraft doctor
+
+🔬 rolecraft doctor — System Health Check
+
+   ✅ Node.js version                        v22.0.0
+   ✅ rolecraft version                      v1.2.0
+   ✅ Home directory                         /home/user
+   ✅ ~/.agents directory                    /home/user/.agents
+   ✅ Global lockfile                        3 skill(s) tracked
+   ⚠️  Project lockfile                       no project skills
+   ✅ Agent detection                        2 agent(s) found
+     ✅  └ opencode                          2 skill(s)
+     ✅  └ claude-code                       1 skill(s)
+   ✅ Skill integrity                        3 checked, 0 hash mismatch(es), 0 missing director(ies)
+
+📋 Summary: 9 passed, 1 warnings, 0 errors
+```
+
+```bash
+$ rolecraft doctor
+
+🔬 rolecraft doctor — System Health Check
+
+   ✅ Node.js version                        v20.11.0
+   ✅ rolecraft version                      v1.2.0
+   ✅ Home directory                         /home/user
+   ⚠️  ~/.agents directory                   not yet created
+   ⚠️  Global lockfile                       no global skills
+   ⚠️  Project lockfile                      no project skills
+   ⚠️  Agent detection                       no supported agents detected
+   ⚠️  Skill integrity                       no skills to verify
+
+📋 Summary: 3 passed, 5 warnings, 0 errors
+```

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -9,7 +9,7 @@
 | GitHub repo install                      | ✅               | ✅                | ❌                  |
 | GitLab / SSH git URL                     | ✅               | ✅                | ❌                  |
 | npm package source                       | ✅               | ✅                | ❌                  |
-| Agent targets                            | **66**           | 55+               | 15+                 |
+| Agent targets                            | **66**           | **72**            | 15+                 |
 | SKILL.md scaffolding (`init`)            | ✅               | ✅                | ❌                  |
 | Skill preview (`use`)                    | ✅               | ✅                | ❌                  |
 | Agent auto-detect + install (`setup`)    | ✅               | ❌                | ✅                  |
@@ -34,7 +34,7 @@
 | In-agent `/learn` command                | ❌               | ❌                | ✅                  |
 | Skill rating / feedback                  | ❌               | ❌                | ✅                  |
 | Skill diff / compose                     | ❌               | ❌                | ❌                  |
-| Conflict detection (`doctor`)            | ❌               | ❌                | ❌                  |
-| Security scanning                        | ❌               | ❌ (audits only)  | ✅                  |
+| System health check (`doctor`)           | ✅               | ❌                | ❌                  |
+| Security scanning (0–100)                | ✅               | ✅ (Snyk)         | ✅                  |
 | Telemetry / leaderboard                  | ❌               | ✅                | ❌                  |
 | File size                                | ~4 KB            | ~465 KB           | ~84 KB              |

--- a/src/commands/completions.js
+++ b/src/commands/completions.js
@@ -1,7 +1,7 @@
 const COMMANDS = [
   'install', 'bundle', 'use', 'list', 'remove', 'update',
   'setup', 'init', 'search', 'verify', 'ci', 'completions',
-  'upgrade', 'help', 'version',
+  'doctor', 'upgrade', 'help', 'version',
 ]
 
 const SCOPE_FLAGS = [

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,0 +1,136 @@
+import { accessSync, constants, readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { readLock, getProjectLockPath, getAgentsDir } from '../utils/lockfile.js'
+import { detectAgents } from './setup.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'))
+
+function icon(status) {
+  return status === 'pass' ? '✅' : status === 'warn' ? '⚠️' : '❌'
+}
+
+export async function doctorCommand() {
+  let passed = 0
+  let warnings = 0
+  let errors = 0
+
+  function report(label, status, detail = '') {
+    console.log(`   ${icon(status)} ${label.padEnd(38)} ${detail}`)
+    if (status === 'pass') passed++
+    else if (status === 'warn') warnings++
+    else errors++
+  }
+
+  console.log('\n🔬 rolecraft doctor — System Health Check\n')
+
+  report('Node.js version', 'pass', `v${process.versions.node}`)
+  const [major] = process.versions.node.split('.').map(Number)
+  if (major < 20) {
+    report('Node.js compatibility', 'error', '>= 20 required, please upgrade')
+  }
+
+  report('rolecraft version', 'pass', `v${pkg.version}`)
+  report('Home directory', 'pass', process.env.HOME || '~')
+
+  const agentsDir = join(process.env.HOME || '~', '.agents')
+  try {
+    accessSync(agentsDir, constants.F_OK)
+    report('~/.agents directory', 'pass', agentsDir)
+  } catch {
+    report('~/.agents directory', 'warn', 'not yet created')
+  }
+
+  const globalLock = await readLock()
+  const globalSkillCount = Object.keys(globalLock.skills).length
+  if (globalSkillCount > 0) {
+    report('Global lockfile', 'pass', `${globalSkillCount} skill(s) tracked`)
+  } else {
+    report('Global lockfile', 'warn', 'no global skills')
+  }
+
+  const projectLock = await readLock(getProjectLockPath(process.cwd())).catch(() => null)
+  const projectSkillCount = projectLock ? Object.keys(projectLock.skills).length : 0
+  if (projectSkillCount > 0) {
+    report('Project lockfile', 'pass', `${projectSkillCount} skill(s) tracked`)
+  } else {
+    report('Project lockfile', 'warn', 'no project skills')
+  }
+
+  const agents = detectAgents()
+  if (agents.length > 0) {
+    report('Agent detection', 'pass', `${agents.length} agent(s) found`)
+    for (const agent of agents) {
+      const skillCount = countAgentSkills(agent.dir())
+      const label = `  └ ${agent.label}`
+      if (skillCount > 0) {
+        report(label, 'pass', `${skillCount} skill(s)`)
+      } else {
+        report(label, 'warn', 'no skills installed')
+      }
+    }
+  } else {
+    report('Agent detection', 'warn', 'no supported agents detected')
+  }
+
+  const allSkills = { ...globalLock.skills }
+  if (projectLock) {
+    for (const [slug, entry] of Object.entries(projectLock.skills)) {
+      allSkills[slug] = entry
+    }
+  }
+
+  let missingDirs = 0
+  let hashMismatches = 0
+  let verifiedSkills = 0
+  for (const [slug, entry] of Object.entries(allSkills)) {
+    const normSlug = slug.replace(/\//g, '-')
+    const searchDirs = [join(getAgentsDir(), normSlug), join(process.cwd(), '.agents', 'skills', normSlug)]
+    const existingDir = searchDirs.find(d => {
+      try { accessSync(d, constants.F_OK); return true } catch { return false }
+    })
+    if (!existingDir) {
+      missingDirs++
+      continue
+    }
+    if (entry.contentSha) {
+      try {
+        const files = readdirSync(existingDir).filter(f => f.endsWith('.md'))
+        const fc = {}
+        for (const f of files) {
+          fc[f] = readFileSync(join(existingDir, f), 'utf-8')
+        }
+        const { computeContentHash } = await import('../utils/lockfile.js')
+        const hash = computeContentHash(fc)
+        if (hash !== entry.contentSha) {
+          hashMismatches++
+        }
+        verifiedSkills++
+      } catch {
+        hashMismatches++
+      }
+    } else {
+      verifiedSkills++
+    }
+  }
+
+  if (Object.keys(allSkills).length > 0) {
+    report('Skill integrity', (hashMismatches + missingDirs) === 0 ? 'pass' : 'warn',
+      `${verifiedSkills} checked, ${hashMismatches} hash mismatch(es), ${missingDirs} missing director(ies)`)
+  } else {
+    report('Skill integrity', 'warn', 'no skills to verify')
+  }
+
+  console.log(`\n📋 Summary: ${passed} passed, ${warnings} warnings, ${errors} errors\n`)
+}
+
+function countAgentSkills(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+      .length
+  } catch {
+    return 0
+  }
+}

--- a/src/commands/doctor.test.js
+++ b/src/commands/doctor.test.js
@@ -1,0 +1,204 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempDir, originalCwd, originalHome, doctorModule
+
+function capture() {
+  const logs = []
+  const origLog = console.log
+  console.log = (...args) => { if (args.length) logs.push(String(args[0])) }
+  return { logs, restore: () => { console.log = origLog } }
+}
+
+before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-doctor-test-'))
+  originalCwd = process.cwd()
+  originalHome = process.env.HOME
+  process.env.HOME = tempDir
+  process.chdir(tempDir)
+
+  await mkdir(join(tempDir, '.agents'), { recursive: true })
+  await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
+    version: 3, skills: {}, dismissed: {}, lastSelectedAgents: [],
+  }))
+
+  doctorModule = await import('./doctor.js')
+})
+
+after(async () => {
+  process.chdir(originalCwd)
+  process.env.HOME = originalHome
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('doctor command', () => {
+  it('shows health check header', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('System Health Check')))
+  })
+
+  it('reports node.js version', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('Node.js version')))
+    assert.ok(logs.some(l => l.includes(`v${process.versions.node}`)))
+  })
+
+  it('reports rolecraft version', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('rolecraft version')))
+  })
+
+  it('reports home directory', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('Home directory')))
+  })
+
+  it('reports ~/.agents directory', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('.agents directory')))
+  })
+
+  it('shows warning when no agents detected', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('no supported agents detected')))
+  })
+
+  it('shows warning when no skills in lockfile', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('no global skills')))
+  })
+
+  it('shows summary at the end', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('Summary:')))
+  })
+
+  it('detects agent when its skill directory exists', async () => {
+    await mkdir(join(tempDir, '.agents', 'skills'), { recursive: true })
+
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('opencode')))
+  })
+
+  it('reports skill count for detected agent', async () => {
+    await mkdir(join(tempDir, '.agents', 'skills'), { recursive: true })
+    await mkdir(join(tempDir, '.agents', 'skills', 'test-skill'), { recursive: true })
+
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('1 skill(s)')))
+  })
+
+  it('reports skills from global lockfile', async () => {
+    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
+      version: 3, skills: {
+        'test/my-skill': { slug: 'test/my-skill', contentSha: 'abc123' },
+      }, dismissed: {}, lastSelectedAgents: [],
+    }))
+
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('1 skill(s) tracked')))
+  })
+
+  it('reports missing skill directories in integrity check', async () => {
+    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
+      version: 3, skills: {
+        'test/missing-skill': { slug: 'test/missing-skill', contentSha: 'abc123' },
+      }, dismissed: {}, lastSelectedAgents: [],
+    }))
+
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('missing director')))
+  })
+
+  it('reports project lockfile skills', async () => {
+    await mkdir(join(tempDir, '.agents'), { recursive: true })
+    await mkdir(join(tempDir, '.agents', 'skills'), { recursive: true })
+    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
+      version: 3, skills: {}, dismissed: {}, lastSelectedAgents: [],
+    }))
+
+    const projectDir = join(tempDir, 'my-project')
+    await mkdir(join(projectDir, '.agents'), { recursive: true })
+    await writeFile(join(projectDir, '.agents', '.skill-lock.json'), JSON.stringify({
+      version: 3, skills: {
+        'project/my-skill': { slug: 'project/my-skill', contentSha: 'def456' },
+      }, dismissed: {}, lastSelectedAgents: [],
+    }))
+
+    const origCwd = process.cwd()
+    process.chdir(projectDir)
+
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+      process.chdir(origCwd)
+    }
+    assert.ok(logs.some(l => l.includes('Project lockfile')))
+  })
+})


### PR DESCRIPTION
## Summary

Adds `rolecraft doctor` — a system health check command that diagnoses common issues in one shot.

## Checks performed

- **Node.js version** — verifies >= 20
- **rolecraft version** — shows current installed version
- **Home directory** — confirms HOME is set
- **~/.agents directory** — checks if the global agents directory exists
- **Global lockfile** — reads and counts tracked skills
- **Project lockfile** — reads project-scoped lockfile (if any)
- **Agent detection** — finds all installed AI agents and their skill counts
- **Skill integrity** — verifies skill directories exist and content hashes match lockfile

## Documentation updated

- `docs/commands/doctor.md` — usage guide with example output
- `docs/architecture.md` — added doctor.js to project tree
- `docs/comparison.md` — marked ✅ for rolecraft, updated agent counts, fixed security scanning row
- `docs/ANALYSIS.md` — moved doctor from ❌ Next to ✅ Done, updated competitor gaps
- `SKILL.md` — added doctor to commands table and quick start
- `README.md` — added doctor to features, commands table, and comparison table
- `bin/rolecraft.js` — registered doctor command
- `src/commands/completions.js` — added doctor to shell completions