### PR TITLE
feat: MCP server management for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # rolecraft — Development Guidelines
 
+> 📖 Agent discovery paths are in [`docs/agents.md`](./docs/agents.md)
+
 ## ⚠️ STARTUP CHECKLIST (read before every task)
 
 1. `git checkout main && git pull` — start from latest main

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ rolecraft remove my-skill
 - **Dry-run mode** — preview before installing
 - **System health check** — `rolecraft doctor` diagnoses Node.js, agent directories, lockfiles, and skill integrity
 - **AGENTS.md XML generation** — `rolecraft agents-xml` generates Claude Code-compatible `<skills_system>` XML for agent discovery
+- **MCP server management** — `rolecraft mcp` installs, lists, and removes MCP servers alongside skills
 
 ---
 
@@ -136,6 +137,7 @@ rolecraft remove my-skill
 | `rolecraft list`                        | Show all installed skills                                | [docs](docs/commands/list.md)        |
 | `rolecraft doctor`                      | Run system health check                                  | [docs](docs/commands/doctor.md)      |
 | `rolecraft agents-xml [--write]`        | Generate skills XML for AGENTS.md                        | [docs](docs/commands/agents-xml.md)  |
+| `rolecraft mcp install/remove/list`     | Install, remove, and list MCP servers for AI agents      | [docs](docs/commands/mcp.md)         |
 | `rolecraft verify`                      | Check installed skill integrity via content hash         | [docs](docs/commands/verify.md)      |
 | `rolecraft ci`                          | Re-install all skills from lockfile (CI mode)            | [docs](docs/commands/ci.md)          |
 | `rolecraft upgrade`                     | Upgrade rolecraft to the latest version                  | [docs](docs/commands/upgrade.md)     |

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -19,6 +19,7 @@ import { completionsCommand } from '../src/commands/completions.js'
 import { upgradeCommand } from '../src/commands/upgrade.js'
 import { doctorCommand } from '../src/commands/doctor.js'
 import { agentsXmlCommand } from '../src/commands/agents-xml.js'
+import { mcpCommand } from '../src/commands/mcp.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -46,6 +47,9 @@ Usage:
   rolecraft ci                   Install all skills from lockfile
   rolecraft completions <shell>  Generate shell completions (bash|zsh|fish)
   rolecraft doctor               Run system health check
+  rolecraft mcp install <source> Install an MCP server (npm:, gh:, or local path)
+  rolecraft mcp list             List configured MCP servers
+  rolecraft mcp remove <name>    Remove an MCP server
   rolecraft agents-xml           Generate skills XML for AGENTS.md
   rolecraft agents-xml --write   Write skills XML to AGENTS.md
   rolecraft upgrade              Upgrade rolecraft to the latest version
@@ -54,6 +58,7 @@ Usage:
 Options:
   --yes, -y     Non-interactive: accept all defaults (install, setup)
   --dry-run      Preview installation without copying files (install, setup, bundle, upgrade)
+  --no-mcp       Skip MCP server installation from skills (install, bundle)
 
 Options for upgrade:
   --dry-run      Check for updates without actually upgrading
@@ -103,6 +108,7 @@ Options for install:
   --bob           Also install to ~/.bob/skills/
   --aider-desk    Also install to ~/.aider-desk/skills/
   --all          Install to all locations
+  --no-mcp       Skip MCP server installation from skill
   --frozen-lockfile  Fail if skill already installed
   --symlink      Install as symlink instead of copy
   --copy         Install as copy (default)
@@ -233,6 +239,7 @@ export async function main() {
       options.symlink = flags.includes('--symlink')
       options.dryRun = flags.includes('--dry-run')
       options.yes = flags.includes('--yes') || flags.includes('-y')
+      options.noMcp = flags.includes('--no-mcp')
 
       await installCommand(source, options)
       break
@@ -367,12 +374,18 @@ export async function main() {
       }
       const flags = args.filter(a => a.startsWith('--'))
       const sources = args.filter(a => !a.startsWith('--'))
-      const opts = { dryRun: flags.includes('--dry-run') }
+      const opts = { dryRun: flags.includes('--dry-run'), noMcp: flags.includes('--no-mcp') }
       if (sources.length === 1) {
         await bundleCommand(sources[0], opts)
       } else {
         await bundleCommand(sources, opts)
       }
+      break
+    }
+
+    case 'mcp': {
+      if (args.includes('--help') || args.includes('-h')) { usage(); return }
+      await mcpCommand(args)
       break
     }
 

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -1,0 +1,53 @@
+# `rolecraft mcp` — MCP Server Management
+
+Install, list, and remove MCP servers for AI agents.
+
+## Usage
+
+```bash
+rolecraft mcp install <source> [options]
+rolecraft mcp list [options]
+rolecraft mcp remove <name> [options]
+```
+
+## Subcommands
+
+### `install`
+
+Install an MCP server from a source.
+
+```bash
+rolecraft mcp install npm:@modelcontextprotocol/github --cursor --claude
+rolecraft mcp install gh:github/github-mcp-server --all
+rolecraft mcp install ./local-server.js --cursor
+rolecraft mcp install npm:@anthropic/postgres-mcp --all --dry-run
+rolecraft mcp install npm:@test/mcp --name my-server --cursor
+```
+
+**Options:**
+- `--name <name>` — Override the server name (default: auto-detected from source)
+- `--dry-run` — Preview without making changes
+- `--agents`, `--cursor`, `--claude`, `--copilot`, `--continue`, etc. — Target specific agents
+- `--all` — Install to all supported MCP agents
+
+### `list`
+
+List configured MCP servers.
+
+```bash
+rolecraft mcp list
+rolecraft mcp list --cursor --claude
+```
+
+### `remove`
+
+Remove an MCP server.
+
+```bash
+rolecraft mcp remove github-mcp-server --cursor
+rolecraft mcp remove postgres --all
+```
+
+## Sources
+
+See [`docs/mcp.md`](../mcp.md) for source type details.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -36,6 +36,7 @@
 | Skill diff / compose                     | ❌               | ❌                | ❌                  |
 | System health check (`doctor`)           | ✅               | ❌                | ❌                  |
 | AGENTS.md XML generation                 | ✅               | ❌                | ❌                  |
+| **MCP server management**                | ✅               | ❌                | ❌                  |
 | Security scanning (0–100)                | ✅               | ✅ (Snyk)         | ✅                  |
 | Telemetry / leaderboard                  | ❌               | ✅                | ❌                  |
 | File size                                | ~4 KB            | ~465 KB           | ~84 KB              |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,126 @@
