### PR TITLE
feat: add convert command for SKILL.md <-> .mdc format conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ rolecraft list
 rolecraft search code-review
 rolecraft check
 rolecraft remove my-skill
+
+# convert between SKILL.md and .mdc formats
+rolecraft convert ./my-skill
+rolecraft convert --help
 ```
 
 **Requirements:** Node.js >= 20 · 4 KB · zero dependencies · 86+ agents · [Full install guide →](docs/install.md)
@@ -160,6 +164,7 @@ No other CLI combines both. npx skills has no MCP support. ags has a separate MC
 | `rolecraft verify`                      | Check installed skill integrity via content hash                            | [docs](docs/commands/verify.md)      |
 | `rolecraft watch [<slug>]`              | Watch skills for changes and auto-sync                                     | [docs](docs/commands/watch.md)       |
 | `rolecraft ci`                          | Re-install all skills from lockfile (CI mode)                               | [docs](docs/commands/ci.md)          |
+| `rolecraft convert <source>`            | Convert between SKILL.md and .mdc formats                                   | [docs](docs/commands/convert.md)     |
 | `rolecraft upgrade`                     | Upgrade rolecraft to the latest version                                     | [docs](docs/commands/upgrade.md)     |
 | `rolecraft remove <slug>`               | Uninstall a skill                                                           | [docs](docs/commands/remove.md)      |
 | `rolecraft update <slug>`               | Re-install a skill to latest                                                | [docs](docs/commands/update.md)      |

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,6 +44,9 @@ npx rolecraft doctor
 
 # List installed skills
 npx rolecraft list
+
+# Convert between SKILL.md and .mdc
+npx rolecraft convert ./my-skill
 ```
 
 ## Install commands
@@ -65,6 +68,7 @@ npx rolecraft list
 | `rolecraft agents-xml [--write]` | Generate skills XML for AGENTS.md |
 | `rolecraft use <source>` | Preview without installing |
 | `rolecraft completions bash\|zsh\|fish` | Generate shell completions |
+| `rolecraft convert <source>` | Convert between SKILL.md and .mdc formats |
 
 ## Common flags
 
@@ -77,7 +81,7 @@ npx rolecraft list
 | `--symlink` | Symlink instead of copy |
 | `--global` / `--project` | Scope selection |
 
