### PR TITLE
fix: add missing return after process.exit in frozenLockfile, update, and remove

### DIFF
--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -60,6 +60,7 @@ export async function installCommand(source, options) {
     if (existing) {
       console.error(`Skill "${slug}" already installed. Use \`rolecraft update ${slug}\` to update or omit --frozen-lockfile to overwrite.`)
       process.exit(1)
+      return
     }
   }
 

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -28,6 +28,7 @@ export async function removeCommand(slug) {
   if (!globalFound && !projectFound) {
     console.error(`Skill "${slug}" not found.`)
     process.exit(1)
+    return
   }
 
   const actualSlug = globalFound || projectFound

--- a/src/commands/update.js
+++ b/src/commands/update.js
@@ -237,6 +237,7 @@ export async function updateCommand(slug) {
   } else {
     console.error(`Skill "${slug}" not found.`)
     process.exit(1)
+    return
   }
 
   const targets = detectTargets(actualSlug, process.cwd())


### PR DESCRIPTION
Closes #64
Fixes the same pattern identified in PR #62 review — missing `return` after `process.exit()` so execution doesn't continue when `process.exit` is stubbed in tests.\n\n**Files changed:**\n- `src/commands/install.js:63` — `frozenLockfile` block\n- `src/commands/update.js:240` — skill not found\n- `src/commands/remove.js:31` — skill not found