### PR TITLE
feat: add watch command for auto-syncing skills on file change

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ rolecraft remove my-skill
 | `rolecraft agents-xml [--write]`        | Generate skills XML for AGENTS.md                                           | [docs](docs/commands/agents-xml.md)  |
 | `rolecraft mcp install/remove/list`     | Install, remove, and list MCP servers for AI agents                         | [docs](docs/commands/mcp.md)         |
 | `rolecraft verify`                      | Check installed skill integrity via content hash                            | [docs](docs/commands/verify.md)      |
+| `rolecraft watch [<slug>]`              | Watch skills for changes and auto-sync                                     | [docs](docs/commands/watch.md)       |
 | `rolecraft ci`                          | Re-install all skills from lockfile (CI mode)                               | [docs](docs/commands/ci.md)          |
 | `rolecraft upgrade`                     | Upgrade rolecraft to the latest version                                     | [docs](docs/commands/upgrade.md)     |
 | `rolecraft remove <slug>`               | Uninstall a skill                                                           | [docs](docs/commands/remove.md)      |

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,6 +59,7 @@ npx rolecraft list
 | `rolecraft bundle <sources>` | Install multiple skills from file or inline |
 | `rolecraft ci` | Re-install from lockfile (CI mode) |
 | `rolecraft verify` | Check skill integrity via content hash |
+| `rolecraft watch [<slug>]` | Watch skills for changes and auto-sync |
 | `rolecraft search <query>` | Search skills on GitHub |
 | `rolecraft doctor` | Run system health check |
 | `rolecraft agents-xml [--write]` | Generate skills XML for AGENTS.md |

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -20,6 +20,7 @@ import { upgradeCommand } from '../src/commands/upgrade.js'
 import { doctorCommand } from '../src/commands/doctor.js'
 import { agentsXmlCommand } from '../src/commands/agents-xml.js'
 import { mcpCommand } from '../src/commands/mcp.js'
+import { watchCommand } from '../src/commands/watch.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'))
@@ -47,7 +48,8 @@ Usage:
   rolecraft ci                   Install all skills from lockfile
   rolecraft completions <shell>  Generate shell completions (bash|zsh|fish)
   rolecraft doctor               Run system health check
-  rolecraft mcp install <source> Install an MCP server (npm:, gh:, or local path)
+   rolecraft watch [<slug>]       Watch skills for changes and auto-sync
+   rolecraft mcp install <source> Install an MCP server (npm:, gh:, or local path)
   rolecraft mcp list             List configured MCP servers
   rolecraft mcp remove <name>    Remove an MCP server
   rolecraft agents-xml           Generate skills XML for AGENTS.md
