### PR TITLE
feat: add 16 new agent targets, surpass Vercel (82 vs 72 agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 </p>
 
 <p align="center">
-  Works with <b>65+ AI agents</b>: opencode · claude-code · cursor · windsurf · devin · codex · copilot · aider · cline · gemini-cli · cody · continue · warp · codeium · fabric · goose · tabnine · supermaven · pr-pilot · loom · roo · trae · hermes · kiro · augment · kilo · openhands · junie · factory · command-code · cortex · mistral-vibe · qwen-code · openclaw · codebuddy · mux · pi · autohand-code · rovo · firebender · bob · aider-desk · and more
+  Works with <b>82+ AI agents</b>: opencode · claude-code · cursor · windsurf · devin · codex · copilot · aider · cline · gemini-cli · cody · continue · warp · codeium · fabric · goose · tabnine · supermaven · pr-pilot · loom · roo · trae · hermes · kiro · augment · kilo · openhands · junie · factory · command-code · cortex · mistral-vibe · qwen-code · openclaw · codebuddy · mux · pi · autohand-code · rovo · firebender · bob · aider-desk · and more
 </p>
 
 <p align="center">
@@ -77,7 +77,7 @@ rolecraft check
 rolecraft remove my-skill
 ```
 
-**Requirements:** Node.js >= 20 · No other dependencies · 65+ agents supported · [Full install guide →](docs/install.md)
+**Requirements:** Node.js >= 20 · No other dependencies · 82+ agents supported · [Full install guide →](docs/install.md)
 
 ---
 
@@ -85,7 +85,7 @@ rolecraft remove my-skill
 
 - **Zero dependencies** — ~4 KB, no bloat
 - **Any source** — local folder, GitHub/GitLab/Bitbucket repo, SSH git URL, npm package
-- **66+ agents** — opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more
+- **82+ agents** — opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more
 - **skills.sh compatible** — installable via `npx skills add sametcelikbicak/rolecraft`
 - **No registry required** — no signup, no marketplace, no vendor lock-in
 - **Security scoring** — static analysis on install: detects prompt injection, command injection, obfuscated code, credential harvesting, and sensitive file access. Scores 0–100. Blocks dangerous skills unless `--yes`
@@ -135,7 +135,7 @@ rolecraft remove my-skill
 | GitHub repo install                  | ✅               | ✅              | ❌                  |
 | GitLab / SSH git URL                 | ✅               | ✅              | ❌                  |
 | npm package source                   | ✅               | ✅              | ❌                  |
-| Agent targets                        | **66**           | 72              | 15+                 |
+| Agent targets                        | **82**           | 72              | 15+                 |
 | Skills.sh listed                     | ✅               | ✅              | ⚠️ (registry only)  |
 | Bundle install + create              | ✅               | ❌              | ✅ (skillset only)  |
 | Interactive TUI search + install     | ✅               | ✅              | ❌                  |

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,12 +2,12 @@
 name: rolecraft
 description: >-
   Install AI agent skills as roles & behaviors from any source — local folder,
-  GitHub, GitLab, SSH git URL. Zero-dependency CLI with 66+ agent targets.
+  GitHub, GitLab, SSH git URL. Zero-dependency CLI with 82+ agent targets.
 ---
 
 # rolecraft
 
-Install and manage AI agent skills across 66+ agents with a single command. Zero dependencies. No registry required.
+Install and manage AI agent skills across 82+ agents with a single command. Zero dependencies. No registry required.
 
 ## When to use
 
@@ -75,7 +75,7 @@ npx rolecraft list
 | `--symlink` | Symlink instead of copy |
 | `--global` / `--project` | Scope selection |
 
-## Supported agents (66+)
+## Supported agents (82+)
 
 `opencode`, `claude-code`, `cursor`, `windsurf`, `devin`, `codex`, `copilot`, `aider`, `cline`, `gemini-cli`, `cody`, `continue`, `warp`, `codeium`, `fabric`, `goose`, `tabnine`, `supermaven`, `pr-pilot`, `loom`, `roo`, `trae`, `hermes`, `kiro`, `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, `cortex`, `mistral-vibe`, `qwen-code`, `openclaw`, `codebuddy`, `mux`, `pi`, `autohand-code`, `rovo`, `firebender`, `bob`, `aider-desk`, and 25+ more.
 

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -27,7 +27,7 @@ function usage() {
 rolecraft — Install AI agent skills like roles & behaviors
 
 Zero dependencies, no marketplace required.
-Works with 65+ agents: opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo, firebender, bob, aider-desk, code-arts-doer, code-maker, code-studio, crush, eve, forge, inference-sh, jazz, iflow, kilo-code, kode, lingma, mcp-jam, moxby, ona, qoder, reasonix, terra-mind, tiny-cloud, zencoder, and all spec-compliant agents.
+Works with 82+ agents: opencode, claude-code, cursor, windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody, continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot, loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo, firebender, bob, aider-desk, code-arts-doer, code-maker, code-studio, crush, eve, forge, inference-sh, jazz, iflow, kilo-code, kode, lingma, mcp-jam, moxby, ona, qoder, reasonix, terra-mind, tiny-cloud, zencoder, amp, antigravity, antigravity-cli, deepagents, dexto, loaf, replit, zed, promptscript, astrbot, qoder-cn, trae-cn, zenflow, neovate, pochi, adal, and all spec-compliant agents.
 
 Usage:
   rolecraft install <source>     Install a skill (local path, owner/repo, or npm:package)
@@ -140,6 +140,9 @@ export async function main() {
       const scopeFlags = ['--global', '--project', '--claude', '--cursor', '--windsurf', '--devin', '--codex', '--copilot', '--aider', '--cline', '--gemini', '--cody', '--continue', '--warp', '--codeium', '--fabric', '--goose', '--tabnine', '--supermaven', '--pr-pilot', '--loom', '--roo', '--trae', '--hermes', '--kiro', '--augment', '--kilo', '--openhands', '--junie', '--factory', '--command-code', '--cortex', '--mistral-vibe', '--qwen-code', '--openclaw', '--codebuddy',
   '--mux', '--pi', '--autohand-code', '--rovo', '--firebender', '--bob', '--aider-desk',
   '--code-arts-doer', '--code-maker', '--code-studio', '--crush', '--eve', '--forge', '--inference-sh', '--jazz', '--iflow', '--kilo-code', '--kode', '--lingma', '--mcp-jam', '--moxby', '--ona', '--qoder', '--reasonix', '--terra-mind', '--tiny-cloud', '--zencoder',
+  '--amp', '--antigravity', '--antigravity-cli', '--deepagents', '--dexto',
+  '--loaf', '--replit', '--zed', '--promptscript',
+  '--astrbot', '--qoder-cn', '--trae-cn', '--zenflow', '--neovate', '--pochi', '--adal',
   '--all']
       const hasScopeFlag = flags.some(f => scopeFlags.includes(f))
       const options = hasScopeFlag ? {
@@ -205,6 +208,22 @@ export async function main() {
         'terra-mind': flags.includes('--terra-mind') || flags.includes('--all'),
         'tiny-cloud': flags.includes('--tiny-cloud') || flags.includes('--all'),
         zencoder: flags.includes('--zencoder') || flags.includes('--all'),
+        amp: flags.includes('--amp') || flags.includes('--all'),
+        antigravity: flags.includes('--antigravity') || flags.includes('--all'),
+        'antigravity-cli': flags.includes('--antigravity-cli') || flags.includes('--all'),
+        deepagents: flags.includes('--deepagents') || flags.includes('--all'),
+        dexto: flags.includes('--dexto') || flags.includes('--all'),
+        loaf: flags.includes('--loaf') || flags.includes('--all'),
+        replit: flags.includes('--replit') || flags.includes('--all'),
+        zed: flags.includes('--zed') || flags.includes('--all'),
+        promptscript: flags.includes('--promptscript') || flags.includes('--all'),
+        astrbot: flags.includes('--astrbot') || flags.includes('--all'),
+        'qoder-cn': flags.includes('--qoder-cn') || flags.includes('--all'),
+        'trae-cn': flags.includes('--trae-cn') || flags.includes('--all'),
+        zenflow: flags.includes('--zenflow') || flags.includes('--all'),
+        neovate: flags.includes('--neovate') || flags.includes('--all'),
+        pochi: flags.includes('--pochi') || flags.includes('--all'),
+        adal: flags.includes('--adal') || flags.includes('--all'),
         project: flags.includes('--project') || flags.includes('--all'),
       } : {}
       options.frozenLockfile = flags.includes('--frozen-lockfile')

--- a/docs/ANALYSIS.md
+++ b/docs/ANALYSIS.md
@@ -12,7 +12,7 @@
 | **Lockfile**                 | agentskill v3                     | Two-tier (global v3 + project v1, SHA) | None                     | None           | None               | ✅                | None            | Config only                |
 | **Offline capable**          | ✅                                | ✅                                     | ❌ (registry)            | ✅             | ✅                 | ✅                | ✅              | ✅                         |
 | **Signup required**          | ❌                                | ❌                                     | ✅ (agentskill.sh)       | ❌             | ❌                 | ❌                | ❌              | ❌                         |
-| **Agent count**              | **66**                            | 72                                     | 15+                      | 10+            | 10+                | 39                | 1 (+ compat)    | 1 (+ plugins)              |
+| **Agent count**              | **82**                            | 72                                     | 15+                      | 10+            | 10+                | 39                | 1 (+ compat)    | 1 (+ plugins)              |
 | **Project scope default**    | ✅                                | ✅                                     | N/A                      | ❌ (global)    | ✅ (project)       | ✅                | N/A             | N/A                        |
 | **Interactive scope prompt** | ✅                                | ✅                                     | ❌                       | ❌             | ❌                 | ❌                | N/A             | N/A                        |
 | **Provenance (npm)**         | ✅                                | ❌                                     | ❌                       | ❌             | ❌                 | ❌                | N/A             | N/A                        |
@@ -45,7 +45,7 @@
 - **agentskill.sh lockfile compatible** — cross-compatible with ecosystem
 - **Interactive scope prompt** — user-friendly first install
 - **Project scope default** — modern default
-- **66 install targets** — 65 named agents + project-local
+- **82 install targets** — 81 named agents + project-local
 - **SHA256 content hash verification** — `rolecraft verify`
 - **CI mode** — `rolecraft ci` for pipeline installs
 - **Symlink + Copy modes** — `--symlink`/`--copy`
@@ -60,7 +60,7 @@
 
 ### Feature gaps vs competitors
 
-1. **Agent count (66)** — ahead of `ags` (15+), `openskills` (10+), `skills-npm` (10+), `qntx/skill` (39) but behind `skills` (72)
+1. ~~Agent count (66)~~ — **now 82**, surpassing Vercel's 72
 2. **Security scoring (done)** — matches `ags` 0–100 scoring, `skills` Snyk audit. rolecraft: zero-dep static analysis with prompt injection, command injection, obfuscated code, credential harvesting, and sensitive file access detection.
 3. **No AGENTS.md XML injection** — `openskills` generates Claude Code compatible `<available_skills>` XML
 4. **Stars / community adoption very low** — building trust and visibility
@@ -86,8 +86,7 @@
 - **Stars**: 23.5K | **Deps**: 1 | **Agents**: 55+
 - **Key features**: `skills use`, `skills ci`/`skills verify` (lockfile workflow), `skills find` (interactive TUI), `skills init`, symlink mode, `vercel skills` built-in, 13.4M weekly downloads, skills.sh directory
 - **Weaknesses**: 1 dep (`yaml`), no provenance, no `setup` command, no dry-run, no bundle
-- **rolecraft advantage**: Zero deps, provenance, `setup` command, dry-run, bundle, doctor
-- **rolecraft gap**: Agent count (66 vs 72)
+- **rolecraft advantage**: Zero deps, provenance, `setup` command, dry-run, bundle, doctor, **highest agent count (82 vs 72)**
 
 ### @agentskill.sh/cli (ags)
 
@@ -95,7 +94,7 @@
 - **Stars**: 23 | **Deps**: 2 | **Agents**: 15+
 - **Key features**: 274K+ skills in marketplace, security scoring (0-100), `/learn` in-agent command, feedback loop (1-5 rating), `ags setup` auto-detection
 - **Weaknesses**: Requires signup, no lockfile, no offline, no local sources, no provenance
-- **rolecraft advantage**: Zero deps, offline-first, lockfile, provenance, local sources, 66 agents
+- **rolecraft advantage**: Zero deps, offline-first, lockfile, provenance, local sources, 82 agents
 
 ### openskills (numman-ali)
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -70,6 +70,22 @@ rolecraft knows where each AI agent looks for skills. When you use a flag like `
 | terra-mind      | `~/.terramind/skills/`                            |
 | tiny-cloud      | `~/.tinycloud/skills/`                            |
 | zencoder        | `~/.zencoder/skills/`                             |
+| amp             | `~/.agents/skills/`                               |
+| antigravity     | `~/.agents/skills/`                               |
+| antigravity-cli | `~/.agents/skills/`                               |
+| deep-agents     | `~/.agents/skills/`                               |
+| dexto           | `~/.agents/skills/`                               |
+| loaf            | `~/.agents/skills/`                               |
+| replit          | `~/.agents/skills/`                               |
+| zed             | `~/.agents/skills/`                               |
+| promptscript    | `./agent/skills/`                                 |
+| astrbot         | `~/.astrbot/data/skills/`                         |
+| qoder-cn        | `~/.qoder-cn/skills/`                             |
+| trae-cn         | `~/.trae-cn/skills/`                              |
+| zenflow         | `~/.zencoder/skills/`                             |
+| neovate         | `~/.neovate/skills/`                              |
+| pochi           | `~/.pochi/skills/`                                |
+| adal            | `~/.adal/skills/`                                 |
 
 > ⚠️ Windsurf has been rebranded to **Devin Desktop**. The `--windsurf` flag and `~/.windsurf/skills/` path still work for backward compatibility, but new deployments should use `--devin` / `~/.devin/skills/`.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -9,7 +9,7 @@
 | GitHub repo install                      | ✅               | ✅                | ❌                  |
 | GitLab / SSH git URL                     | ✅               | ✅                | ❌                  |
 | npm package source                       | ✅               | ✅                | ❌                  |
-| Agent targets                            | **66**           | **72**            | 15+                 |
+| Agent targets                            | **82**           | **72**            | 15+                 |
 | SKILL.md scaffolding (`init`)            | ✅               | ✅                | ❌                  |
 | Skill preview (`use`)                    | ✅               | ✅                | ❌                  |
 | Agent auto-detect + install (`setup`)    | ✅               | ❌                | ✅                  |

--- a/src/commands/completions.js
+++ b/src/commands/completions.js
@@ -15,6 +15,9 @@ const SCOPE_FLAGS = [
   '--codebuddy', '--mux', '--pi', '--autohand-code', '--rovo', '--firebender',
   '--bob', '--aider-desk',
   '--zap', '--codeep', '--kimi-code', '--zcode',
+  '--amp', '--antigravity', '--antigravity-cli', '--deepagents', '--dexto',
+  '--loaf', '--replit', '--zed', '--promptscript',
+  '--astrbot', '--qoder-cn', '--trae-cn', '--zenflow', '--neovate', '--pochi', '--adal',
   '--all',
 ]
 

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,7 +1,7 @@
 import { accessSync, readdirSync, constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir } from '../utils/lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir, getAstrbotDir, getQoderCnDir, getTraeCnDir, getZenflowDir, getNeovateDir, getPochiDir, getAdalDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 
@@ -72,6 +72,22 @@ const KNOWN_AGENTS = [
   { flag: 'codeep', label: 'codeep', dir: getCodeepDir },
   { flag: 'kimi-code', label: 'kimi-code', dir: getKimiCodeDir },
   { flag: 'zcode', label: 'zcode', dir: getZCodeDir },
+  { flag: 'amp', label: 'amp', dir: getAgentsDir },
+  { flag: 'antigravity', label: 'antigravity', dir: getAgentsDir },
+  { flag: 'antigravity-cli', label: 'antigravity-cli', dir: getAgentsDir },
+  { flag: 'deepagents', label: 'deep-agents', dir: getAgentsDir },
+  { flag: 'dexto', label: 'dexto', dir: getAgentsDir },
+  { flag: 'loaf', label: 'loaf', dir: getAgentsDir },
+  { flag: 'replit', label: 'replit', dir: getAgentsDir },
+  { flag: 'zed', label: 'zed', dir: getAgentsDir },
+  { flag: 'promptscript', label: 'promptscript', dir: getEveDir },
+  { flag: 'astrbot', label: 'astrbot', dir: getAstrbotDir },
+  { flag: 'qoder-cn', label: 'qoder-cn', dir: getQoderCnDir },
+  { flag: 'trae-cn', label: 'trae-cn', dir: getTraeCnDir },
+  { flag: 'zenflow', label: 'zenflow', dir: getZenflowDir },
+  { flag: 'neovate', label: 'neovate', dir: getNeovateDir },
+  { flag: 'pochi', label: 'pochi', dir: getPochiDir },
+  { flag: 'adal', label: 'adal', dir: getAdalDir },
 ]
 
 export function detectAgents() {
@@ -105,7 +121,8 @@ export async function setupCommand(source, options = {}) {
     console.log('   windsurf, devin, codex, copilot, aider, cline, gemini-cli, cody,')
     console.log('   continue, warp, codeium, fabric, goose, tabnine, supermaven, pr-pilot,')
     console.log('   loom, roo, trae, hermes, kiro, augment, kilo, openhands, junie, factory, command-code, cortex, mistral-vibe, qwen-code, openclaw, codebuddy, mux, pi, autohand-code, rovo-dev, firebender, ibm-bob, aider-desk, code-arts-doer, code-maker, code-studio,')
-    console.log('   crush, eve, forge, inference-sh, jazz, iflow, kilo-code, kode, lingma, mcp-jam, moxby, ona, qoder, reasonix, terra-mind, tiny-cloud, zencoder) first.')
+    console.log('   crush, eve, forge, inference-sh, jazz, iflow, kilo-code, kode, lingma, mcp-jam, moxby, ona, qoder, reasonix, terra-mind, tiny-cloud, zencoder,')
+    console.log('   amp, antigravity, antigravity-cli, deepagents, dexto, loaf, replit, zed, promptscript, astrbot, qoder-cn, trae-cn, zenflow, neovate, pochi, adal) first.')
     return
   }
 

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -1,4 +1,4 @@
-import { readLock, getProjectLockPath, computeContentHash, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getDevinDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir } from '../utils/lockfile.js'
+import { readLock, getProjectLockPath, computeContentHash, getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getDevinDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir, getAstrbotDir, getQoderCnDir, getTraeCnDir, getZenflowDir, getNeovateDir, getPochiDir, getAdalDir } from '../utils/lockfile.js'
 import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createHash } from 'node:crypto'
@@ -70,6 +70,22 @@ const agentDirMap = {
   'codeep': getCodeepDir,
   'kimi-code': getKimiCodeDir,
   'zcode': getZCodeDir,
+  'amp': getAgentsDir,
+  'antigravity': getAgentsDir,
+  'antigravity-cli': getAgentsDir,
+  'deep-agents': getAgentsDir,
+  'dexto': getAgentsDir,
+  'loaf': getAgentsDir,
+  'replit': getAgentsDir,
+  'zed': getAgentsDir,
+  'promptscript': getEveDir,
+  'astrbot': getAstrbotDir,
+  'qoder-cn': getQoderCnDir,
+  'trae-cn': getTraeCnDir,
+  'zenflow': getZenflowDir,
+  'neovate': getNeovateDir,
+  'pochi': getPochiDir,
+  'adal': getAdalDir,
 }
 
 async function readFilesFromDir(dir) {

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -1,6 +1,6 @@
 import { mkdir, cp, writeFile, stat, symlink, rm } from 'node:fs/promises'
 import { join, relative, dirname } from 'node:path'
-import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir, addSkillToLock, getGlobalLockPath, getProjectLockPath, computeFileHashes } from './lockfile.js'
+import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir, getAstrbotDir, getQoderCnDir, getTraeCnDir, getZenflowDir, getNeovateDir, getPochiDir, getAdalDir, addSkillToLock, getGlobalLockPath, getProjectLockPath, computeFileHashes } from './lockfile.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -73,6 +73,22 @@ const targetToAgentName = {
   codeep: 'codeep',
   'kimi-code': 'kimi-code',
   zcode: 'zcode',
+  amp: 'amp',
+  antigravity: 'antigravity',
+  'antigravity-cli': 'antigravity-cli',
+  deepagents: 'deep-agents',
+  dexto: 'dexto',
+  loaf: 'loaf',
+  replit: 'replit',
+  zed: 'zed',
+  promptscript: 'promptscript',
+  astrbot: 'astrbot',
+  'qoder-cn': 'qoder-cn',
+  'trae-cn': 'trae-cn',
+  zenflow: 'zenflow',
+  neovate: 'neovate',
+  pochi: 'pochi',
+  adal: 'adal',
 }
 
 export async function installSkill(resolved, targets, mode = 'copy') {
@@ -414,6 +430,41 @@ export async function installSkill(resolved, targets, mode = 'copy') {
       case 'zcode': {
         baseDir = getZCodeDir()
         label = '~/.zcode/skills/'
+        break
+      }
+      case 'astrbot': {
+        baseDir = getAstrbotDir()
+        label = '~/.astrbot/data/skills/'
+        break
+      }
+      case 'qoder-cn': {
+        baseDir = getQoderCnDir()
+        label = '~/.qoder-cn/skills/'
+        break
+      }
+      case 'trae-cn': {
+        baseDir = getTraeCnDir()
+        label = '~/.trae-cn/skills/'
+        break
+      }
+      case 'zenflow': {
+        baseDir = getZenflowDir()
+        label = '~/.zencoder/skills/'
+        break
+      }
+      case 'neovate': {
+        baseDir = getNeovateDir()
+        label = '~/.neovate/skills/'
+        break
+      }
+      case 'pochi': {
+        baseDir = getPochiDir()
+        label = '~/.pochi/skills/'
+        break
+      }
+      case 'adal': {
+        baseDir = getAdalDir()
+        label = '~/.adal/skills/'
         break
       }
       case 'project': {

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -699,4 +699,60 @@ describe('installer', () => {
     const skillDir = join(process.env.HOME, '.zcode', 'skills', 'test-my-skill')
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
+
+  it('installs skill to astrbot directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['astrbot'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'astrbot')
+    const skillDir = join(process.env.HOME, '.astrbot', 'data', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to qoder-cn directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['qoder-cn'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'qoder-cn')
+    const skillDir = join(process.env.HOME, '.qoder-cn', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to trae-cn directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['trae-cn'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'trae-cn')
+    const skillDir = join(process.env.HOME, '.trae-cn', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to zenflow directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['zenflow'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'zenflow')
+    const skillDir = join(process.env.HOME, '.zencoder', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to neovate directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['neovate'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'neovate')
+    const skillDir = join(process.env.HOME, '.neovate', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to pochi directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['pochi'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'pochi')
+    const skillDir = join(process.env.HOME, '.pochi', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to adal directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['adal'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'adal')
+    const skillDir = join(process.env.HOME, '.adal', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
 })

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -278,6 +278,34 @@ export function getZencoderDir() {
   return home('.zencoder', 'skills')
 }
 
+export function getAstrbotDir() {
+  return home('.astrbot', 'data', 'skills')
+}
+
+export function getQoderCnDir() {
+  return home('.qoder-cn', 'skills')
+}
+
+export function getTraeCnDir() {
+  return home('.trae-cn', 'skills')
+}
+
+export function getZenflowDir() {
+  return home('.zencoder', 'skills')
+}
+
+export function getNeovateDir() {
+  return home('.neovate', 'skills')
+}
+
+export function getPochiDir() {
+  return home('.pochi', 'skills')
+}
+
+export function getAdalDir() {
+  return home('.adal', 'skills')
+}
+
 export function getProjectLockPath(cwd) {
   return join(cwd, '.agents', '.skill-lock.json')
 }

--- a/src/utils/lockfile.test.js
+++ b/src/utils/lockfile.test.js
@@ -89,6 +89,34 @@ describe('lockfile', () => {
     assert.equal(lockModule.getCopilotDir(), join(tempDir, '.copilot', 'skills'))
   })
 
+  it('getAstrbotDir returns path inside homedir', () => {
+    assert.equal(lockModule.getAstrbotDir(), join(tempDir, '.astrbot', 'data', 'skills'))
+  })
+
+  it('getQoderCnDir returns path inside homedir', () => {
+    assert.equal(lockModule.getQoderCnDir(), join(tempDir, '.qoder-cn', 'skills'))
+  })
+
+  it('getTraeCnDir returns path inside homedir', () => {
+    assert.equal(lockModule.getTraeCnDir(), join(tempDir, '.trae-cn', 'skills'))
+  })
+
+  it('getZenflowDir returns path inside homedir', () => {
+    assert.equal(lockModule.getZenflowDir(), join(tempDir, '.zencoder', 'skills'))
+  })
+
+  it('getNeovateDir returns path inside homedir', () => {
+    assert.equal(lockModule.getNeovateDir(), join(tempDir, '.neovate', 'skills'))
+  })
+
+  it('getPochiDir returns path inside homedir', () => {
+    assert.equal(lockModule.getPochiDir(), join(tempDir, '.pochi', 'skills'))
+  })
+
+  it('getAdalDir returns path inside homedir', () => {
+    assert.equal(lockModule.getAdalDir(), join(tempDir, '.adal', 'skills'))
+  })
+
   it('readLock returns default when no file exists', async () => {
     const lock = await lockModule.readLock()
     assert.deepEqual(lock, {


### PR DESCRIPTION
## Summary

Adds 16 new agent targets to rolecraft, bringing the total from **66 → 82**, surpassing Vercel's 72.

## New agents

| Flag | Agent | Path |
|------|-------|------|
| `--amp` | Amp | `~/.agents/skills` (universal) |
| `--antigravity` | Antigravity | `~/.agents/skills` (universal) |
| `--antigravity-cli` | Antigravity CLI | `~/.agents/skills` (universal) |
| `--deepagents` | Deep Agents | `~/.agents/skills` (universal) |
| `--dexto` | Dexto | `~/.agents/skills` (universal) |
| `--loaf` | Loaf | `~/.agents/skills` (universal) |
| `--replit` | Replit | `~/.agents/skills` (universal) |
| `--zed` | Zed Text Editor | `~/.agents/skills` (universal) |
| `--promptscript` | PromptScript | `./agent/skills` (project) |
| `--astrbot` | AstrBot | `~/.astrbot/data/skills` |
| `--qoder-cn` | Qoder CN | `~/.qoder-cn/skills` |
| `--trae-cn` | Trae CN | `~/.trae-cn/skills` |
| `--zenflow` | Zenflow | `~/.zencoder/skills` |
| `--neovate` | Neovate | `~/.neovate/skills` |
| `--pochi` | Pochi | `~/.pochi/skills` |
| `--adal` | AdaL | `~/.adal/skills` |

## Files modified

- `src/utils/lockfile.js` — 7 new getDir functions
- `src/utils/lockfile.test.js` — 7 tests for new getDir functions
- `src/utils/installer.js` — 16 entries in targetToAgentName, 7 new switch cases
- `src/utils/installer.test.js` — 7 tests for new agent install paths
- `src/commands/setup.js` — 16 entries in KNOWN_AGENTS
- `src/commands/verify.js` — 16 entries in agentDirMap
- `bin/rolecraft.js` — 16 new scope flags, usage text updated
- `src/commands/completions.js` — 16 new flags in SCOPE_FLAGS
- `docs/agents.md` — new agent paths table
- `docs/comparison.md` — 82 vs 72
- `docs/ANALYSIS.md` — agent count gap closed
- `SKILL.md` — 82+ agents
- `README.md` — 82+ agents

## Tests

367 tests pass (was 353, +14 new)