### PR TITLE
feat: add benchmark comparison SVG visual

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@
 </p>
 
 <p align="center">
-  <a href="benchmark/RESULTS.md"><b>Benchmark: 434x faster than Vercel →</b></a>
+  <a href="benchmark/RESULTS.md"><img src="benchmark/comparison.svg" alt="Benchmark: 434x faster than Vercel" width="600"></a>
+  <br>
+  <a href="benchmark/RESULTS.md"><b>Full benchmark results →</b></a>
     
   <a href="docs/comparison.md"><b>Full feature comparison →</b></a>
     

--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -7,6 +7,10 @@
 > **Fixture (GitHub):** [`sametcelikbicak/task-decomposer`](https://github.com/sametcelikbicak/task-decomposer)
 > **Iterations:** 10 per tool per scenario
 
+<p align="center">
+  <img src="comparison.svg" alt="Benchmark comparison chart" width="800">
+</p>
+
 ## Local path install
 
 | Tool | avg | min | max | p50 | vs rolecraft |

--- a/benchmark/comparison.svg
+++ b/benchmark/comparison.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="820" viewBox="0 0 800 820">
+  <rect width="800" height="820" fill="#ffffff" rx="12"/>
+  <rect x="0" y="0" width="800" height="80" fill="#f8fafc" rx="12"/>
+  <text x="40" y="34" font-family="system-ui,sans-serif" font-size="20" fill="#1e293b" font-weight="800">⚡ Benchmark Comparison</text>
+  <text x="40" y="60" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">rolecraft vs Vercel skills vs @agentskill.sh/cli · Node.js v22 · 10 iterations</text>
+
+  <text x="40" y="110" font-family="system-ui,sans-serif" font-size="16" fill="#1e293b" font-weight="700">📁 Local Path Install — Speed</text>
+  <rect x="40" y="125" width="580" height="50" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="48" y="147" font-family="system-ui,sans-serif" font-size="14" fill="#15803d" font-weight="700">🏆 rolecraft is 434x faster than Vercel skills</text>
+  <text x="48" y="165" font-family="system-ui,sans-serif" font-size="11" fill="#64748b">@agentskill.sh/cli: not supported for local paths (marketplace-only)</text>
+
+  <rect x="40" y="195" width="1.1430232558139535" height="28" rx="4" fill="#15803d" opacity="0.9"/><text x="48" y="214" font-family="system-ui,sans-serif" font-size="13" fill="#15803d" font-weight="600">rolecraft</text><text x="198" y="214" font-family="system-ui,sans-serif" font-size="12" fill="#64748b">9.83 ms</text>
+  <rect x="40" y="233" width="495.6976744186046" height="28" rx="4" fill="#1d4ed8" opacity="0.9"/><text x="48" y="252" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">Vercel skills</text><text x="527.6976744186046" y="252" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">4,263 ms</text>
+
+  <text x="40" y="290" font-family="system-ui,sans-serif" font-size="16" fill="#1e293b" font-weight="700">🌐 GitHub Repo Install — Speed</text>
+  <rect x="40" y="320" width="190.9090909090909" height="28" rx="4" fill="#15803d" opacity="0.9"/><text x="48" y="339" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">rolecraft</text><text x="222.9090909090909" y="339" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">4.2 s</text>
+  <rect x="40" y="358" width="455.6363636363636" height="28" rx="4" fill="#1d4ed8" opacity="0.9"/><text x="48" y="377" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">Vercel skills</text><text x="487.6363636363636" y="377" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">10.0 s</text>
+
+  <text x="40" y="415" font-family="system-ui,sans-serif" font-size="12" fill="#64748b">@agentskill.sh/cli: failed — Error: Unknown agent: antigravity-cli</text>
+
+  <text x="40" y="450" font-family="system-ui,sans-serif" font-size="16" fill="#1e293b" font-weight="700">📦 Package Size</text>
+  <text x="40" y="497" font-family="system-ui,sans-serif" font-size="13" fill="#15803d" font-weight="600">rolecraft</text>
+  <rect x="185" y="484" width="14" height="24" rx="3" fill="#15803d" opacity="0.9"/>
+  <text x="205" y="500" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">~4 KB</text>
+
+  <text x="40" y="535" font-family="system-ui,sans-serif" font-size="13" fill="#1d4ed8" font-weight="600">Vercel skills</text>
+  <rect x="185" y="522" width="277.02127659574467" height="24" rx="3" fill="#1d4ed8" opacity="0.9"/>
+  <text x="470.02127659574467" y="538" font-family="system-ui,sans-serif" font-size="13" fill="#64748b" font-weight="600">~465 KB</text>
+
+  <text x="40" y="573" font-family="system-ui,sans-serif" font-size="13" fill="#92400e" font-weight="600">@agentskill.sh/cli</text>
+  <rect x="185" y="560" width="50.04255319148936" height="24" rx="3" fill="#92400e" opacity="0.9"/>
+  <text x="243.04255319148936" y="576" font-family="system-ui,sans-serif" font-size="13" fill="#64748b" font-weight="600">~84 KB</text>
+
+  <text x="40" y="620" font-family="system-ui,sans-serif" font-size="12" fill="#64748b">Dependencies: rolecraft 0 · Vercel 1 · @agentskill.sh/cli 2</text>
+
+  <line x1="40" y1="660" x2="760" y2="660" stroke="#e2e8f0" stroke-width="1"/>
+
+  <text x="40" y="685" font-family="system-ui,sans-serif" font-size="13" fill="#1e293b" font-weight="600">Agent Support</text>
+  <rect x="40" y="700" width="200" height="24" rx="4" fill="#15803d"/>
+  <text x="50" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">rolecraft: 82+ agents</text>
+  <rect x="260" y="700" width="200" height="24" rx="4" fill="#1d4ed8"/>
+  <text x="270" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">Vercel skills: 72 agents</text>
+  <rect x="480" y="700" width="200" height="24" rx="4" fill="#92400e"/>
+  <text x="490" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">@agentskill.sh/cli: 15+</text>
+
+  <text x="40" y="755" font-family="system-ui,sans-serif" font-size="13" fill="#1e293b" font-weight="600">Unique Features</text>
+  <text x="40" y="778" font-family="system-ui,sans-serif" font-size="12" fill="#1e293b">✅ MCP server management    ✅ bundle + create    ✅ watch mode (auto-sync)</text>
+  <text x="40" y="798" font-family="system-ui,sans-serif" font-size="12" fill="#1e293b">✅ shell completions        ✅ doctor            ✅ agents-xml</text>
+</svg>

--- a/scripts/benchmark-visual.js
+++ b/scripts/benchmark-visual.js
@@ -1,0 +1,82 @@
+import { writeFileSync } from 'node:fs'
+
+const W = 800
+const H = 820
+const COLORS = {
+  rolecraft: '#15803d',
+  rolecraftLight: '#22c55e',
+  vercel: '#1d4ed8',
+  vercelLight: '#3b82f6',
+  agentskill: '#92400e',
+  agentskillLight: '#d97706',
+  bg: '#ffffff',
+  text: '#1e293b',
+  muted: '#64748b',
+  border: '#e2e8f0',
+  highlight: '#f0fdf4',
+}
+
+function sectionTitle(y, text) {
+  return `<text x="40" y="${y}" font-family="system-ui,sans-serif" font-size="16" fill="${COLORS.text}" font-weight="700">${esc(text)}</text>`
+}
+
+function esc(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+const MAX_LOCAL = 4300
+const MAX_GITHUB = 11000
+const MAX_SIZE = 470
+
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+  <rect width="${W}" height="${H}" fill="${COLORS.bg}" rx="12"/>
+  <rect x="0" y="0" width="${W}" height="80" fill="#f8fafc" rx="12"/>
+  <text x="40" y="34" font-family="system-ui,sans-serif" font-size="20" fill="${COLORS.text}" font-weight="800">⚡ Benchmark Comparison</text>
+  <text x="40" y="60" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}">rolecraft vs Vercel skills vs @agentskill.sh/cli · Node.js v22 · 10 iterations</text>
+
+  ${sectionTitle(110, '📁 Local Path Install — Speed')}
+  <rect x="40" y="125" width="580" height="50" rx="8" fill="${COLORS.highlight}" stroke="${COLORS.rolecraftLight}" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="48" y="147" font-family="system-ui,sans-serif" font-size="14" fill="${COLORS.rolecraft}" font-weight="700">🏆 rolecraft is 434x faster than Vercel skills</text>
+  <text x="48" y="165" font-family="system-ui,sans-serif" font-size="11" fill="${COLORS.muted}">@agentskill.sh/cli: not supported for local paths (marketplace-only)</text>
+
+  <rect x="40" y="195" width="${(9.83 / MAX_LOCAL) * 500}" height="28" rx="4" fill="${COLORS.rolecraft}" opacity="0.9"/><text x="48" y="214" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.rolecraft}" font-weight="600">rolecraft</text><text x="198" y="214" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.muted}">9.83 ms</text>
+  <rect x="40" y="233" width="${(4263 / MAX_LOCAL) * 500}" height="28" rx="4" fill="${COLORS.vercel}" opacity="0.9"/><text x="48" y="252" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">Vercel skills</text><text x="${40 + (4263 / MAX_LOCAL) * 500 - 8}" y="252" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">4,263 ms</text>
+
+  ${sectionTitle(290, '🌐 GitHub Repo Install — Speed')}
+  <rect x="40" y="320" width="${(4200 / MAX_GITHUB) * 500}" height="28" rx="4" fill="${COLORS.rolecraft}" opacity="0.9"/><text x="48" y="339" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">rolecraft</text><text x="${40 + (4200 / MAX_GITHUB) * 500 - 8}" y="339" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">4.2 s</text>
+  <rect x="40" y="358" width="${(10024 / MAX_GITHUB) * 500}" height="28" rx="4" fill="${COLORS.vercel}" opacity="0.9"/><text x="48" y="377" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">Vercel skills</text><text x="${40 + (10024 / MAX_GITHUB) * 500 - 8}" y="377" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">10.0 s</text>
+
+  <text x="40" y="415" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.muted}">@agentskill.sh/cli: failed — Error: Unknown agent: antigravity-cli</text>
+
+  ${sectionTitle(450, '📦 Package Size')}
+  <text x="40" y="497" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.rolecraft}" font-weight="600">rolecraft</text>
+  <rect x="185" y="484" width="14" height="24" rx="3" fill="${COLORS.rolecraft}" opacity="0.9"/>
+  <text x="205" y="500" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}">~4 KB</text>
+
+  <text x="40" y="535" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.vercel}" font-weight="600">Vercel skills</text>
+  <rect x="185" y="522" width="${(465 / MAX_SIZE) * 280}" height="24" rx="3" fill="${COLORS.vercel}" opacity="0.9"/>
+  <text x="${185 + (465 / MAX_SIZE) * 280 + 8}" y="538" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}" font-weight="600">~465 KB</text>
+
+  <text x="40" y="573" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.agentskill}" font-weight="600">@agentskill.sh/cli</text>
+  <rect x="185" y="560" width="${Math.max((84 / MAX_SIZE) * 280, 14)}" height="24" rx="3" fill="${COLORS.agentskill}" opacity="0.9"/>
+  <text x="${185 + Math.max((84 / MAX_SIZE) * 280, 14) + 8}" y="576" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}" font-weight="600">~84 KB</text>
+
+  <text x="40" y="620" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.muted}">Dependencies: rolecraft 0 · Vercel 1 · @agentskill.sh/cli 2</text>
+
+  <line x1="40" y1="660" x2="760" y2="660" stroke="${COLORS.border}" stroke-width="1"/>
+
+  <text x="40" y="685" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.text}" font-weight="600">Agent Support</text>
+  <rect x="40" y="700" width="200" height="24" rx="4" fill="${COLORS.rolecraft}"/>
+  <text x="50" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">rolecraft: 82+ agents</text>
+  <rect x="260" y="700" width="200" height="24" rx="4" fill="${COLORS.vercel}"/>
+  <text x="270" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">Vercel skills: 72 agents</text>
+  <rect x="480" y="700" width="200" height="24" rx="4" fill="${COLORS.agentskill}"/>
+  <text x="490" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">@agentskill.sh/cli: 15+</text>
+
+  <text x="40" y="755" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.text}" font-weight="600">Unique Features</text>
+  <text x="40" y="778" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.text}">✅ MCP server management    ✅ bundle + create    ✅ watch mode (auto-sync)</text>
+  <text x="40" y="798" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.text}">✅ shell completions        ✅ doctor            ✅ agents-xml</text>
+</svg>`
+
+writeFileSync('benchmark/comparison.svg', svg)
+console.log('✅ benchmark/comparison.svg created')


### PR DESCRIPTION
## Summary

Adds a visual benchmark comparison SVG showing rolecraft vs Vercel skills vs @agentskill.sh/cli across 4 dimensions:

- **📁 Local install speed** — 434x faster than Vercel (9.83ms vs 4263ms)
- **🌐 GitHub install speed** — 2.4x faster (4.2s vs 10.0s)
- **📦 Package size** — ~4KB vs ~465KB vs ~84KB
- **Agent support & features** comparison

### Changes
- New `benchmark/comparison.svg` — zero-dependency SVG bar chart
- New `scripts/benchmark-visual.js` — reproducible generation script
- Updated `benchmark/RESULTS.md` — embed visual at top
- Updated `README.md` — replace benchmark text link with clickable visual

### Contrast
All background colors pass WCAG AA contrast ratio with white text (≥4.5:1)