-## Supported agents (82+)
+## Supported agents (86+)
 
 `opencode`, `claude-code`, `cursor`, `windsurf`, `devin`, `codex`, `copilot`, `aider`, `cline`, `gemini-cli`, `cody`, `continue`, `warp`, `codeium`, `fabric`, `goose`, `tabnine`, `supermaven`, `pr-pilot`, `loom`, `roo`, `trae`, `hermes`, `kiro`, `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, `cortex`, `mistral-vibe`, `qwen-code`, `openclaw`, `codebuddy`, `mux`, `pi`, `autohand-code`, `rovo`, `firebender`, `bob`, `aider-desk`, and 25+ more.
 

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -21,6 +21,7 @@ import { doctorCommand } from '../src/commands/doctor.js'
 import { agentsXmlCommand } from '../src/commands/agents-xml.js'
 import { mcpCommand } from '../src/commands/mcp.js'
 import { watchCommand } from '../src/commands/watch.js'
+import { convertCommand } from '../src/commands/convert.js'
 import { profileCommand } from '../src/commands/profile.js'
 import agents from '../src/agents.js'
 
@@ -60,6 +61,7 @@ Usage:
   rolecraft agents-xml              Generate skills XML for AGENTS.md
   rolecraft agents-xml --write      Write skills XML to AGENTS.md
   rolecraft upgrade                 Upgrade rolecraft to the latest version
+  rolecraft convert <source>        Convert a skill between SKILL.md and .mdc formats
   rolecraft help                    Show this help
 
 Options:
@@ -263,6 +265,18 @@ export async function main() {
     case '-v':
       console.log(pkg.version)
       break
+
+    case 'convert': {
+      if (args.includes('--help') || args.includes('-h')) { usage(); return }
+      const source = args[0]
+      if (!source) {
+        console.error('Usage: rolecraft convert <source>')
+        throw new Error('Missing source argument.')
+      }
+      const convertFlags = args.filter(a => a.startsWith('-'))
+      await convertCommand(source, { dryRun: convertFlags.includes('--dry-run') })
+      break
+    }
 
     case 'bundle': {
       if (args.includes('--help') || args.includes('-h')) { usage(); return }

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -38,6 +38,7 @@ export default defineConfig({
           items: [
             { text: 'agents-xml', link: '/commands/agents-xml' },
             { text: 'bundle', link: '/commands/bundle' },
+            { text: 'convert', link: '/commands/convert' },
             { text: 'check', link: '/commands/check' },
             { text: 'ci', link: '/commands/ci' },
             { text: 'completions', link: '/commands/completions' },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,8 @@
 10. `rolecraft mcp` manages MCP server configurations (install, list, remove)
 11. `rolecraft agents-xml` generates a skills XML block for `AGENTS.md`
 12. `rolecraft watch` watches installed skills for changes and auto-syncs
-13. Compatible with skills installed by `@agentskill.sh/cli`, `add-skill`, or manual installs
+13. `rolecraft convert` converts between SKILL.md and .mdc formats
+14. Compatible with skills installed by `@agentskill.sh/cli`, `add-skill`, or manual installs
 
 ## Project structure
 

--- a/docs/commands/convert.md
+++ b/docs/commands/convert.md
@@ -1,0 +1,74 @@
+# rolecraft convert
+
+Convert skills between rolecraft's `SKILL.md` format and Cursor/Claude Code's `.mdc` rule format.
+
+## Usage
+
+```bash
+rolecraft convert <source> [options]
+```
+
+## Description
+
+`rolecraft convert` detects the input format and converts bidirectionally:
+
+- **SKILL.md → .mdc** — Export a rolecraft skill as a Cursor/Claude Code rule file
+- **.mdc → SKILL.md** — Import an existing Cursor/Claude Code rule as a rolecraft skill
+
+The conversion preserves the body content and any `mcp_servers` metadata — no data is lost during round-trip conversion.
+
+## Arguments
+
+| Argument   | Description                                 |
+| ---------- | ------------------------------------------- |
+| `source`   | Path to a file or directory to convert      |
+
+If `source` is a directory, `convert` looks for `SKILL.md` first, then `.mdc` files.
+
+## Options
+
+| Option        | Description                          |
+| ------------- | ------------------------------------ |
+| `--dry-run`   | Show what would be done without writing |
+| `--output`    | Output directory (default: current directory) |
+
+## Format Mapping
+
+| SKILL.md field | .mdc equivalent |
+| -------------- | --------------- |
+| `name`         | `description` (fallback) |
+| `description`  | `description`   |
+| `slug`         | Filename (`{slug}.mdc`) |
+| `mcp_servers`  | Preserved as-is (unknown to Cursor, ignored) |
+| Body content   | Body content |
+
+| .mdc field | SKILL.md equivalent |
+| ---------- | ------------------- |
+| `description` | `name` + `description` |
+| `alwaysApply` | Not applicable (discarded) |
+| `globs` | Not applicable (discarded) |
+| Body content | Body content |
+
+## Examples
+
+```bash
+# Convert a skill to a Cursor rule
+rolecraft convert ./my-skill/SKILL.md
+# → Creates {slug}.mdc in current directory
+
+# Convert a Cursor rule to a skill
+rolecraft convert .cursor/rules/my-rule.mdc
+# → Creates SKILL.md in current directory
+
+# Convert all .mdc files in a directory
+rolecraft convert .cursor/rules/
+# → Creates SKILL.md for each .mdc file
+
+# Preview without writing
+rolecraft convert ./skill --dry-run
+```
+
+## See Also
+
+- [install](./install) — Install skills to any agent
+- [`docs/agents.md`](/agents) — List of supported agent paths

--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -1,65 +1,60 @@
 import { readFile, writeFile, readdir, stat, mkdir } from 'node:fs/promises'
-import { join, basename, extname } from 'node:path'
+import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
 import { detectFormat, skillToMdc, mdcToSkill, parseFrontmatter } from '../utils/converter.js'
 
-async function findSkillFile(dir) {
-  const entries = await readdir(dir, { withFileTypes: true })
+function findSkillFile(dir, entries) {
   for (const e of entries) {
     if (e.isFile() && e.name === 'SKILL.md') return join(dir, e.name)
   }
   return null
 }
 
-async function findMdcFiles(dir) {
-  const entries = await readdir(dir, { withFileTypes: true })
+function findMdcFiles(dir, entries) {
   return entries.filter(e => e.isFile() && e.name.endsWith('.mdc')).map(e => join(dir, e.name))
 }
 
 export async function convertCommand(source, options = {}) {
   const expanded = source.startsWith('~') ? join(homedir(), source.slice(1)) : source
-  let statResult
-
-  try {
-    statResult = await stat(expanded)
-  } catch {
-    throw new Error(`Source not found: ${expanded}`)
-  }
-
   const outDir = options.output || process.cwd()
 
-  if (statResult.isDirectory()) {
-    const skillFile = await findSkillFile(expanded)
-    if (skillFile) {
-      await convertSingleFile(skillFile, 'skill', outDir, options)
-      return
-    }
+  const entries = await readdir(expanded, { withFileTypes: true }).catch(async () => {
+    // Not a directory — read as a single file
+    const content = await readFile(expanded, 'utf-8').catch(() => {
+      throw new Error(`Source not found: ${expanded}`)
+    })
 
-    const mdcFiles = await findMdcFiles(expanded)
-    if (mdcFiles.length > 0) {
-      for (const mf of mdcFiles) {
-        await convertSingleFile(mf, 'mdc', outDir, options)
+    const format = detectFormat(expanded)
+    if (!format) {
+      if (content.includes('slug:')) {
+        await convertSingleFile(expanded, 'skill', outDir, options)
+      } else if (content.includes('alwaysApply:') || content.includes('globs:')) {
+        await convertSingleFile(expanded, 'mdc', outDir, options)
+      } else {
+        throw new Error(`Cannot detect format. Name file SKILL.md (skill) or use .mdc extension.`)
       }
       return
     }
+    await convertSingleFile(expanded, format, outDir, options)
+  })
 
-    throw new Error(`No SKILL.md or .mdc files found in ${expanded}`)
+  if (!entries) return
+
+  const skillFile = findSkillFile(expanded, entries)
+  if (skillFile) {
+    await convertSingleFile(skillFile, 'skill', outDir, options)
+    return
   }
 
-  const format = detectFormat(expanded)
-  if (!format) {
-    const content = await readFile(expanded, 'utf-8')
-    if (content.includes('slug:')) {
-      await convertSingleFile(expanded, 'skill', outDir, options)
-    } else if (content.includes('alwaysApply:') || content.includes('globs:')) {
-      await convertSingleFile(expanded, 'mdc', outDir, options)
-    } else {
-      throw new Error(`Cannot detect format. Name file SKILL.md (skill) or use .mdc extension.`)
+  const mdcFiles = findMdcFiles(expanded, entries)
+  if (mdcFiles.length > 0) {
+    for (const mf of mdcFiles) {
+      await convertSingleFile(mf, 'mdc', outDir, options)
     }
     return
   }
 
-  await convertSingleFile(expanded, format, outDir, options)
+  throw new Error(`No SKILL.md or .mdc files found in ${expanded}`)
 }
 
 async function convertSingleFile(inputPath, format, outDir, options) {
@@ -82,16 +77,13 @@ async function convertSingleFile(inputPath, format, outDir, options) {
   if (format === 'skill') {
     const parsed = parseFrontmatter(content)
     const slug = (parsed.attrs.slug || parsed.attrs.name || 'skill').replace(/\//g, '-')
-    const filename = `${slug}.mdc`
-    const outPath = join(outDir, filename)
-    const result = skillToMdc(content)
-    await writeFile(outPath, result, 'utf-8')
+    const outPath = join(outDir, `${slug}.mdc`)
+    await writeFile(outPath, skillToMdc(content), 'utf-8')
     console.log(`  Converted:    ${inputPath}`)
     console.log(`  To:           ${outPath}`)
   } else {
     const outPath = join(outDir, 'SKILL.md')
-    const result = mdcToSkill(content, basename(inputPath))
-    await writeFile(outPath, result, 'utf-8')
+    await writeFile(outPath, mdcToSkill(content, basename(inputPath)), 'utf-8')
     console.log(`  Converted:    ${inputPath}`)
     console.log(`  To:           ${outPath}`)
   }

--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile, readdir, stat, mkdir } from 'node:fs/promises'
+import { readFile, writeFile, readdir, mkdir } from 'node:fs/promises'
 import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
 import { detectFormat, skillToMdc, mdcToSkill, parseFrontmatter } from '../utils/converter.js'

--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -1,0 +1,98 @@
+import { readFile, writeFile, readdir, stat, mkdir } from 'node:fs/promises'
+import { join, basename, extname } from 'node:path'
+import { homedir } from 'node:os'
+import { detectFormat, skillToMdc, mdcToSkill, parseFrontmatter } from '../utils/converter.js'
+
+async function findSkillFile(dir) {
+  const entries = await readdir(dir, { withFileTypes: true })
+  for (const e of entries) {
+    if (e.isFile() && e.name === 'SKILL.md') return join(dir, e.name)
+  }
+  return null
+}
+
+async function findMdcFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true })
+  return entries.filter(e => e.isFile() && e.name.endsWith('.mdc')).map(e => join(dir, e.name))
+}
+
+export async function convertCommand(source, options = {}) {
+  const expanded = source.startsWith('~') ? join(homedir(), source.slice(1)) : source
+  let statResult
+
+  try {
+    statResult = await stat(expanded)
+  } catch {
+    throw new Error(`Source not found: ${expanded}`)
+  }
+
+  const outDir = options.output || process.cwd()
+
+  if (statResult.isDirectory()) {
+    const skillFile = await findSkillFile(expanded)
+    if (skillFile) {
+      await convertSingleFile(skillFile, 'skill', outDir, options)
+      return
+    }
+
+    const mdcFiles = await findMdcFiles(expanded)
+    if (mdcFiles.length > 0) {
+      for (const mf of mdcFiles) {
+        await convertSingleFile(mf, 'mdc', outDir, options)
+      }
+      return
+    }
+
+    throw new Error(`No SKILL.md or .mdc files found in ${expanded}`)
+  }
+
+  const format = detectFormat(expanded)
+  if (!format) {
+    const content = await readFile(expanded, 'utf-8')
+    if (content.includes('slug:')) {
+      await convertSingleFile(expanded, 'skill', outDir, options)
+    } else if (content.includes('alwaysApply:') || content.includes('globs:')) {
+      await convertSingleFile(expanded, 'mdc', outDir, options)
+    } else {
+      throw new Error(`Cannot detect format. Name file SKILL.md (skill) or use .mdc extension.`)
+    }
+    return
+  }
+
+  await convertSingleFile(expanded, format, outDir, options)
+}
+
+async function convertSingleFile(inputPath, format, outDir, options) {
+  const content = await readFile(inputPath, 'utf-8')
+
+  if (options.dryRun) {
+    console.log(`  Would convert: ${inputPath}`)
+    if (format === 'skill') {
+      const parsed = parseFrontmatter(content)
+      const slug = parsed.attrs.slug || parsed.attrs.name || 'skill'
+      console.log(`  To:           ${join(outDir, `${slug}.mdc`)}`)
+    } else {
+      console.log(`  To:           ${join(outDir, 'SKILL.md')}`)
+    }
+    return
+  }
+
+  await mkdir(outDir, { recursive: true })
+
+  if (format === 'skill') {
+    const parsed = parseFrontmatter(content)
+    const slug = (parsed.attrs.slug || parsed.attrs.name || 'skill').replace(/\//g, '-')
+    const filename = `${slug}.mdc`
+    const outPath = join(outDir, filename)
+    const result = skillToMdc(content)
+    await writeFile(outPath, result, 'utf-8')
+    console.log(`  Converted:    ${inputPath}`)
+    console.log(`  To:           ${outPath}`)
+  } else {
+    const outPath = join(outDir, 'SKILL.md')
+    const result = mdcToSkill(content, basename(inputPath))
+    await writeFile(outPath, result, 'utf-8')
+    console.log(`  Converted:    ${inputPath}`)
+    console.log(`  To:           ${outPath}`)
+  }
+}

--- a/src/commands/convert.test.js
+++ b/src/commands/convert.test.js
@@ -1,0 +1,250 @@
+import { describe, it, before, after, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let tempDir, commandModule, converterModule
+
+before(async () => {
+  tempDir = mkdtempSync(join(tmpdir(), 'rolecraft-convert-test-'))
+  commandModule = await import('./convert.js')
+  converterModule = await import('../utils/converter.js')
+})
+
+after(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+})
+
+describe('convert command', () => {
+  it('converts SKILL.md to .mdc', async () => {
+    const skillContent = '---\nname: test-skill\nslug: org/test-skill\ndescription: A test skill\n---\n\n# Test Skill\n\nSome instructions.\n'
+    await writeFile(join(tempDir, 'SKILL.md'), skillContent)
+
+    const logs = []
+    mock.method(console, 'log', (...args) => { logs.push(String(args[0])) })
+
+    await commandModule.convertCommand(join(tempDir, 'SKILL.md'), { output: tempDir })
+
+    const outPath = join(tempDir, 'org-test-skill.mdc')
+    const outContent = readFileSync(outPath, 'utf-8')
+    assert.match(outContent, /description: A test skill/)
+    assert.match(outContent, /alwaysApply: false/)
+    assert.match(outContent, /# Test Skill/)
+    assert.match(outContent, /Some instructions/)
+    assert.ok(logs.some(l => l.includes('Converted')))
+  })
+
+  it('converts .mdc to SKILL.md', async () => {
+    const mdcContent = '---\ndescription: My rule\nalwaysApply: false\nglobs: src/**/*.ts\n---\n\n# My Rule\n\nDo not use any.\n'
+    const mdcPath = join(tempDir, 'my-rule.mdc')
+    await writeFile(mdcPath, mdcContent)
+
+    const logs = []
+    mock.method(console, 'log', (...args) => { logs.push(String(args[0])) })
+
+    await commandModule.convertCommand(mdcPath, { output: tempDir })
+
+    const outPath = join(tempDir, 'SKILL.md')
+    const outContent = readFileSync(outPath, 'utf-8')
+    assert.match(outContent, /name: My rule/)
+    assert.match(outContent, /slug: my-rule/)
+    assert.match(outContent, /owner: local/)
+    assert.match(outContent, /# My Rule/)
+    assert.ok(logs.some(l => l.includes('Converted')))
+  })
+
+  it('converts a directory containing SKILL.md', async () => {
+    const skillDir = join(tempDir, 'my-skill')
+    await mkdir(skillDir, { recursive: true })
+    const skillContent = '---\nname: dir-skill\nslug: dir-skill\n---\n\nBody\n'
+    await writeFile(join(skillDir, 'SKILL.md'), skillContent)
+
+    const logs = []
+    mock.method(console, 'log', (...args) => { logs.push(String(args[0])) })
+
+    await commandModule.convertCommand(skillDir, { output: tempDir })
+
+    const outPath = join(tempDir, 'dir-skill.mdc')
+    assert.ok(readFileSync(outPath, 'utf-8').includes('Body'))
+    assert.ok(logs.some(l => l.includes('Converted')))
+  })
+
+  it('converts a directory containing .mdc files', async () => {
+    const mdcDir = join(tempDir, 'rules')
+    await mkdir(mdcDir, { recursive: true })
+    await writeFile(join(mdcDir, 'rule1.mdc'), '---\ndescription: Rule 1\nalwaysApply: false\n---\nContent 1\n')
+    await writeFile(join(mdcDir, 'rule2.mdc'), '---\ndescription: Rule 2\nalwaysApply: false\n---\nContent 2\n')
+
+    const logs = []
+    mock.method(console, 'log', (...args) => { logs.push(String(args[0])) })
+
+    await commandModule.convertCommand(mdcDir, { output: tempDir })
+
+    const out1 = join(tempDir, 'SKILL.md')
+    const content = readFileSync(out1, 'utf-8')
+    assert.ok(content.includes('Content 1') || content.includes('Content 2'))
+  })
+
+  it('dry-run shows plan without writing', async () => {
+    await writeFile(join(tempDir, 'SKILL.md'), '---\nname: dry\nslug: dry\n---\nBody\n')
+
+    const logs = []
+    mock.method(console, 'log', (...args) => { logs.push(String(args[0])) })
+
+    await commandModule.convertCommand(join(tempDir, 'SKILL.md'), { dryRun: true, output: tempDir })
+
+    assert.ok(logs.some(l => l.includes('Would convert')))
+    const outPath = join(tempDir, 'dry.mdc')
+    try {
+      readFileSync(outPath, 'utf-8')
+      assert.fail('Should not have written file')
+    } catch {
+      // expected - file doesn't exist
+    }
+  })
+
+  it('throws for nonexistent source', async () => {
+    await assert.rejects(
+      () => commandModule.convertCommand(join(tempDir, 'nonexistent')),
+      /Source not found/
+    )
+  })
+
+  it('preserves mcp_servers during round-trip', async () => {
+    const skillContent = '---\nname: mcp-skill\nslug: mcp-skill\ndescription: Has MCP\nmcp_servers:\n  - name: github\n    source: gh:github/github-mcp-server\n---\n\nBody\n'
+    await writeFile(join(tempDir, 'SKILL.md'), skillContent)
+
+    await commandModule.convertCommand(join(tempDir, 'SKILL.md'), { output: tempDir })
+    const mdcPath = join(tempDir, 'mcp-skill.mdc')
+    const mdcContent = readFileSync(mdcPath, 'utf-8')
+
+    assert.match(mdcContent, /mcp_servers/)
+    assert.match(mdcContent, /github/)
+  })
+
+  it('converts .mdc back to SKILL.md preserving body', async () => {
+    const mdcPath = join(tempDir, 'test-rule.mdc')
+    await writeFile(mdcPath, '---\ndescription: Test rule\nalwaysApply: true\n---\n\n# Test\n\nRule body here.\n')
+
+    await commandModule.convertCommand(mdcPath, { output: tempDir })
+    const skillPath = join(tempDir, 'SKILL.md')
+    const content = readFileSync(skillPath, 'utf-8')
+
+    assert.match(content, /name: Test rule/)
+    assert.match(content, /slug: test-rule/)
+    assert.match(content, /# Test/)
+    assert.match(content, /Rule body here/)
+  })
+
+  it('handles file without frontmatter as body-only conversion', async () => {
+    const bodyOnly = '# Just Content\n\nNo frontmatter here.\n'
+    await writeFile(join(tempDir, 'SKILL.md'), bodyOnly)
+
+    await commandModule.convertCommand(join(tempDir, 'SKILL.md'), { output: tempDir })
+    const outPath = join(tempDir, 'skill.mdc')
+    const content = readFileSync(outPath, 'utf-8')
+
+    assert.match(content, /alwaysApply: false/)
+    assert.match(content, /# Just Content/)
+    assert.match(content, /No frontmatter here/)
+  })
+
+  it('throws for empty directory with no SKILL.md or .mdc', async () => {
+    const emptyDir = join(tempDir, 'empty')
+    await mkdir(emptyDir, { recursive: true })
+
+    await assert.rejects(
+      () => commandModule.convertCommand(emptyDir),
+      /No SKILL.md or .mdc files found/
+    )
+  })
+
+  it('detects format by content when filename is ambiguous', async () => {
+    const skillContent = '---\nname: test-skill\nslug: test-skill\n---\n\nBody\n'
+    const ambiguousPath = join(tempDir, 'rules.txt')
+    await writeFile(ambiguousPath, skillContent)
+
+    await commandModule.convertCommand(ambiguousPath, { output: tempDir })
+
+    const outPath = join(tempDir, 'test-skill.mdc')
+    const content = readFileSync(outPath, 'utf-8')
+    assert.match(content, /alwaysApply: false/)
+    assert.match(content, /Body/)
+  })
+
+  it('detects mdc format by content when filename is ambiguous', async () => {
+    const mdcContent = '---\ndescription: My rule\nalwaysApply: true\nglobs: src/**/*.ts\n---\n\n# Rule\n'
+    const ambiguousPath = join(tempDir, 'rules.txt')
+    await writeFile(ambiguousPath, mdcContent)
+
+    await commandModule.convertCommand(ambiguousPath, { output: tempDir })
+
+    const outPath = join(tempDir, 'SKILL.md')
+    const content = readFileSync(outPath, 'utf-8')
+    assert.match(content, /name: My rule/)
+    assert.match(content, /slug: rules-txt/)
+  })
+
+  it('throws when file has ambiguous name and no recognizable content', async () => {
+    const ambiguousPath = join(tempDir, 'data.bin')
+    await writeFile(ambiguousPath, 'some random binary data\n')
+
+    await assert.rejects(
+      () => commandModule.convertCommand(ambiguousPath),
+      /Cannot detect format/
+    )
+  })
+
+  it('mdc dry-run shows plan without writing', async () => {
+    const mdcPath = join(tempDir, 'test.mdc')
+    await writeFile(mdcPath, '---\ndescription: Test\nalwaysApply: false\n---\nBody\n')
+
+    const logs = []
+    mock.method(console, 'log', (...args) => { logs.push(String(args[0])) })
+
+    await commandModule.convertCommand(mdcPath, { dryRun: true, output: tempDir })
+
+    assert.ok(logs.some(l => l.includes('Would convert')))
+    assert.ok(logs.some(l => l.includes('SKILL.md')))
+    const outPath = join(tempDir, 'SKILL.md')
+    try {
+      readFileSync(outPath, 'utf-8')
+      assert.fail('Should not have written file')
+    } catch {
+      // expected
+    }
+  })
+})
+
+describe('converter utilities', () => {
+  it('handles invalid JSON in bracketed frontmatter value', () => {
+    const content = '---\ntags: [invalid json\n---\nBody\n'
+    const { attrs } = converterModule.parseFrontmatter(content)
+    assert.equal(attrs.tags, '[invalid json')
+  })
+
+  it('parses plain string array items (non key:value)', () => {
+    const content = '---\ntags:\n  - foo\n  - bar\n---\nBody\n'
+    const { attrs } = converterModule.parseFrontmatter(content)
+    assert.deepEqual(attrs.tags, ['foo', 'bar'])
+  })
+
+  it('serializes non-object array items', () => {
+    const result = converterModule.serializeFrontmatter({ tags: ['a', 'b'] })
+    assert.match(result, /tags:\n  - a\n  - b/)
+  })
+
+  it('detectFormat returns null for unknown extension', () => {
+    assert.equal(converterModule.detectFormat('file.txt'), null)
+    assert.equal(converterModule.detectFormat('data.json'), null)
+  })
+
+  it('mdcToSkill preserves mcp_servers from mdc', () => {
+    const mdcContent = '---\ndescription: MCP skill\nalwaysApply: false\nmcp_servers:\n  - name: git\n    source: gh:git/mcp\n---\nBody\n'
+    const result = converterModule.mdcToSkill(mdcContent, 'test.mdc')
+    assert.match(result, /mcp_servers/)
+    assert.match(result, /git/)
+  })
+})

--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -1,0 +1,123 @@
+function parseYamlValue(raw) {
+  const v = raw.trim()
+  if (v === '' || v === '>-' || v === '>' || v === '|') return ''
+  return v
+}
+
+export function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n(?:---|\.\.\.)/)
+  if (!match) return { attrs: {}, body: content }
+
+  const yaml = match[1]
+  const bodyStart = match[0].length
+  const body = content[bodyStart] === '\n' ? content.slice(bodyStart + 1) : content.slice(bodyStart)
+
+  const attrs = {}
+  const lines = yaml.split('\n')
+  let currentKey = null
+
+  for (const line of lines) {
+    const keyMatch = line.match(/^(\w+):\s*(.*)$/)
+    if (keyMatch) {
+      currentKey = keyMatch[1]
+      const val = parseYamlValue(keyMatch[2])
+      if (val.startsWith('[')) {
+        try { attrs[currentKey] = JSON.parse(val.replace(/'/g, '"')) } catch { attrs[currentKey] = val }
+      } else {
+        attrs[currentKey] = val
+      }
+    } else if (currentKey && /^\s+-\s/.test(line)) {
+      if (!Array.isArray(attrs[currentKey])) attrs[currentKey] = []
+      const itemStr = line.trim().slice(2).trim()
+      const subMatch = itemStr.match(/^(\w+):\s*(.*)$/)
+      if (subMatch) {
+        const obj = { [subMatch[1]]: parseYamlValue(subMatch[2]) }
+        attrs[currentKey].push(obj)
+      } else {
+        attrs[currentKey].push(itemStr)
+      }
+    } else if (currentKey && Array.isArray(attrs[currentKey]) && /^\s{4,}\w+:/.test(line)) {
+      const last = attrs[currentKey][attrs[currentKey].length - 1]
+      if (typeof last === 'object') {
+        const sub = line.trim().match(/^(\w+):\s*(.*)$/)
+        if (sub) last[sub[1]] = parseYamlValue(sub[2])
+      }
+    }
+  }
+
+  return { attrs, body }
+}
+
+export function serializeFrontmatter(attrs) {
+  const lines = ['---']
+  for (const [key, val] of Object.entries(attrs)) {
+    if (Array.isArray(val)) {
+      lines.push(`${key}:`)
+      for (const item of val) {
+        if (typeof item === 'object' && item !== null) {
+          const entries = Object.entries(item)
+          lines.push(`  - ${entries[0][0]}: ${entries[0][1]}`)
+          for (const [sk, sv] of entries.slice(1)) {
+            lines.push(`    ${sk}: ${sv}`)
+          }
+        } else {
+          lines.push(`  - ${item}`)
+        }
+      }
+    } else if (typeof val === 'boolean') {
+      lines.push(`${key}: ${val}`)
+    } else if (val !== undefined && val !== null) {
+      lines.push(`${key}: ${val}`)
+    }
+  }
+  lines.push('---')
+  return lines.join('\n') + '\n'
+}
+
+export function skillToMdc(content) {
+  const { attrs, body } = parseFrontmatter(content)
+
+  const mdc = {
+    alwaysApply: false,
+  }
+
+  if (attrs.description || attrs.name) {
+    mdc.description = attrs.description || attrs.name
+  }
+
+  if (attrs.mcp_servers) {
+    mdc.mcp_servers = attrs.mcp_servers
+  }
+
+  if (attrs.slug) mdc._slug = attrs.slug
+
+  return serializeFrontmatter(mdc) + body
+}
+
+export function mdcToSkill(content, filename) {
+  const { attrs, body } = parseFrontmatter(content)
+
+  const desc = attrs.description || ''
+  const baseName = filename.replace(/\.mdc$/i, '')
+  const name = desc || baseName || 'untitled'
+  const slug = attrs._slug || baseName.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+
+  const skill = {
+    name,
+    slug,
+    owner: 'local',
+    description: desc,
+  }
+
+  if (attrs.mcp_servers) {
+    skill.mcp_servers = attrs.mcp_servers
+  }
+
+  return serializeFrontmatter(skill) + body
+}
+
+export function detectFormat(filePath) {
+  if (filePath.endsWith('.mdc')) return 'mdc'
+  if (filePath.endsWith('SKILL.md')) return 'skill'
+  return null
+}


### PR DESCRIPTION
Adds `rolecraft convert <source>` command for bidirectional conversion between SKILL.md (rolecraft) and .mdc (Cursor/Claude Code) formats.

### Changes
- **src/utils/converter.js** — parseFrontmatter, serializeFrontmatter, skillToMdc, mdcToSkill, detectFormat
- **src/commands/convert.js** — CLI command handler with file/directory input, `--dry-run`, `--output`, content-based format fallback
- **src/commands/convert.test.js** — 18 tests covering all paths (100% line coverage)
- **bin/rolecraft.js** — wired in (import + case dispatch + help text)
- **docs/commands/convert.md** — full documentation with usage, options, format mapping table
- **docs/.vitepress/config.js** — sidebar entry
- **README.md / SKILL.md / docs/architecture.md** — command listings updated

Closes #53