@@ -347,6 +349,22 @@ export async function main() {
       if (args.includes('--help') || args.includes('-h')) { usage(); return }
       await doctorCommand()
       break
+
+    case 'watch': {
+      if (args.includes('--help') || args.includes('-h')) { usage(); return }
+      const slug = args[0]
+      const { watchers } = await watchCommand(slug)
+      if (watchers.length === 0) {
+        return
+      }
+      process.on('SIGINT', () => {
+        console.log('\nStopping watch...')
+        for (const w of watchers) w.close()
+        process.exit(0)
+      })
+      await new Promise(() => {})
+      break
+    }
 
     case 'agents-xml':
       if (args.includes('--help') || args.includes('-h')) { usage(); return }

--- a/docs/commands/watch.md
+++ b/docs/commands/watch.md
@@ -1,0 +1,43 @@
+# `rolecraft watch`
+
+Watch installed skills for file changes and auto-sync to agent directories.
+
+## Usage
+
+```bash
+rolecraft watch [<slug>]
+```
+
+## Description
+
+Monitors skill source directories using `node:fs` FSWatcher. When a file changes, the skill is automatically re-installed to all its configured agent targets and the lockfile is updated with new content hashes.
+
+Only local source skills can be watched. Remote (GitHub, npm, git) sources are skipped.
+
+## Examples
+
+```bash
+# Watch all local skills
+rolecraft watch
+
+# Watch a specific skill
+rolecraft watch my-skill
+```
+
+## Output
+
+```
+👀 Watching 2 skill(s) for changes...
+
+   ✓ my-skill → watching /Users/me/projects/my-skill
+   ✓ team-rules → watching /Users/me/projects/team-rules
+
+📌 Press Ctrl+C to stop watching
+```
+
+On file change:
+
+```
+  [2:30:15 PM] my-skill: SKILL.md changed, syncing...
+  [2:30:15 PM] my-skill: synced successfully
+```

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -1,0 +1,157 @@
+import { watch } from 'node:fs'
+import { readLock, getProjectLockPath } from '../utils/lockfile.js'
+import { resolveSource } from '../utils/resolver.js'
+import { installSkill } from '../utils/installer.js'
+
+const agentNameToTarget = {
+  opencode: 'agents',
+  'claude-code': 'claude',
+  cursor: 'cursor',
+  windsurf: 'windsurf',
+  devin: 'devin',
+  codex: 'codex',
+  copilot: 'copilot',
+  aider: 'aider',
+  cline: 'cline',
+  'gemini-cli': 'gemini',
+  cody: 'cody',
+  continue: 'continue',
+  warp: 'warp',
+  codeium: 'codeium',
+  fabric: 'fabric',
+  goose: 'goose',
+  tabnine: 'tabnine',
+  supermaven: 'supermaven',
+  'pr-pilot': 'pr-pilot',
+  loom: 'loom',
+  roo: 'roo',
+  trae: 'trae',
+  hermes: 'hermes',
+  kiro: 'kiro',
+  augment: 'augment',
+  kilo: 'kilo',
+  openhands: 'openhands',
+  junie: 'junie',
+  factory: 'factory',
+  'command-code': 'command-code',
+  cortex: 'cortex',
+  'mistral-vibe': 'mistral-vibe',
+  'qwen-code': 'qwen-code',
+  openclaw: 'openclaw',
+  codebuddy: 'codebuddy',
+  mux: 'mux',
+  pi: 'pi',
+  'autohand-code': 'autohand-code',
+  'rovo-dev': 'rovo',
+  firebender: 'firebender',
+  'ibm-bob': 'bob',
+  'aider-desk': 'aider-desk',
+  'code-arts-doer': 'code-arts-doer',
+  'code-maker': 'code-maker',
+  'code-studio': 'code-studio',
+  crush: 'crush',
+  eve: 'eve',
+  forge: 'forge',
+  'inference-sh': 'inference-sh',
+  jazz: 'jazz',
+  iflow: 'iflow',
+  'kilo-code': 'kilo-code',
+  kode: 'kode',
+  lingma: 'lingma',
+  'mcp-jam': 'mcp-jam',
+  moxby: 'moxby',
+  ona: 'ona',
+  qoder: 'qoder',
+  reasonix: 'reasonix',
+  'terra-mind': 'terra-mind',
+  'tiny-cloud': 'tiny-cloud',
+  zencoder: 'zencoder',
+}
+
+function normalizeSlug(slug) {
+  return slug.replace(/\//g, '-')
+}
+
+async function reinstallSkill(slug, lock, cwd) {
+  const entry = lock.skills[slug]
+  if (!entry || entry.sourceType !== 'local') return false
+
+  try {
+    const resolved = await resolveSource(entry.source)
+    const targets = (entry.agents || []).map(a => agentNameToTarget[a] || a).filter(Boolean)
+    if (targets.length === 0) targets.push('project')
+
+    await installSkill(resolved, targets)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function watchCommand(slug, cwd = process.cwd()) {
+  const globalLock = await readLock()
+  const projectLock = await readLock(getProjectLockPath(cwd))
+
+  const mergedSkills = { ...globalLock.skills, ...projectLock.skills }
+  const skills = Object.entries(mergedSkills)
+
+  if (skills.length === 0) {
+    console.log('No skills installed. Nothing to watch.')
+    return { watchers: [], skills: [] }
+  }
+
+  const watchSlugs = slug
+    ? [slug]
+    : skills.filter(([, e]) => e.sourceType === 'local').map(([s]) => s)
+
+  if (slug && !mergedSkills[slug]) {
+    console.error(`Skill "${slug}" not found.`)
+    return { watchers: [], skills: [] }
+  }
+
+  if (watchSlugs.length === 0) {
+    if (!slug) console.log('No local skills to watch.')
+    return { watchers: [], skills: watchSlugs }
+  }
+
+  console.log(`\n👀 Watching ${watchSlugs.length} skill(s) for changes...\n`)
+
+  const debounceTimers = {}
+  const watchers = []
+
+  for (const s of watchSlugs) {
+    const entry = mergedSkills[s]
+    if (entry.sourceType !== 'local') {
+      console.log(`   Skipping "${s}" (${entry.sourceType} source)`)
+      continue
+    }
+
+    const sourcePath = entry.source.replace(/^~/, process.env.HOME || process.env.HOMEPATH || '/tmp')
+
+    const handler = (eventType, filename) => {
+      if (!filename || filename.startsWith('.')) return
+
+      const key = `watch-${s}`
+      if (debounceTimers[key]) clearTimeout(debounceTimers[key])
+
+      debounceTimers[key] = setTimeout(async () => {
+        const timestamp = new Date().toLocaleTimeString()
+        console.log(`  [${timestamp}] ${s}: ${filename} changed, syncing...`)
+        const ok = await reinstallSkill(s, mergedSkills, cwd)
+        if (ok) {
+          console.log(`  [${timestamp}] ${s}: synced successfully`)
+        }
+      }, 300)
+    }
+
+    try {
+      const w = watch(sourcePath, { recursive: true }, handler)
+      watchers.push(w)
+      console.log(`   ✓ ${s} → watching ${sourcePath}`)
+    } catch (err) {
+      console.error(`   ✗ ${s}: cannot watch (${err.message})`)
+    }
+  }
+
+  return { watchers, skills: watchSlugs }
+}

--- a/src/commands/watch.test.js
+++ b/src/commands/watch.test.js
@@ -1,0 +1,150 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempDir, watchModule, origHome, origCwd
+
+before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-watch-test-'))
+  origHome = process.env.HOME
+  process.env.HOME = tempDir
+  origCwd = process.cwd
+  process.cwd = () => tempDir
+
+  await mkdir(join(tempDir, '.agents', 'skills', 'local-skill'), { recursive: true })
+  writeFileSync(join(tempDir, '.agents', 'skills', 'local-skill', 'SKILL.md'), '---\nname: Local Skill\nslug: local-skill\n---\nContent')
+
+  const lockPath = join(tempDir, '.agents', '.skill-lock.json')
+  await writeFile(lockPath, JSON.stringify({
+    version: 3,
+    skills: {
+      'local-skill': {
+        name: 'Local Skill',
+        source: join(tempDir, 'source-local'),
+        sourceType: 'local',
+        installedAt: new Date().toISOString(),
+        agents: ['opencode'],
+      },
+      'remote-skill': {
+        name: 'Remote Skill',
+        source: 'someuser/some-repo',
+        sourceType: 'github',
+        installedAt: new Date().toISOString(),
+        agents: ['opencode'],
+      },
+    },
+    dismissed: {},
+    lastSelectedAgents: [],
+  }))
+
+  const sourceDir = join(tempDir, 'source-local')
+  mkdirSync(sourceDir, { recursive: true })
+  writeFileSync(join(sourceDir, 'SKILL.md'), '---\nname: Local Skill\nslug: local-skill\n---\nContent')
+
+  watchModule = await import('./watch.js')
+})
+
+after(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+  process.env.HOME = origHome
+  process.cwd = origCwd
+})
+
+describe('watch command', () => {
+  it('shows message when no skills installed', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'rolecraft-watch-empty-'))
+    const origHome2 = process.env.HOME
+    process.env.HOME = emptyDir
+
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => { if (args.length) logs.push(String(args[0])) }
+
+    const { watchers } = await watchModule.watchCommand(undefined, emptyDir)
+    for (const w of watchers) w.close()
+
+    assert.ok(logs.some(l => l.includes('No skills installed')))
+    console.log = origLog
+    process.env.HOME = origHome2
+    await rm(emptyDir, { recursive: true, force: true })
+  })
+
+  it('shows error when specific slug not found', async () => {
+    const logs = []
+    const errors = []
+    const origLog = console.log
+    const origError = console.error
+    console.log = (...args) => { if (args.length) logs.push(String(args[0])) }
+    console.error = (...args) => { if (args.length) errors.push(String(args[0])) }
+
+    const { watchers } = await watchModule.watchCommand('nonexistent', tempDir)
+    for (const w of watchers) w.close()
+
+    assert.ok(logs.some(l => l.includes('not found')) || errors.some(e => e.includes('not found')))
+    console.log = origLog
+    console.error = origError
+  })
+
+  it('shows message when no local skills available', async () => {
+    const remoteOnlyDir = mkdtempSync(join(tmpdir(), 'rolecraft-watch-remote-'))
+    const origHome3 = process.env.HOME
+    process.env.HOME = remoteOnlyDir
+
+    await mkdir(join(remoteOnlyDir, '.agents', 'skills', 'gh-skill'), { recursive: true })
+    writeFileSync(join(remoteOnlyDir, '.agents', 'skills', 'gh-skill', 'SKILL.md'), '---\nname: GH Skill\nslug: gh-skill\n---\nContent')
+    await writeFile(join(remoteOnlyDir, '.agents', '.skill-lock.json'), JSON.stringify({
+      version: 3,
+      skills: {
+        'gh-skill': {
+          source: 'user/repo',
+          sourceType: 'github',
+          agents: ['opencode'],
+          installedAt: new Date().toISOString(),
+        },
+      },
+      dismissed: {},
+      lastSelectedAgents: [],
+    }))
+
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => { if (args.length) logs.push(String(args[0])) }
+
+    const { watchers } = await watchModule.watchCommand(undefined, remoteOnlyDir)
+    for (const w of watchers) w.close()
+
+    assert.ok(logs.some(l => l.includes('No local skills')))
+    console.log = origLog
+    process.env.HOME = origHome3
+    await rm(remoteOnlyDir, { recursive: true, force: true })
+  })
+
+  it('starts watching local skills', async () => {
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => { if (args.length) logs.push(String(args[0])) }
+
+    const { watchers } = await watchModule.watchCommand(undefined, tempDir)
+    for (const w of watchers) w.close()
+
+    assert.ok(logs.some(l => l.includes('local-skill')))
+    assert.ok(logs.some(l => l.includes('watching')))
+    console.log = origLog
+  })
+
+  it('starts watching specific skill by slug', async () => {
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => { if (args.length) logs.push(String(args[0])) }
+
+    const { watchers } = await watchModule.watchCommand('local-skill', tempDir)
+    for (const w of watchers) w.close()
+
+    assert.ok(logs.some(l => l.includes('local-skill')))
+    assert.ok(logs.some(l => l.includes('watching')))
+    console.log = origLog
+  })
+})


### PR DESCRIPTION
## Özet

`rolecraft watch` komutu eklendi. Skill kaynak dizinlerini `node:fs` FSWatcher ile izler, dosya değişikliklerinde otomatik olarak tüm hedef agent dizinlerine sync eder.

## Kullanım

```bash
# Tüm local skill'leri izle
rolecraft watch

# Belirli bir skill'i izle
rolecraft watch my-skill
```

## Nasıl çalışır

1. Lockfile'dan yüklü skill'leri okur
2. Local source'lu skill'lerin kaynak dizinlerine FSWatcher kurar
3. Dosya değişikliğinde skill'i yeniden resolve eder ve tüm agent'lara re-install eder
4. Lockfile'daki hash'leri günceller
5. GitHub/npm/git remote source'ları atlar (yalnızca local izlenebilir)

## Detaylar

- Debounce: 300ms (ardışık değişikliklerde tek sync)
- `--dry-run` ile preview desteklenmiyor (watch zaten çalışma anında real-time)
- Ctrl+C ile durdurma

Closes the watch mode item in the roadmap