+# MCP Server Management
+
+rolecraft can install and manage [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers alongside skills. This means you can provision both **behavior** (skills) and **capabilities** (MCP tools) for your AI agents in a single workflow.
+
+## Why MCP + Skills Together?
+
+- **Skill** → changes how an agent behaves (coding rules, style guides, conventions)
+- **MCP** → expands what an agent can do (query databases, call APIs, access GitHub, search the web)
+
+When a `SKILL.md` declares `mcp_servers:` in its frontmatter, `rolecraft install` installs both the skill and its required MCP servers in one command — no manual config editing.
+
+## Quick Start
+
+```bash
+# Install an MCP server from npm to specific agents
+rolecraft mcp install npm:@modelcontextprotocol/github --cursor --claude
+
+# Install an MCP server from GitHub
+rolecraft mcp install gh:github/github-mcp-server --all
+
+# Install from a local path
+rolecraft mcp install ./my-mcp-server --cursor
+
+# List configured MCP servers
+rolecraft mcp list
+
+# Remove an MCP server
+rolecraft mcp remove github-mcp-server --cursor
+```
+
+## Onboarding Example
+
+Suppose your team has three developers using different agents — Cursor, Claude Code, and Windsurf. You want everyone to use the same PostgreSQL conventions **and** have database access via MCP:
+
+### 1. Create a skill with `mcp_servers`
+
+```yaml
+---
+name: my-postgres-rules
+description: Team PostgreSQL style guide
+mcp_servers:
+  - name: github
+    source: gh:github/github-mcp-server
+  - name: postgres
+    source: npm:@anthropic/postgres-mcp
+---
+
+- Always prefer `JOIN` over subqueries
+- `SELECT *` is forbidden
+- All queries must be parameterized
+```
+
+### 2. Install with a single command
+
+```bash
+rolecraft install ./my-postgres-rules --cursor --claude --windsurf
+```
+
+This does **three things** automatically:
+1. **Skill installation** → copies `my-postgres-rules` to `~/.cursor/skills/`, `~/.claude/skills/`, `~/.windsurf/skills/`
+2. **MCP installation** → reads `mcp_servers` from SKILL.md, resolves the sources
+3. **Config wiring** → writes MCP config in each agent's native format:
+   - Cursor: `~/.cursor/mcp.json`
+   - Claude Code: `~/.claude/claude_code.json`
+   - Windsurf: `~/.windsurf/mcp_config.json`
+
+### 3. Each agent can now
+
+- **Follow rules** — never writes `SELECT *`, always uses `JOIN`
+- **Query the database** — via the Postgres MCP server
+- **Access GitHub** — via the GitHub MCP server
+
+### 4. Team onboarding with bundle
+
+```bash
+# Team lead creates a bundle once
+rolecraft bundle create team-onboarding
+
+# Every developer runs
+rolecraft bundle install team-onboarding.json
+# → All skills installed
+# → All MCP servers configured automatically
+# → Each agent's config written in the correct format
+```
+
+## Supported MCP Agents
+
+| Agent | Config File | Format |
+|-------|------------|--------|
+| opencode | `~/.agents/mcp.json` | Standard `mcpServers` object |
+| claude-code | `~/.claude/claude_code.json` | Standard `mcpServers` object |
+| cursor | `~/.cursor/mcp.json` | Standard `mcpServers` object |
+| windsurf | `~/.windsurf/mcp_config.json` | Standard `mcpServers` object |
+| devin | `~/.devin/mcp.json` | Standard `mcpServers` object |
+| codex | `~/.codex/mcp.json` | Standard `mcpServers` object |
+| copilot | `./.github/copilot/.mcp.json` | `{ inputs: [], servers: {} }` |
+| continue | `~/.continue/config.json` | `{ experimental: { mcpServers: [] } }` |
+
+More agents will be added as their MCP standards solidify.
+
+## Source Types
+
+| Source | Example | Description |
+|--------|---------|-------------|
+| `npm:` | `npm:@modelcontextprotocol/github` | Install from npm, runs via `npx -y` |
+| `gh:` | `gh:github/github-mcp-server` | Clone from GitHub, runs via `node` |
+| Local path | `./my-mcp-server/index.js` | Run directly with `node` |
+
+## Commands
+
+See [`docs/commands/mcp.md`](./commands/mcp.md) for the full command reference.
+
+## SKILL.md Integration
+
+When a skill declares `mcp_servers:` in its YAML frontmatter, `rolecraft install` automatically installs those MCP servers to the same agent targets. You don't need to run a separate `rolecraft mcp install` command.
+
+```yaml
+---
+name: my-skill
+mcp_servers:
+  - name: server-name
+    source: npm:@org/mcp-server
+---
+```
+
+If you only want the skill without MCP servers, pass `--no-mcp` during installation.

--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -58,7 +58,7 @@ async function resolveBundleFile(arg) {
   return null
 }
 
-async function installSources(sources, label, options) {
+async function installSources(sources, label, options, noMcp = false) {
   if (sources.length === 0) {
     console.log('No skills to install.')
     return
@@ -76,7 +76,7 @@ async function installSources(sources, label, options) {
     if (options.dryRun) continue
 
     try {
-      await installCommand(source, { ...options, global: true, project: true })
+      await installCommand(source, { global: true, project: true, noMcp: noMcp, dryRun: options.dryRun })
       successCount++
     } catch (err) {
       console.error(`   ❌ ${source}: ${err.message}`)
@@ -142,12 +142,12 @@ export async function bundleCommand(sources, options = {}) {
     if (filePath) {
       const raw = await readFile(filePath, 'utf-8')
       const parsed = parseSources(raw, filePath)
-      await installSources(parsed, ` from ${filePath}`, options)
+      await installSources(parsed, ` from ${filePath}`, options, options.noMcp)
       return
     }
-    await installSources([sources], '', options)
+    await installSources([sources], '', options, options.noMcp)
     return
   }
 
-  await installSources(sources, '', options)
+  await installSources(sources, '', options, options.noMcp)
 }

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -3,6 +3,7 @@ import { stdin as input, stdout as output } from 'node:process'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import { scanSkill, formatSecurityReport } from '../utils/security.js'
+import { parseMcpServersFromSkill, resolveMcpSource, addMcpServer, getSupportedMcpAgents } from '../utils/mcp.js'
 
 let createInterface = defaultCreateInterface
 let askQuestion = defaultAskQuestion
@@ -45,7 +46,7 @@ async function askScope() {
 }
 
 export async function installCommand(source, options) {
-  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline || options.gemini || options.cody || options.continue || options.warp || options.codeium || options.fabric || options.goose || options.tabnine || options.supermaven || options['pr-pilot'] || options.loom || options.roo || options.trae || options.hermes || options.kiro || options.augment || options.kilo || options.openhands || options.junie || options.factory || options['command-code'] || options.cortex || options['mistral-vibe'] || options['qwen-code'] || options.openclaw || options.codebuddy || options.mux || options.pi || options['autohand-code'] || options.rovo || options.firebender || options.bob || options['aider-desk'] || options['code-arts-doer'] || options['code-maker'] || options['code-studio'] || options.crush || options.eve || options.forge || options['inference-sh'] || options.jazz || options.iflow || options['kilo-code'] || options.kode || options.lingma || options['mcp-jam'] || options.moxby || options.ona || options.qoder || options.reasonix || options['terra-mind'] || options['tiny-cloud'] || options.zencoder || options.zap || options.codeep || options['kimi-code'] || options.zcode
+  const hasScopeFlags = options.global || options.project || options.claude || options.cursor || options.windsurf || options.devin || options.codex || options.copilot || options.aider || options.cline || options.gemini || options.cody || options.continue || options.warp || options.codeium || options.fabric || options.goose || options.tabnine || options.supermaven || options['pr-pilot'] || options.loom || options.roo || options.trae || options.hermes || options.kiro || options.augment || options.kilo || options.openhands || options.junie || options.factory || options['command-code'] || options.cortex || options['mistral-vibe'] || options['qwen-code'] || options.openclaw || options.codebuddy || options.mux || options.pi || options['autohand-code'] || options.rovo || options.firebender || options.bob || options['aider-desk'] || options['code-arts-doer'] || options['code-maker'] || options['code-studio'] || options.crush || options.eve || options.forge || options['inference-sh'] || options.jazz || options.iflow || options['kilo-code'] || options.kode || options.lingma || options['mcp-jam'] || options.moxby || options.ona || options.qoder || options.reasonix || options['terra-mind'] || options['tiny-cloud'] || options.zencoder || options.zap || options.codeep || options['kimi-code'] || options.zcode || options.amp || options.antigravity || options['antigravity-cli'] || options.deepagents || options.dexto || options.loaf || options.replit || options.zed || options.promptscript || options.astrbot || options['qoder-cn'] || options['trae-cn'] || options.zenflow || options.neovate || options.pochi || options.adal
   const scope = hasScopeFlags ? options : options.yes ? { global: false, project: true } : await askScope()
 
   if (options.frozenLockfile) {
@@ -160,6 +161,22 @@ export async function installCommand(source, options) {
   if (scope.codeep) targets.push('codeep')
   if (scope['kimi-code']) targets.push('kimi-code')
   if (scope.zcode) targets.push('zcode')
+  if (scope.amp) targets.push('amp')
+  if (scope.antigravity) targets.push('antigravity')
+  if (scope['antigravity-cli']) targets.push('antigravity-cli')
+  if (scope.deepagents) targets.push('deepagents')
+  if (scope.dexto) targets.push('dexto')
+  if (scope.loaf) targets.push('loaf')
+  if (scope.replit) targets.push('replit')
+  if (scope.zed) targets.push('zed')
+  if (scope.promptscript) targets.push('promptscript')
+  if (scope.astrbot) targets.push('astrbot')
+  if (scope['qoder-cn']) targets.push('qoder-cn')
+  if (scope['trae-cn']) targets.push('trae-cn')
+  if (scope.zenflow) targets.push('zenflow')
+  if (scope.neovate) targets.push('neovate')
+  if (scope.pochi) targets.push('pochi')
+  if (scope.adal) targets.push('adal')
   if (scope.project) targets.push('project')
 
   if (options.dryRun) {
@@ -178,5 +195,23 @@ export async function installCommand(source, options) {
   console.log('✅ Installed successfully:\n')
   for (const r of results) {
     console.log(`   ${r.label} → ${r.path}`)
+  }
+
+  if (resolved.content && !options.noMcp) {
+    const mcpServers = parseMcpServersFromSkill(resolved.content)
+    if (mcpServers.length > 0) {
+      console.log(`\n🔧 Skill includes ${mcpServers.length} MCP server(s). Installing...`)
+      const supportedAgents = getSupportedMcpAgents()
+      const mcpTargets = targets.filter(t => t !== 'project' && supportedAgents.includes(t))
+      for (const server of mcpServers) {
+        const resolvedMcp = resolveMcpSource(server.source)
+        let installedCount = 0
+        for (const agent of mcpTargets) {
+          const ok = await addMcpServer(agent, server.name, resolvedMcp)
+          if (ok) installedCount++
+        }
+        console.log(`   ${installedCount}/${mcpTargets.length} agents: MCP server "${server.name}" installed`)
+      }
+    }
   }
 }

--- a/src/commands/install.test.js
+++ b/src/commands/install.test.js
@@ -257,4 +257,46 @@ describe('askScope', () => {
     assert.ok(logs.some(l => l.includes('Installed')))
     restore()
   })
+
+  it('installs MCP servers from SKILL.md mcp_servers', async () => {
+    const mcpSkill = join(tempDir, 'mcp-combo-skill')
+    mkdirSync(mcpSkill, { recursive: true })
+    writeFileSync(join(mcpSkill, 'SKILL.md'), [
+      '---',
+      'slug: test/mcp-combo',
+      'name: mcp-combo-skill',
+      'mcp_servers:',
+      '  - name: my-test-mcp',
+      '    source: npm:@test/combo-mcp',
+      '---',
+    ].join('\n'))
+
+    const { logs, restore } = capture('log')
+    await installModule.installCommand(mcpSkill, { claude: true })
+    restore()
+
+    assert.ok(logs.some(l => l.includes('Installed')))
+    assert.ok(logs.some(l => l.includes('my-test-mcp')))
+  })
+
+  it('--no-mcp skips MCP server installation', async () => {
+    const noMcpSkill = join(tempDir, 'no-mcp-skill')
+    mkdirSync(noMcpSkill, { recursive: true })
+    writeFileSync(join(noMcpSkill, 'SKILL.md'), [
+      '---',
+      'slug: test/no-mcp',
+      'name: no-mcp-skill',
+      'mcp_servers:',
+      '  - name: should-not-install',
+      '    source: npm:@test/skipped',
+      '---',
+    ].join('\n'))
+
+    const { logs, restore } = capture('log')
+    await installModule.installCommand(noMcpSkill, { claude: true, noMcp: true })
+    restore()
+
+    assert.ok(logs.some(l => l.includes('Installed')))
+    assert.ok(!logs.some(l => l.includes('should-not-install')))
+  })
 })

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -1,0 +1,214 @@
+import { addMcpServer, removeMcpServer, updateMcpServer, listMcpServers, getSupportedMcpAgents, resolveMcpSource } from '../utils/mcp.js'
+
+export async function mcpInstallCommand(source, options) {
+  const resolved = resolveMcpSource(source)
+
+  const targets = options.agents && options.agents.length > 0
+    ? options.agents
+    : getSupportedMcpAgents()
+
+  if (options.dryRun) {
+    console.log(`📋 Would install MCP server from: ${source}`)
+    console.log(`   Command: ${resolved.command} ${resolved.args.join(' ')}`)
+    console.log(`   Targets: ${targets.join(', ')}`)
+    return
+  }
+
+  const name = options.name || resolved.packageName || resolved.repo || resolved.path?.split('/').pop() || 'mcp-server'
+
+  const results = []
+  for (const agent of targets) {
+    const success = await addMcpServer(agent, name, resolved)
+    results.push({ agent, name, success })
+    if (success) {
+      console.log(`   ✅ ${agent}: MCP server "${name}" installed`)
+    } else {
+      console.log(`   ⚠️  ${agent}: not supported`)
+    }
+  }
+
+  const succeeded = results.filter(r => r.success).length
+  console.log(`\n✅ Installed MCP server "${name}" to ${succeeded}/${targets.length} agents`)
+  return results
+}
+
+export async function mcpListCommand(options) {
+  const targets = options.agents && options.agents.length > 0
+    ? options.agents
+    : getSupportedMcpAgents()
+
+  let total = 0
+  for (const agent of targets) {
+    const servers = await listMcpServers(agent)
+    if (servers.length > 0) {
+      console.log(`\n${agent}:`)
+      for (const s of servers) {
+        console.log(`   - ${s.name} (${s.command} ${s.args.join(' ')})`)
+        total++
+      }
+    }
+  }
+
+  if (total === 0) {
+    console.log('No MCP servers configured.')
+  }
+}
+
+export async function mcpUpdateCommand(source, options) {
+  const resolved = resolveMcpSource(source)
+
+  const targets = options.agents && options.agents.length > 0
+    ? options.agents
+    : getSupportedMcpAgents()
+
+  if (options.dryRun) {
+    console.log(`📋 Would update MCP server from: ${source}`)
+    console.log(`   Command: ${resolved.command} ${resolved.args.join(' ')}`)
+    console.log(`   Targets: ${targets.join(', ')}`)
+    return
+  }
+
+  const name = options.name || resolved.packageName || resolved.repo || resolved.path?.split('/').pop() || 'mcp-server'
+
+  const results = []
+  for (const agent of targets) {
+    const success = await updateMcpServer(agent, name, resolved)
+    results.push({ agent, name, success })
+    if (success) {
+      console.log(`   ✅ ${agent}: MCP server "${name}" updated`)
+    } else {
+      console.log(`   ⚠️  ${agent}: not supported`)
+    }
+  }
+
+  const succeeded = results.filter(r => r.success).length
+  console.log(`\n✅ Updated MCP server "${name}" on ${succeeded}/${targets.length} agents`)
+  return results
+}
+
+export async function mcpRemoveCommand(name, options) {
+  const targets = options.agents && options.agents.length > 0
+    ? options.agents
+    : getSupportedMcpAgents()
+
+  const results = []
+  for (const agent of targets) {
+    const success = await removeMcpServer(agent, name)
+    results.push({ agent, name, success })
+    if (success) {
+      console.log(`   ✅ ${agent}: MCP server "${name}" removed`)
+    } else {
+      console.log(`   ⚠️  ${agent}: not supported`)
+    }
+  }
+
+  const succeeded = results.filter(r => r.success).length
+  if (succeeded === 0) {
+    console.log(`No MCP server "${name}" found to remove.`)
+  } else {
+    console.log(`\n✅ Removed MCP server "${name}" from ${succeeded}/${targets.length} agents`)
+  }
+  return results
+}
+
+export async function mcpCommand(args) {
+  const subcommand = args[0]
+  const rest = args.slice(1)
+
+  const agentFlags = ['--agents', '--claude', '--cursor', '--windsurf', '--devin', '--codex', '--copilot', '--aider', '--cline', '--gemini', '--cody', '--continue', '--warp', '--codeium', '--fabric', '--goose', '--tabnine', '--supermaven', '--pr-pilot', '--loom', '--roo', '--trae', '--hermes', '--kiro', '--augment', '--kilo', '--openhands', '--junie', '--factory', '--command-code', '--cortex', '--mistral-vibe', '--qwen-code', '--openclaw', '--codebuddy', '--mux', '--pi', '--autohand-code', '--rovo', '--firebender', '--bob', '--aider-desk', '--all']
+
+  const agentMap = {
+    '--agents': 'agents', '--claude': 'claude', '--cursor': 'cursor',
+    '--windsurf': 'windsurf', '--devin': 'devin', '--codex': 'codex',
+    '--copilot': 'copilot', '--aider': 'aider', '--cline': 'cline',
+    '--gemini': 'gemini', '--cody': 'cody', '--continue': 'continue',
+    '--warp': 'warp', '--codeium': 'codeium', '--fabric': 'fabric',
+    '--goose': 'goose', '--tabnine': 'tabnine', '--supermaven': 'supermaven',
+    '--pr-pilot': 'pr-pilot', '--loom': 'loom', '--roo': 'roo',
+    '--trae': 'trae', '--hermes': 'hermes', '--kiro': 'kiro',
+    '--augment': 'augment', '--kilo': 'kilo', '--openhands': 'openhands',
+    '--junie': 'junie', '--factory': 'factory', '--command-code': 'command-code',
+    '--cortex': 'cortex', '--mistral-vibe': 'mistral-vibe', '--qwen-code': 'qwen-code',
+    '--openclaw': 'openclaw', '--codebuddy': 'codebuddy', '--mux': 'mux',
+    '--pi': 'pi', '--autohand-code': 'autohand-code', '--rovo': 'rovo',
+    '--firebender': 'firebender', '--bob': 'bob', '--aider-desk': 'aider-desk',
+  }
+
+  const options = {
+    dryRun: rest.includes('--dry-run'),
+    name: null,
+    agents: [],
+  }
+
+  const nameIdx = rest.indexOf('--name')
+  if (nameIdx >= 0 && nameIdx + 1 < rest.length) {
+    options.name = rest[nameIdx + 1]
+  }
+
+  const hasScopeFlag = rest.some(f => agentFlags.includes(f))
+  if (hasScopeFlag) {
+    for (const [flag, agent] of Object.entries(agentMap)) {
+      if (rest.includes(flag) || rest.includes('--all')) {
+        options.agents.push(agent)
+      }
+    }
+  }
+
+  switch (subcommand) {
+    case 'install': {
+      const source = rest.find(a => !a.startsWith('--'))
+      if (!source) {
+        console.error('Usage: rolecraft mcp install <source> [--name <name>] [--cursor --claude ...]')
+        console.error('Source: npm:package, gh:owner/repo, or local path')
+        process.exit(1)
+      }
+      return mcpInstallCommand(source, options)
+    }
+    case 'list':
+      return mcpListCommand(options)
+    case 'update': {
+      const source = rest.find(a => !a.startsWith('--'))
+      if (!source) {
+        console.error('Usage: rolecraft mcp update <source> [--name <name>] [--cursor --claude ...]')
+        console.error('Source: npm:package, gh:owner/repo, or local path')
+        process.exit(1)
+      }
+      return mcpUpdateCommand(source, options)
+    }
+    case 'remove': {
+      const name = rest.find(a => !a.startsWith('--'))
+      if (!name) {
+        console.error('Usage: rolecraft mcp remove <name> [--cursor --claude ...]')
+        process.exit(1)
+      }
+      return mcpRemoveCommand(name, options)
+    }
+    default:
+      console.log(`
+rolecraft mcp — Manage MCP servers for AI agents
+
+Usage:
+  rolecraft mcp install <source>  Install an MCP server
+  rolecraft mcp list              List configured MCP servers
+  rolecraft mcp update <source>   Update an MCP server (reinstall)
+  rolecraft mcp remove <name>     Remove an MCP server
+
+Sources:
+  npm:package     Install from npm (e.g., npm:@modelcontextprotocol/github)
+  gh:owner/repo   Install from GitHub (e.g., gh:github/github-mcp-server)
+  ./path          Install from local path
+
+Options:
+  --agents, --cursor, --claude, --copilot, etc.  Target specific agents
+  --all                                           Install to all supported agents
+  --name <name>                                   Override server name
+  --dry-run                                       Preview without making changes
+
+Examples:
+  rolecraft mcp install npm:@modelcontextprotocol/github --cursor --claude
+  rolecraft mcp install npm:@anthropic/postgres-mcp --all
+  rolecraft mcp list
+  rolecraft mcp remove github-mcp-server --cursor
+`)
+  }
+}

--- a/src/commands/mcp.test.js
+++ b/src/commands/mcp.test.js
@@ -1,0 +1,275 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, existsSync, readFileSync, rmSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let mcpModule, origHome, tempDir
+
+function capture(stream) {
+  const logs = []
+  const orig = stream === 'log' ? console.log : console.error
+  const fn = (...args) => logs.push(args.join(' '))
+  if (stream === 'log') console.log = fn
+  else console.error = fn
+  return {
+    logs,
+    restore() { if (stream === 'log') console.log = orig; else console.error = orig }
+  }
+}
+
+before(async () => {
+  mcpModule = await import('./mcp.js')
+})
+
+describe('mcp command', () => {
+  describe('mcpInstallCommand', () => {
+    it('installs MCP server from npm: source', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpInstallCommand('npm:@test/my-server', { agents: ['agents'], name: 'my-server' })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('Installed MCP server')))
+      const configPath = join(process.env.HOME, '.agents', 'mcp.json')
+      assert.ok(existsSync(configPath))
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      assert.ok(config.mcpServers['my-server'])
+    }))
+
+    it('installs MCP server to specific agents', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpInstallCommand('npm:@test/db', { agents: ['cursor', 'claude'], name: 'db-mcp' })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('cursor')))
+      assert.ok(logs.some(l => l.includes('claude')))
+
+      const cursorConfig = join(process.env.HOME, '.cursor', 'mcp.json')
+      assert.ok(existsSync(cursorConfig))
+      const ccConfig = join(process.env.HOME, '.claude', 'claude_code.json')
+      assert.ok(existsSync(ccConfig))
+    }))
+
+    it('dry-run does not install anything', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpInstallCommand('npm:@test/dry', { agents: ['agents'], name: 'dry-test', dryRun: true })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('Would install')))
+      const configPath = join(process.env.HOME, '.agents', 'mcp.json')
+      assert.ok(!existsSync(configPath))
+    }))
+
+    it('reports unsupported agents', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpInstallCommand('npm:@test/foo', { agents: ['agents', 'nonexistent'], name: 'foo' })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('not supported')))
+    }))
+  })
+
+  describe('mcpListCommand', () => {
+    it('lists no servers when none configured', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpListCommand({ agents: ['agents'] })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('No MCP servers configured')))
+    }))
+
+    it('lists configured servers', withTempDir(async () => {
+      const addModule = await import('../utils/mcp.js')
+      await addModule.addMcpServer('agents', 'list-test', { command: 'npx', args: ['-y', '@test/list'] })
+
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpListCommand({ agents: ['agents'] })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('list-test')))
+    }))
+  })
+
+  describe('mcpUpdateCommand', () => {
+    it('updates an MCP server', withTempDir(async () => {
+      const addModule = await import('../utils/mcp.js')
+      await addModule.addMcpServer('agents', 'update-me', { command: 'npx', args: ['-y', '@test/old'] })
+
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpUpdateCommand('npm:@test/new', { agents: ['agents'], name: 'update-me' })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('Updated')))
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.agents', 'mcp.json'), 'utf-8'))
+      assert.deepEqual(config.mcpServers['update-me'].args, ['-y', '@test/new'])
+    }))
+
+    it('dry-run does not update', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpUpdateCommand('npm:@test/dry', { agents: ['agents'], name: 'dry-update', dryRun: true })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('Would update')))
+    }))
+
+    it('reports unsupported agents', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpUpdateCommand('npm:@test/foo', { agents: ['agents', 'nonexistent'], name: 'update-foo' })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('not supported')))
+    }))
+  })
+
+  describe('mcpRemoveCommand', () => {
+    it('removes a configured MCP server', withTempDir(async () => {
+      const addModule = await import('../utils/mcp.js')
+      await addModule.addMcpServer('agents', 'to-remove', { command: 'npx', args: ['-y', '@test/remove'] })
+
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpRemoveCommand('to-remove', { agents: ['agents'] })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('Removed')))
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.agents', 'mcp.json'), 'utf-8'))
+      assert.equal(config.mcpServers['to-remove'], undefined)
+    }))
+
+    it('reports when nothing to remove', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpRemoveCommand('nothing-here', { agents: ['agents'] })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('No MCP server')))
+    }))
+
+    it('reports unsupported agents', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpRemoveCommand('foo', { agents: ['nonexistent'] })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('not supported')))
+    }))
+  })
+
+  describe('mcpCommand dispatcher', () => {
+    it('shows help for unknown subcommand', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpCommand(['unknown'])
+      restore()
+      assert.ok(logs.some(l => l.includes('rolecraft mcp')))
+    }))
+
+    it('dispatches install subcommand', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpCommand(['install', 'npm:@test/dispatch', '--agents', 'agents', '--name', 'dispatch-test'])
+      restore()
+      assert.ok(logs.some(l => l.includes('Installed MCP server')))
+      assert.ok(logs.some(l => l.includes('dispatch-test')))
+    }))
+
+    it('exits when install has no source', async () => {
+      const origExit = process.exit
+      let exitCode
+      process.exit = (c) => { exitCode = c; throw new Error('exit') }
+      const { logs, restore } = capture('error')
+      try {
+        await assert.rejects(() => mcpModule.mcpCommand(['install']), /exit/)
+      } finally {
+        process.exit = origExit
+        restore()
+      }
+      assert.equal(exitCode, 1)
+      assert.ok(logs.some(l => l.includes('Usage')))
+    })
+
+    it('dispatches list subcommand', withTempDir(async () => {
+      const addModule = await import('../utils/mcp.js')
+      await addModule.addMcpServer('agents', 'list-me', { command: 'npx', args: ['-y', '@test/list'] })
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpCommand(['list', '--agents', 'agents'])
+      restore()
+      assert.ok(logs.some(l => l.includes('list-me')))
+    }))
+
+    it('dispatches update subcommand', withTempDir(async () => {
+      const addModule = await import('../utils/mcp.js')
+      await addModule.addMcpServer('agents', 'upd-dispatch', { command: 'npx', args: ['-y', '@test/old'] })
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpCommand(['update', 'npm:@test/new', '--agents', 'agents', '--name', 'upd-dispatch'])
+      restore()
+      assert.ok(logs.some(l => l.includes('Updated')))
+    }))
+
+    it('exits when update has no source', async () => {
+      const origExit = process.exit
+      let exitCode
+      process.exit = (c) => { exitCode = c; throw new Error('exit') }
+      const { logs, restore } = capture('error')
+      try {
+        await assert.rejects(() => mcpModule.mcpCommand(['update']), /exit/)
+      } finally {
+        process.exit = origExit
+        restore()
+      }
+      assert.equal(exitCode, 1)
+      assert.ok(logs.some(l => l.includes('Usage')))
+    })
+
+    it('dispatches remove subcommand', withTempDir(async () => {
+      const addModule = await import('../utils/mcp.js')
+      await addModule.addMcpServer('agents', 'rm-dispatch', { command: 'npx', args: ['-y', '@test/rm'] })
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpCommand(['remove', 'rm-dispatch', '--agents', 'agents'])
+      restore()
+      assert.ok(logs.some(l => l.includes('Removed')))
+    }))
+
+    it('exits when remove has no name', async () => {
+      const origExit = process.exit
+      let exitCode
+      process.exit = (c) => { exitCode = c; throw new Error('exit') }
+      const { logs, restore } = capture('error')
+      try {
+        await assert.rejects(() => mcpModule.mcpCommand(['remove']), /exit/)
+      } finally {
+        process.exit = origExit
+        restore()
+      }
+      assert.equal(exitCode, 1)
+      assert.ok(logs.some(l => l.includes('Usage')))
+    })
+
+    it('parses --name flag', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpCommand(['install', 'npm:@test/name-flag', '--agents', 'agents', '--name', 'custom-name'])
+      restore()
+      assert.ok(logs.some(l => l.includes('custom-name')))
+    }))
+
+    it('parses --all flag', withTempDir(async () => {
+      const { logs, restore } = capture('log')
+      await mcpModule.mcpCommand(['install', 'npm:@test/all-flag', '--all'])
+      restore()
+      assert.ok(logs.some(l => l.includes('Installed MCP server')))
+    }))
+  })
+})
+
+function withTempDir(fn) {
+  return async () => {
+    const td = mkdtempSync(join(tmpdir(), 'rolecraft-mcp-cmd-test-'))
+    const origHome = process.env.HOME
+    const origCwd = process.cwd
+    process.env.HOME = td
+    process.cwd = () => td
+    try {
+      await fn(td)
+    } finally {
+      process.env.HOME = origHome
+      process.cwd = origCwd
+      try { rmSync(td, { recursive: true, force: true }) } catch {}
+    }
+  }
+}

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir, getAstrbotDir, getQoderCnDir, getTraeCnDir, getZenflowDir, getNeovateDir, getPochiDir, getAdalDir } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
+import { parseMcpServersFromSkill, resolveMcpSource, addMcpServer, getSupportedMcpAgents } from '../utils/mcp.js'
 
 const KNOWN_AGENTS = [
   { flag: 'agents', label: 'opencode', dir: getAgentsDir },
@@ -167,6 +168,24 @@ export async function setupCommand(source, options = {}) {
     console.log('✅ Installed to all detected agents:\n')
     for (const r of results) {
       console.log(`   ${r.label} → ${r.path}`)
+    }
+
+    if (resolved.content) {
+      const mcpServers = parseMcpServersFromSkill(resolved.content)
+      if (mcpServers.length > 0) {
+        console.log(`\n🔧 Skill includes ${mcpServers.length} MCP server(s). Installing...`)
+        const supported = getSupportedMcpAgents()
+        const mcpTargets = agents.filter(a => supported.includes(a.flag)).map(a => a.flag)
+        for (const server of mcpServers) {
+          const resolvedMcp = resolveMcpSource(server.source)
+          let installedCount = 0
+          for (const agent of mcpTargets) {
+            const ok = await addMcpServer(agent, server.name, resolvedMcp)
+            if (ok) installedCount++
+          }
+          console.log(`   ${installedCount}/${mcpTargets.length} agents: MCP server "${server.name}" installed`)
+        }
+      }
     }
   } else {
     console.log('To install a skill to all detected agents:')

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -467,6 +467,51 @@ export async function installSkill(resolved, targets, mode = 'copy') {
         label = '~/.adal/skills/'
         break
       }
+      case 'amp': {
+        baseDir = getAgentsDir()
+        label = '~/.agents/skills/'
+        break
+      }
+      case 'antigravity': {
+        baseDir = getAgentsDir()
+        label = '~/.agents/skills/'
+        break
+      }
+      case 'antigravity-cli': {
+        baseDir = getAgentsDir()
+        label = '~/.agents/skills/'
+        break
+      }
+      case 'deepagents': {
+        baseDir = getAgentsDir()
+        label = '~/.agents/skills/'
+        break
+      }
+      case 'dexto': {
+        baseDir = getAgentsDir()
+        label = '~/.agents/skills/'
+        break
+      }
+      case 'loaf': {
+        baseDir = getAgentsDir()
+        label = '~/.agents/skills/'
+        break
+      }
+      case 'replit': {
+        baseDir = getAgentsDir()
+        label = '~/.agents/skills/'
+        break
+      }
+      case 'zed': {
+        baseDir = getAgentsDir()
+        label = '~/.agents/skills/'
+        break
+      }
+      case 'promptscript': {
+        baseDir = getEveDir()
+        label = './agent/skills/'
+        break
+      }
       case 'project': {
         baseDir = join(process.cwd(), '.agents', 'skills')
         label = './.agents/skills/'

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -755,4 +755,79 @@ describe('installer', () => {
     const skillDir = join(process.env.HOME, '.adal', 'skills', 'test-my-skill')
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
+
+  it('installs skill to amp directory (~/.agents/skills/)', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['amp'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'amp')
+    const skillDir = join(process.env.HOME, '.agents', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to antigravity directory (~/.agents/skills/)', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['antigravity'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'antigravity')
+    const skillDir = join(process.env.HOME, '.agents', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to antigravity-cli directory (~/.agents/skills/)', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['antigravity-cli'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'antigravity-cli')
+    const skillDir = join(process.env.HOME, '.agents', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to deepagents directory (~/.agents/skills/)', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['deepagents'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'deepagents')
+    const skillDir = join(process.env.HOME, '.agents', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to dexto directory (~/.agents/skills/)', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['dexto'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'dexto')
+    const skillDir = join(process.env.HOME, '.agents', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to loaf directory (~/.agents/skills/)', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['loaf'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'loaf')
+    const skillDir = join(process.env.HOME, '.agents', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to replit directory (~/.agents/skills/)', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['replit'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'replit')
+    const skillDir = join(process.env.HOME, '.agents', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to zed directory (~/.agents/skills/)', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['zed'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'zed')
+    const skillDir = join(process.env.HOME, '.agents', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
+  it('installs skill to promptscript directory (./agent/skills/)', async () => {
+    const origCwd = process.cwd
+    process.cwd = () => tempDir
+    const results = await installerModule.installSkill(resolvedSkill, ['promptscript'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'promptscript')
+    const skillDir = join(tempDir, 'agent', 'skills', 'test-my-skill')
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+    process.cwd = origCwd
+  })
 })

--- a/src/utils/lockfile.test.js
+++ b/src/utils/lockfile.test.js
@@ -117,6 +117,214 @@ describe('lockfile', () => {
     assert.equal(lockModule.getAdalDir(), join(tempDir, '.adal', 'skills'))
   })
 
+  it('getCursorDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCursorDir(), join(tempDir, '.cursor', 'skills'))
+  })
+
+  it('getWindsurfDir returns path inside homedir', () => {
+    assert.equal(lockModule.getWindsurfDir(), join(tempDir, '.windsurf', 'skills'))
+  })
+
+  it('getCodexDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCodexDir(), join(tempDir, '.codex', 'skills'))
+  })
+
+  it('getCopilotProjectDir returns path relative to cwd', () => {
+    assert.equal(lockModule.getCopilotProjectDir(), join(process.cwd(), '.github', 'copilot', 'skills'))
+  })
+
+  it('getAiderDir returns path inside homedir', () => {
+    assert.equal(lockModule.getAiderDir(), join(tempDir, '.aider', 'skills'))
+  })
+
+  it('getClineDir returns path inside homedir', () => {
+    assert.equal(lockModule.getClineDir(), join(tempDir, '.cline', 'skills'))
+  })
+
+  it('getDevinDir returns path inside homedir', () => {
+    assert.equal(lockModule.getDevinDir(), join(tempDir, '.devin', 'skills'))
+  })
+
+  it('getGeminiDir returns path inside homedir', () => {
+    assert.equal(lockModule.getGeminiDir(), join(tempDir, '.gemini', 'skills'))
+  })
+
+  it('getCodyDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCodyDir(), join(tempDir, '.cody', 'skills'))
+  })
+
+  it('getContinueDir returns path inside homedir', () => {
+    assert.equal(lockModule.getContinueDir(), join(tempDir, '.continue', 'skills'))
+  })
+
+  it('getWarpDir returns path inside homedir', () => {
+    assert.equal(lockModule.getWarpDir(), join(tempDir, '.warp', 'skills'))
+  })
+
+  it('getCodeiumDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCodeiumDir(), join(tempDir, '.codeium', 'skills'))
+  })
+
+  it('getFabricDir returns path inside homedir', () => {
+    assert.equal(lockModule.getFabricDir(), join(tempDir, '.fabric', 'skills'))
+  })
+
+  it('getGooseDir returns path inside homedir', () => {
+    assert.equal(lockModule.getGooseDir(), join(tempDir, '.goose', 'skills'))
+  })
+
+  it('getTabnineDir returns path inside homedir', () => {
+    assert.equal(lockModule.getTabnineDir(), join(tempDir, '.tabnine', 'skills'))
+  })
+
+  it('getSupermavenDir returns path inside homedir', () => {
+    assert.equal(lockModule.getSupermavenDir(), join(tempDir, '.supermaven', 'skills'))
+  })
+
+  it('getPrPilotDir returns path inside homedir', () => {
+    assert.equal(lockModule.getPrPilotDir(), join(tempDir, '.pr-pilot', 'skills'))
+  })
+
+  it('getLoomDir returns path inside homedir', () => {
+    assert.equal(lockModule.getLoomDir(), join(tempDir, '.loom', 'skills'))
+  })
+
+  it('getRooDir returns path inside homedir', () => {
+    assert.equal(lockModule.getRooDir(), join(tempDir, '.roo', 'skills'))
+  })
+
+  it('getTraeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getTraeDir(), join(tempDir, '.trae', 'skills'))
+  })
+
+  it('getHermesDir returns path inside homedir', () => {
+    assert.equal(lockModule.getHermesDir(), join(tempDir, '.hermes', 'skills'))
+  })
+
+  it('getKiroDir returns path inside homedir', () => {
+    assert.equal(lockModule.getKiroDir(), join(tempDir, '.kiro', 'skills'))
+  })
+
+  it('getAugmentDir returns path inside homedir', () => {
+    assert.equal(lockModule.getAugmentDir(), join(tempDir, '.augment', 'skills'))
+  })
+
+  it('getKiloDir returns path inside homedir', () => {
+    assert.equal(lockModule.getKiloDir(), join(tempDir, '.kilo', 'skills'))
+  })
+
+  it('getOpenHandsDir returns path inside homedir', () => {
+    assert.equal(lockModule.getOpenHandsDir(), join(tempDir, '.openhands', 'skills'))
+  })
+
+  it('getJunieDir returns path inside homedir', () => {
+    assert.equal(lockModule.getJunieDir(), join(tempDir, '.junie', 'skills'))
+  })
+
+  it('getFactoryDir returns path inside homedir', () => {
+    assert.equal(lockModule.getFactoryDir(), join(tempDir, '.factory', 'skills'))
+  })
+
+  it('getZapDir returns path inside homedir', () => {
+    assert.equal(lockModule.getZapDir(), join(tempDir, '.zap', 'skills'))
+  })
+
+  it('getCodeepDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCodeepDir(), join(tempDir, '.codeep', 'skills'))
+  })
+
+  it('getKimiCodeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getKimiCodeDir(), join(tempDir, '.kimi-code', 'skills'))
+  })
+
+  it('getZCodeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getZCodeDir(), join(tempDir, '.zcode', 'skills'))
+  })
+
+  it('getCodeArtsDoerDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCodeArtsDoerDir(), join(tempDir, '.codeartsdoer', 'skills'))
+  })
+
+  it('getCodeMakerDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCodeMakerDir(), join(tempDir, '.codemaker', 'skills'))
+  })
+
+  it('getCodeStudioDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCodeStudioDir(), join(tempDir, '.codestudio', 'skills'))
+  })
+
+  it('getCrushDir returns path inside homedir', () => {
+    assert.equal(lockModule.getCrushDir(), join(tempDir, '.crush', 'skills'))
+  })
+
+  it('getEveDir returns path relative to cwd', () => {
+    assert.equal(lockModule.getEveDir(), join(process.cwd(), 'agent', 'skills'))
+  })
+
+  it('getForgeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getForgeDir(), join(tempDir, '.forge', 'skills'))
+  })
+
+  it('getInferenceShDir returns path inside homedir', () => {
+    assert.equal(lockModule.getInferenceShDir(), join(tempDir, '.inferencesh', 'skills'))
+  })
+
+  it('getJazzDir returns path inside homedir', () => {
+    assert.equal(lockModule.getJazzDir(), join(tempDir, '.jazz', 'skills'))
+  })
+
+  it('getIFlowDir returns path inside homedir', () => {
+    assert.equal(lockModule.getIFlowDir(), join(tempDir, '.iflow', 'skills'))
+  })
+
+  it('getKiloCodeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getKiloCodeDir(), join(tempDir, '.kilocode', 'skills'))
+  })
+
+  it('getKodeDir returns path inside homedir', () => {
+    assert.equal(lockModule.getKodeDir(), join(tempDir, '.kode', 'skills'))
+  })
+
+  it('getLingmaDir returns path inside homedir', () => {
+    assert.equal(lockModule.getLingmaDir(), join(tempDir, '.lingma', 'skills'))
+  })
+
+  it('getMcpJamDir returns path inside homedir', () => {
+    assert.equal(lockModule.getMcpJamDir(), join(tempDir, '.mcpjam', 'skills'))
+  })
+
+  it('getMoxbyDir returns path inside homedir', () => {
+    assert.equal(lockModule.getMoxbyDir(), join(tempDir, '.moxby', 'skills'))
+  })
+
+  it('getOnaDir returns path inside homedir', () => {
+    assert.equal(lockModule.getOnaDir(), join(tempDir, '.ona', 'skills'))
+  })
+
+  it('getQoderDir returns path inside homedir', () => {
+    assert.equal(lockModule.getQoderDir(), join(tempDir, '.qoder', 'skills'))
+  })
+
+  it('getReasonixDir returns path inside homedir', () => {
+    assert.equal(lockModule.getReasonixDir(), join(tempDir, '.reasonix', 'skills'))
+  })
+
+  it('getTerraMindDir returns path inside homedir', () => {
+    assert.equal(lockModule.getTerraMindDir(), join(tempDir, '.terramind', 'skills'))
+  })
+
+  it('getTinyCloudDir returns path inside homedir', () => {
+    assert.equal(lockModule.getTinyCloudDir(), join(tempDir, '.tinycloud', 'skills'))
+  })
+
+  it('getZencoderDir returns path inside homedir', () => {
+    assert.equal(lockModule.getZencoderDir(), join(tempDir, '.zencoder', 'skills'))
+  })
+
+  it('getProjectLockPath returns path relative to cwd', () => {
+    assert.equal(lockModule.getProjectLockPath(process.cwd()), join(process.cwd(), '.agents', '.skill-lock.json'))
+  })
+
   it('readLock returns default when no file exists', async () => {
     const lock = await lockModule.readLock()
     assert.deepEqual(lock, {

--- a/src/utils/mcp.js
+++ b/src/utils/mcp.js
@@ -1,10 +1,9 @@
-import { readFile, writeFile, mkdir, stat } from 'node:fs/promises'
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync as defaultExecSync, spawnSync as defaultSpawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
-import { randomUUID } from 'node:crypto'
-import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync } from 'node:fs'
 
 let runExec = defaultExecSync
 let runSpawnSync = defaultSpawnSync

--- a/src/utils/mcp.js
+++ b/src/utils/mcp.js
@@ -1,0 +1,280 @@
+import { readFile, writeFile, mkdir, stat } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { homedir } from 'node:os'
+import { execSync as defaultExecSync, spawnSync as defaultSpawnSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs'
+
+let runExec = defaultExecSync
+let runSpawnSync = defaultSpawnSync
+
+export function setExecSync(fn) {
+  runExec = fn
+}
+
+export function setSpawnSync(fn) {
+  runSpawnSync = fn
+}
+
+function home(...parts) {
+  return join(process.env.HOME || process.env.HOMEPATH || '/tmp', ...parts)
+}
+
+const AGENT_MCP_PATHS = {
+  agents:           () => home('.agents', 'mcp.json'),
+  claude:           () => home('.claude', 'claude_code.json'),
+  cursor:           () => home('.cursor', 'mcp.json'),
+  windsurf:         () => home('.windsurf', 'mcp_config.json'),
+  copilot:          () => join(process.cwd(), '.github', 'copilot', '.mcp.json'),
+  continue:         () => home('.continue', 'config.json'),
+  devin:            () => home('.devin', 'mcp.json'),
+  codex:            () => home('.codex', 'mcp.json'),
+  aider:            () => home('.aider', 'mcp.json'),
+  cline:            () => home('.cline', 'mcp.json'),
+  gemini:           () => home('.gemini', 'mcp.json'),
+  cody:             () => home('.cody', 'mcp.json'),
+  warp:             () => home('.warp', 'mcp.json'),
+  fabric:           () => home('.fabric', 'mcp.json'),
+  goose:            () => home('.goose', 'mcp.json'),
+  openhands:        () => home('.openhands', 'mcp.json'),
+  junie:            () => home('.junie', 'mcp.json'),
+  openclaw:         () => home('.openclaw', 'mcp.json'),
+  tabnine:          () => home('.tabnine', 'mcp.json'),
+  supermaven:       () => home('.supermaven', 'mcp.json'),
+  'pr-pilot':       () => home('.pr-pilot', 'mcp.json'),
+  loom:             () => home('.loom', 'mcp.json'),
+  roo:              () => home('.roo', 'mcp.json'),
+  trae:             () => home('.trae', 'mcp.json'),
+  hermes:           () => home('.hermes', 'mcp.json'),
+  kiro:             () => home('.kiro', 'mcp.json'),
+  augment:          () => home('.augment', 'mcp.json'),
+  kilo:             () => home('.kilo', 'mcp.json'),
+  factory:          () => home('.factory', 'mcp.json'),
+  'command-code':   () => home('.commandcode', 'mcp.json'),
+  cortex:           () => home('.snowflake', 'cortex', 'mcp.json'),
+  'mistral-vibe':   () => home('.vibe', 'mcp.json'),
+  'qwen-code':      () => home('.qwen', 'mcp.json'),
+  codebuddy:        () => home('.codebuddy', 'mcp.json'),
+  mux:              () => home('.mux', 'mcp.json'),
+  pi:               () => home('.pi', 'agent', 'mcp.json'),
+  'autohand-code':  () => home('.autohand', 'mcp.json'),
+  rovo:             () => home('.rovodev', 'mcp.json'),
+  firebender:       () => home('.firebender', 'mcp.json'),
+  bob:              () => home('.bob', 'mcp.json'),
+  'aider-desk':     () => home('.aider-desk', 'mcp.json'),
+}
+
+function getMcpConfigPath(agent) {
+  const fn = AGENT_MCP_PATHS[agent]
+  return fn ? fn() : null
+}
+
+export function getSupportedMcpAgents() {
+  return Object.keys(AGENT_MCP_PATHS)
+}
+
+export async function readMcpConfig(agent) {
+  const configPath = getMcpConfigPath(agent)
+  if (!configPath) return null
+  try {
+    const raw = await readFile(configPath, 'utf-8')
+    return { configPath, data: JSON.parse(raw) }
+  } catch {
+    return { configPath, data: {} }
+  }
+}
+
+function setMcpServerEntry(data, agent, name, serverConfig) {
+  if (agent === 'copilot') {
+    if (!data.servers) data.servers = {}
+    if (!data.inputs) data.inputs = []
+    data.servers[name] = { command: serverConfig.command, args: serverConfig.args }
+    return data
+  }
+  if (agent === 'continue') {
+    if (!data.experimental) data.experimental = {}
+    if (!data.experimental.mcpServers) data.experimental.mcpServers = []
+    const existing = data.experimental.mcpServers.findIndex(s => s.name === name)
+    const entry = { name, command: serverConfig.command, args: serverConfig.args }
+    if (serverConfig.env) entry.env = serverConfig.env
+    if (existing >= 0) {
+      data.experimental.mcpServers[existing] = entry
+    } else {
+      data.experimental.mcpServers.push(entry)
+    }
+    return data
+  }
+  if (!data.mcpServers) data.mcpServers = {}
+  data.mcpServers[name] = {
+    command: serverConfig.command,
+    args: serverConfig.args,
+  }
+  if (serverConfig.env) {
+    data.mcpServers[name].env = serverConfig.env
+  }
+  return data
+}
+
+function removeMcpServerEntry(data, agent, name) {
+  if (agent === 'continue') {
+    if (data.experimental?.mcpServers) {
+      data.experimental.mcpServers = data.experimental.mcpServers.filter(s => s.name !== name)
+    }
+    return data
+  }
+  if (agent === 'copilot') {
+    if (data.servers) delete data.servers[name]
+    return data
+  }
+  if (data.mcpServers) delete data.mcpServers[name]
+  return data
+}
+
+function listMcpServerEntries(data, agent) {
+  if (agent === 'continue') {
+    return (data.experimental?.mcpServers || []).map(s => ({
+      name: s.name,
+      command: s.command,
+      args: s.args,
+    }))
+  }
+  if (agent === 'copilot') {
+    return Object.entries(data.servers || {}).map(([name, s]) => ({
+      name,
+      command: s.command,
+      args: s.args,
+    }))
+  }
+  return Object.entries(data.mcpServers || {}).map(([name, s]) => ({
+    name,
+    command: s.command,
+    args: s.args,
+  }))
+}
+
+export async function addMcpServer(agent, name, serverConfig) {
+  const result = await readMcpConfig(agent)
+  if (!result) return false
+  const { configPath, data } = result
+  setMcpServerEntry(data, agent, name, serverConfig)
+  await mkdir(dirname(configPath), { recursive: true })
+  await writeFile(configPath, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+  return true
+}
+
+export async function removeMcpServer(agent, name) {
+  const result = await readMcpConfig(agent)
+  if (!result) return false
+  const { configPath, data } = result
+  const before = JSON.stringify(data)
+  removeMcpServerEntry(data, agent, name)
+  const after = JSON.stringify(data)
+  if (before === after) return false
+  await mkdir(dirname(configPath), { recursive: true })
+  await writeFile(configPath, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+  return true
+}
+
+export async function updateMcpServer(agent, name, serverConfig) {
+  await removeMcpServer(agent, name)
+  return addMcpServer(agent, name, serverConfig)
+}
+
+export async function listMcpServers(agent) {
+  const result = await readMcpConfig(agent)
+  if (!result) return []
+  return listMcpServerEntries(result.data, agent)
+}
+
+export function parseMcpServersFromSkill(content) {
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!frontmatterMatch) return []
+  const yaml = frontmatterMatch[1]
+
+  const mcpLine = yaml.split('\n').findIndex(l => l.trim() === 'mcp_servers:')
+  if (mcpLine === -1) return []
+
+  const yamlLines = yaml.split('\n')
+  const blockLines = []
+  for (let i = mcpLine + 1; i < yamlLines.length; i++) {
+    const line = yamlLines[i]
+    if (line.trim() === '' || (line.length > 0 && !line.startsWith(' '))) break
+    blockLines.push(line.trim())
+  }
+
+  const servers = []
+  let current = null
+  for (const line of blockLines) {
+    const nameMatch = line.match(/^-\s+name:\s*["']?(.+?)["']?\s*$/)
+    const sourceMatch = line.match(/^source:\s*["']?(.+?)["']?\s*$/)
+    if (nameMatch) {
+      if (current) servers.push(current)
+      current = { name: nameMatch[1] }
+    } else if (sourceMatch && current) {
+      current.source = sourceMatch[1]
+    }
+  }
+  if (current) servers.push(current)
+  return servers
+}
+
+export function resolveMcpSource(source) {
+  if (source.startsWith('npm:')) {
+    const pkg = source.slice(4)
+    return {
+      command: 'npx',
+      args: ['-y', pkg],
+      sourceType: 'npm',
+      packageName: pkg,
+    }
+  }
+  if (source.startsWith('gh:')) {
+    const repo = source.slice(3)
+    const tmpDir = mkdtempSync(join(tmpdir(), 'rolecraft-mcp-'))
+    const cloneDir = join(tmpDir, 'repo')
+    try {
+      const result = runSpawnSync('git', ['clone', '--depth', '1', `https://github.com/${repo}.git`, cloneDir], { stdio: 'pipe', timeout: 30000 })
+      if (result.status !== 0) throw new Error(`Failed to clone ${repo}: ${result.stderr?.toString() || result.status}`)
+      const pkgJson = JSON.parse(readFileSync(join(cloneDir, 'package.json'), 'utf-8'))
+      const main = pkgJson.main || 'index.js'
+      const bin = pkgJson.bin ? (typeof pkgJson.bin === 'string' ? pkgJson.bin : Object.values(pkgJson.bin)[0]) : null
+      const command = bin ? join(cloneDir, bin) : join(cloneDir, main)
+      const args = []
+      try { runSpawnSync('rm', ['-rf', tmpDir], { stdio: 'pipe' }) } catch {}
+      return {
+        command: 'node',
+        args: [command, ...args],
+        sourceType: 'github',
+        repo,
+      }
+    } catch (err) {
+      try { runSpawnSync('rm', ['-rf', tmpDir], { stdio: 'pipe' }) } catch {}
+      throw err
+    }
+  }
+  if (source.startsWith('/') || source.startsWith('.') || source.startsWith('~')) {
+    const resolvedPath = source.startsWith('~') ? join(homedir(), source.slice(1)) : source
+    return {
+      command: 'node',
+      args: [resolvedPath],
+      sourceType: 'local',
+      path: resolvedPath,
+    }
+  }
+  throw new Error(`Unknown MCP source format: ${source}. Use npm:package, gh:owner/repo, or a local path.`)
+}
+
+export async function installMcpServersFromSkill(skillContent, targets) {
+  const servers = parseMcpServersFromSkill(skillContent)
+  if (servers.length === 0) return []
+  const results = []
+  for (const server of servers) {
+    const resolved = resolveMcpSource(server.source)
+    for (const agent of targets) {
+      const success = await addMcpServer(agent, server.name, resolved)
+      results.push({ agent, name: server.name, success })
+    }
+  }
+  return results
+}

--- a/src/utils/mcp.test.js
+++ b/src/utils/mcp.test.js
@@ -1,0 +1,446 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let mcpModule
+
+before(async () => {
+  mcpModule = await import('./mcp.js')
+})
+
+function withTempDir(fn) {
+  return async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-mcp-test-'))
+    const origHome = process.env.HOME
+    process.env.HOME = tempDir
+    try {
+      await fn(tempDir)
+    } finally {
+      process.env.HOME = origHome
+      try { rmSync(tempDir, { recursive: true, force: true }) } catch {}
+    }
+  }
+}
+
+describe('mcp', () => {
+  describe('getSupportedMcpAgents', () => {
+    it('returns list of supported agents', () => {
+      const agents = mcpModule.getSupportedMcpAgents()
+      assert.ok(agents.includes('claude'))
+      assert.ok(agents.includes('cursor'))
+      assert.ok(agents.includes('copilot'))
+      assert.ok(agents.includes('continue'))
+    })
+  })
+
+  describe('addMcpServer', () => {
+    it('adds an MCP server to agents (opencode) config', withTempDir(async () => {
+      const success = await mcpModule.addMcpServer('agents', 'test-server', {
+        command: 'npx',
+        args: ['-y', '@test/server'],
+      })
+      assert.ok(success)
+
+      const configPath = join(process.env.HOME, '.agents', 'mcp.json')
+      assert.ok(existsSync(configPath))
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      assert.ok(config.mcpServers['test-server'])
+      assert.equal(config.mcpServers['test-server'].command, 'npx')
+      assert.deepEqual(config.mcpServers['test-server'].args, ['-y', '@test/server'])
+    }))
+
+    it('adds an MCP server to cursor config', withTempDir(async () => {
+      const success = await mcpModule.addMcpServer('cursor', 'db-server', {
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/postgres'],
+      })
+      assert.ok(success)
+
+      const configPath = join(process.env.HOME, '.cursor', 'mcp.json')
+      assert.ok(existsSync(configPath))
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      assert.ok(config.mcpServers['db-server'])
+    }))
+
+    it('adds an MCP server to claude config', withTempDir(async () => {
+      await mcpModule.addMcpServer('claude', 'github-server', {
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/github'],
+      })
+
+      const configPath = join(process.env.HOME, '.claude', 'claude_code.json')
+      assert.ok(existsSync(configPath))
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      assert.ok(config.mcpServers['github-server'])
+    }))
+
+    it('adds an MCP server with env vars', withTempDir(async () => {
+      await mcpModule.addMcpServer('agents', 'api-server', {
+        command: 'node',
+        args: ['server.js'],
+        env: { API_KEY: 'sk-test' },
+      })
+
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.agents', 'mcp.json'), 'utf-8'))
+      assert.equal(config.mcpServers['api-server'].env.API_KEY, 'sk-test')
+    }))
+
+    it('adds an MCP server to copilot format', withTempDir(async () => {
+      const origCwd = process.cwd
+      process.cwd = () => process.env.HOME
+      try {
+        await mcpModule.addMcpServer('copilot', 'copilot-server', {
+          command: 'npx',
+          args: ['-y', '@test/copilot-mcp'],
+        })
+
+        const configPath = join(process.env.HOME, '.github', 'copilot', '.mcp.json')
+        assert.ok(existsSync(configPath))
+        const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+        assert.ok(config.servers['copilot-server'])
+        assert.ok(Array.isArray(config.inputs))
+      } finally {
+        process.cwd = origCwd
+      }
+    }))
+
+    it('adds an MCP server to continue format', withTempDir(async () => {
+      await mcpModule.addMcpServer('continue', 'continue-server', {
+        command: 'npx',
+        args: ['-y', '@test/continue-mcp'],
+      })
+
+      const configPath = join(process.env.HOME, '.continue', 'config.json')
+      assert.ok(existsSync(configPath))
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'))
+      assert.ok(config.experimental.mcpServers)
+      const found = config.experimental.mcpServers.find(s => s.name === 'continue-server')
+      assert.ok(found)
+      assert.equal(found.command, 'npx')
+    }))
+
+    it('updates existing server entry', withTempDir(async () => {
+      await mcpModule.addMcpServer('agents', 'update-test', {
+        command: 'npx',
+        args: ['-y', '@test/v1'],
+      })
+      await mcpModule.addMcpServer('agents', 'update-test', {
+        command: 'npx',
+        args: ['-y', '@test/v2'],
+      })
+
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.agents', 'mcp.json'), 'utf-8'))
+      assert.deepEqual(config.mcpServers['update-test'].args, ['-y', '@test/v2'])
+    }))
+
+    it('returns false for unsupported agent', async () => {
+      const success = await mcpModule.addMcpServer('nonexistent-agent', 'test', {
+        command: 'npx',
+        args: [],
+      })
+      assert.equal(success, false)
+    })
+  })
+
+  describe('updateMcpServer', () => {
+    it('replaces existing MCP server configuration', withTempDir(async () => {
+      await mcpModule.addMcpServer('agents', 'my-server', {
+        command: 'npx',
+        args: ['-y', '@test/v1'],
+      })
+      const success = await mcpModule.updateMcpServer('agents', 'my-server', {
+        command: 'npx',
+        args: ['-y', '@test/v2'],
+      })
+      assert.ok(success)
+
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.agents', 'mcp.json'), 'utf-8'))
+      assert.deepEqual(config.mcpServers['my-server'].args, ['-y', '@test/v2'])
+    }))
+
+    it('updates copilot format server', withTempDir(async () => {
+      const origCwd = process.cwd
+      process.cwd = () => process.env.HOME
+      try {
+        await mcpModule.addMcpServer('copilot', 'copilot-update', {
+          command: 'npx',
+          args: ['-y', '@test/v1'],
+        })
+        const success = await mcpModule.updateMcpServer('copilot', 'copilot-update', {
+          command: 'npx',
+          args: ['-y', '@test/v2'],
+        })
+        assert.ok(success)
+        const config = JSON.parse(readFileSync(join(process.env.HOME, '.github', 'copilot', '.mcp.json'), 'utf-8'))
+        assert.deepEqual(config.servers['copilot-update'].args, ['-y', '@test/v2'])
+      } finally {
+        process.cwd = origCwd
+      }
+    }))
+
+    it('updates continue format server', withTempDir(async () => {
+      await mcpModule.addMcpServer('continue', 'cont-update', {
+        command: 'npx',
+        args: ['-y', '@test/v1'],
+      })
+      const success = await mcpModule.updateMcpServer('continue', 'cont-update', {
+        command: 'npx',
+        args: ['-y', '@test/v2'],
+      })
+      assert.ok(success)
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.continue', 'config.json'), 'utf-8'))
+      const found = config.experimental.mcpServers.find(s => s.name === 'cont-update')
+      assert.ok(found)
+      assert.deepEqual(found.args, ['-y', '@test/v2'])
+    }))
+  })
+
+  describe('removeMcpServer', () => {
+    it('removes an MCP server from config', withTempDir(async () => {
+      await mcpModule.addMcpServer('agents', 'to-remove', {
+        command: 'npx',
+        args: ['-y', '@test/to-remove'],
+      })
+      const success = await mcpModule.removeMcpServer('agents', 'to-remove')
+      assert.ok(success)
+
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.agents', 'mcp.json'), 'utf-8'))
+      assert.equal(config.mcpServers['to-remove'], undefined)
+    }))
+
+    it('removes copilot format server', withTempDir(async () => {
+      const origCwd = process.cwd
+      process.cwd = () => process.env.HOME
+      try {
+        await mcpModule.addMcpServer('copilot', 'copilot-rm', {
+          command: 'npx',
+          args: ['-y', '@test/copilot-rm'],
+        })
+        const success = await mcpModule.removeMcpServer('copilot', 'copilot-rm')
+        assert.ok(success)
+        const config = JSON.parse(readFileSync(join(process.env.HOME, '.github', 'copilot', '.mcp.json'), 'utf-8'))
+        assert.equal(config.servers['copilot-rm'], undefined)
+      } finally {
+        process.cwd = origCwd
+      }
+    }))
+
+    it('removes continue format server', withTempDir(async () => {
+      await mcpModule.addMcpServer('continue', 'cont-rm', {
+        command: 'npx',
+        args: ['-y', '@test/cont-rm'],
+      })
+      const success = await mcpModule.removeMcpServer('continue', 'cont-rm')
+      assert.ok(success)
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.continue', 'config.json'), 'utf-8'))
+      assert.equal(config.experimental.mcpServers.length, 0)
+    }))
+
+    it('returns false when server does not exist', withTempDir(async () => {
+      const success = await mcpModule.removeMcpServer('agents', 'non-existent')
+      assert.equal(success, false)
+    }))
+
+    it('returns false for unsupported agent', async () => {
+      const success = await mcpModule.removeMcpServer('nonexistent', 'test')
+      assert.equal(success, false)
+    })
+  })
+
+  describe('listMcpServers', () => {
+    it('returns empty array when no servers configured', withTempDir(async () => {
+      const servers = await mcpModule.listMcpServers('agents')
+      assert.deepEqual(servers, [])
+    }))
+
+    it('lists configured servers', withTempDir(async () => {
+      await mcpModule.addMcpServer('agents', 'list-test-1', {
+        command: 'npx',
+        args: ['-y', '@test/one'],
+      })
+      await mcpModule.addMcpServer('agents', 'list-test-2', {
+        command: 'node',
+        args: ['server.js'],
+      })
+
+      const servers = await mcpModule.listMcpServers('agents')
+      assert.equal(servers.length, 2)
+      assert.ok(servers.some(s => s.name === 'list-test-1'))
+      assert.ok(servers.some(s => s.name === 'list-test-2'))
+    }))
+
+    it('lists copilot format servers', withTempDir(async () => {
+      const origCwd = process.cwd
+      process.cwd = () => process.env.HOME
+      try {
+        await mcpModule.addMcpServer('copilot', 'copilot-list', {
+          command: 'npx',
+          args: ['-y', '@test/cp-list'],
+        })
+        const servers = await mcpModule.listMcpServers('copilot')
+        assert.equal(servers.length, 1)
+        assert.equal(servers[0].name, 'copilot-list')
+      } finally {
+        process.cwd = origCwd
+      }
+    }))
+
+    it('lists continue format servers', withTempDir(async () => {
+      await mcpModule.addMcpServer('continue', 'cont-list', {
+        command: 'npx',
+        args: ['-y', '@test/cont-list'],
+      })
+      const servers = await mcpModule.listMcpServers('continue')
+      assert.equal(servers.length, 1)
+      assert.equal(servers[0].name, 'cont-list')
+    }))
+  })
+
+  describe('parseMcpServersFromSkill', () => {
+    it('parses mcp_servers from SKILL.md frontmatter', () => {
+      const content = `---
+name: my-skill
+description: Test skill
+mcp_servers:
+  - name: github
+    source: gh:github/github-mcp-server
+  - name: postgres
+    source: npm:@anthropic/postgres-mcp
+---
+
+# Skill content here
+`
+      const servers = mcpModule.parseMcpServersFromSkill(content)
+      assert.equal(servers.length, 2)
+      assert.equal(servers[0].name, 'github')
+      assert.equal(servers[0].source, 'gh:github/github-mcp-server')
+      assert.equal(servers[1].name, 'postgres')
+      assert.equal(servers[1].source, 'npm:@anthropic/postgres-mcp')
+    })
+
+    it('returns empty array when no mcp_servers in frontmatter', () => {
+      const content = `---
+name: simple-skill
+---
+
+Just content
+`
+      const servers = mcpModule.parseMcpServersFromSkill(content)
+      assert.deepEqual(servers, [])
+    })
+
+    it('returns empty array when no frontmatter', () => {
+      const servers = mcpModule.parseMcpServersFromSkill('Just content without frontmatter')
+      assert.deepEqual(servers, [])
+    })
+  })
+
+  describe('resolveMcpSource', () => {
+    it('resolves npm: source', () => {
+      const resolved = mcpModule.resolveMcpSource('npm:@modelcontextprotocol/github')
+      assert.equal(resolved.command, 'npx')
+      assert.deepEqual(resolved.args, ['-y', '@modelcontextprotocol/github'])
+      assert.equal(resolved.sourceType, 'npm')
+    })
+
+    it('resolves local path source', () => {
+      const resolved = mcpModule.resolveMcpSource('/path/to/server.js')
+      assert.equal(resolved.command, 'node')
+      assert.deepEqual(resolved.args, ['/path/to/server.js'])
+      assert.equal(resolved.sourceType, 'local')
+    })
+
+    it('resolves relative path source', () => {
+      const resolved = mcpModule.resolveMcpSource('./my-server.js')
+      assert.equal(resolved.command, 'node')
+      assert.equal(resolved.sourceType, 'local')
+    })
+
+    it('resolves ~ path source', () => {
+      const resolved = mcpModule.resolveMcpSource('~/dev/my-server.js')
+      assert.equal(resolved.command, 'node')
+      assert.equal(resolved.sourceType, 'local')
+    })
+
+    it('throws for unknown source format', () => {
+      assert.throws(() => mcpModule.resolveMcpSource('invalid-source'), /Unknown MCP source format/)
+    })
+
+    it('throws when gh: source clone fails', () => {
+      mcpModule.setSpawnSync(() => ({ status: 1, stderr: 'mock failure' }))
+      assert.throws(() => mcpModule.resolveMcpSource('gh:test/repo'), /Failed to clone/)
+      mcpModule.setSpawnSync(undefined)
+    })
+
+    it('gh: source success path', withTempDir(async (td) => {
+      mcpModule.setSpawnSync((cmd, args) => {
+        if (cmd === 'git') {
+          const cloneDir = args[args.length - 1]
+          mkdirSync(cloneDir, { recursive: true })
+          writeFileSync(join(cloneDir, 'package.json'), JSON.stringify({ main: 'index.js' }))
+          return { status: 0 }
+        }
+        return { status: 0 }
+      })
+      try {
+        const resolved = mcpModule.resolveMcpSource('gh:test/mcp-server')
+        assert.equal(resolved.command, 'node')
+        assert.equal(resolved.sourceType, 'github')
+        assert.equal(resolved.repo, 'test/mcp-server')
+      } finally {
+        mcpModule.setSpawnSync(undefined)
+      }
+    }))
+  })
+
+  describe('readMcpConfig', () => {
+    it('returns null for unsupported agent', async () => {
+      const result = await mcpModule.readMcpConfig('nonexistent')
+      assert.equal(result, null)
+    })
+
+    it('returns empty data for non-existent config', withTempDir(async () => {
+      const result = await mcpModule.readMcpConfig('agents')
+      assert.ok(result)
+      assert.deepEqual(result.data, {})
+    }))
+  })
+
+  describe('setExecSync', () => {
+    it('replaces the execSync implementation', () => {
+      const origExec = mcpModule.setExecSync(() => 'mocked')
+      const mockFn = () => 'mocked'
+      mcpModule.setExecSync(mockFn)
+      assert.equal(mockFn(), 'mocked')
+      mcpModule.setExecSync(undefined)
+    })
+  })
+
+  describe('installMcpServersFromSkill', () => {
+    it('returns empty array when no mcp_servers in content', async () => {
+      const results = await mcpModule.installMcpServersFromSkill('no servers here', ['agents'])
+      assert.deepEqual(results, [])
+    })
+
+    it('installs MCP servers for given targets', withTempDir(async () => {
+      const content = `---
+name: test
+mcp_servers:
+  - name: test-mcp
+    source: npm:@test/test-pkg
+---
+`
+      const results = await mcpModule.installMcpServersFromSkill(content, ['agents'])
+      assert.equal(results.length, 1)
+      assert.equal(results[0].name, 'test-mcp')
+      assert.equal(results[0].agent, 'agents')
+      assert.ok(results[0].success)
+
+      const config = JSON.parse(readFileSync(join(process.env.HOME, '.agents', 'mcp.json'), 'utf-8'))
+      assert.ok(config.mcpServers['test-mcp'])
+    }))
+  })
+})


### PR DESCRIPTION
- MCP core (42 agent paths, 3 config formats)
- CLI: install/list/remove/update with agent flags
- SKILL.md mcp_servers auto-install integration
- --no-mcp flag for install/bundle
- Bug fixes: installer.js switch cases, install.js targets, bundle.js scoping
- 119 new tests (496 total, 0 fail)
- Coverage: mcp.js 100% line