### PR TITLE
fix: enable docs deployment after release

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -75,7 +75,7 @@ jobs:
           git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
           git checkout -b "$BRANCH_NAME"
           git add CHANGELOG.md package.json
-          git commit -m "chore: update changelog and version for ${{ github.ref_name }} [skip ci]"
+          git commit -m "chore: update changelog and version for ${{ github.ref_name }}"
           git push origin "$BRANCH_NAME"
 
       - name: Update tag to release commit (re-signed)

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,3 +34,15 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  deploy-docs:
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'changelog/'))
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger docs deployment
+        run: gh workflow run "Deploy docs" --ref main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Docs sitesi release sonrası güncellenmiyordu. Sebebi: `release-prep.yml` commit mesajında `[skip ci]` vardı, bu da PR merge olunca `docs.yml`'ın tetiklenmesini engelliyordu.

## Değişiklikler

1. **`release-prep.yml`** — Commit mesajından `[skip ci]` kaldırıldı. Tag force-push loop'u zaten `github.actor != 'github-actions[bot]'` guard'ı ile engelleniyor.
2. **`release-publish.yml`** — npm publish sonrası docs workflow'unu tetikleyen `deploy-docs` job'ı eklendi (safety net).

Fixes: docs version not updating after release
