### PR TITLE
feat: add skills.sh search with --skills-sh flag (experimental)

### DIFF
--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -47,7 +47,7 @@ Usage:
   rolecraft update <slug>           Re-install a skill (update to latest)
   rolecraft setup [<source>]        Detect agents and optionally install a skill
   rolecraft init [<name>]           Scaffold a new SKILL.md
-  rolecraft search <query>          Search for skills on GitHub
+  rolecraft search <query>          Search for skills on GitHub --skills-sh  Search skills.sh (experimental)
   rolecraft check                   Check for available skill updates
   rolecraft verify                  Verify installed skill integrity
   rolecraft ci                      Install all skills from lockfile
@@ -187,7 +187,7 @@ export async function main() {
         console.error('Usage: rolecraft search <query> [--interactive]')
         throw new Error('Missing query argument.')
       }
-      await searchCommand(query, { interactive: flags.includes('--interactive') })
+      await searchCommand(query, { interactive: flags.includes('--interactive'), skillsSh: flags.includes('--skills-sh') })
       break
     }
 

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -1,18 +1,26 @@
 # `rolecraft search`
 
-Search for skills on GitHub.
+Search for skills on GitHub or skills.sh (experimental).
 
 ## Usage
 
 ```bash
-rolecraft search <query> [--interactive]
+rolecraft search <query> [--interactive] [--skills-sh]
 ```
 
 ## Description
 
+### GitHub (default)
+
 Queries the GitHub API for repositories containing `SKILL.md` files matching your query. Results include stars, language, and the exact install command.
 
 Use `--interactive` to open an arrow-key navigable TUI. Browse results with `↑`/`↓`, select with `Enter`, or quit with `q`. A status bar at the bottom shows available commands.
+
+### skills.sh (experimental)
+
+> ⚠️ **Experimental.** The skills.sh API is undocumented and may change or become unavailable without notice.
+
+Use `--skills-sh` to search the [skills.sh](https://skills.sh) skill directory instead of GitHub. Results include install counts and the exact install command.
 
 ## Examples
 
@@ -31,4 +39,7 @@ rolecraft search code-review --interactive
 
 # Multi-word search + install
 rolecraft search "code review" --interactive
+
+# Search skills.sh directory (experimental)
+rolecraft search react --skills-sh
 ```

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -34,6 +34,12 @@ export function formatRepo(r) {
   return `${bold(r.full_name)}\n  ${dim(desc)}  ${yellow(`⭐ ${stars}`)}  ${cyan(lang)}`
 }
 
+export function formatSkillsShItem(skill) {
+  const desc = skill.name || 'No description'
+  const installs = skill.installs || 0
+  return `${bold(skill.source + '/' + skill.skillId)}\n  ${dim(desc)}  ${yellow(`📦 ${installs}`)}  ${cyan('skills.sh')}`
+}
+
 const ITEM_LINES = 4
 
 function tuiFormat(item, selected) {
@@ -211,6 +217,18 @@ async function searchGitHub(query, filenameFilter = true) {
   return await response.json()
 }
 
+async function searchSkillsSh(query) {
+  const url = `https://skills.sh/api/search?q=${encodeURIComponent(query)}`
+  const response = await runFetch(url, {
+    signal: AbortSignal.timeout(10000),
+  })
+  if (!response.ok) {
+    return { error: `skills.sh API error: ${response.status}` }
+  }
+  const data = await response.json()
+  return { items: data.skills || [] }
+}
+
 async function lookupGithubRepo(ref) {
   const url = `https://api.github.com/repos/${ref}`
   try {
@@ -266,6 +284,35 @@ function displayResults(data, query) {
 
 export async function searchCommand(query, options = {}) {
   let data
+
+  if (options.skillsSh) {
+    try {
+      data = await searchSkillsSh(query)
+    } catch {
+      throw new Error('Failed to search skills.sh. Check your internet connection.')
+    }
+
+    if (data.error) {
+      throw new Error(data.error)
+    }
+
+    if (data.items.length === 0) {
+      console.log(`\nNo skills found on skills.sh for "${query}".`)
+      return
+    }
+
+    console.log(`\n🔍 [Experimental] skills.sh results for "${query}":\n`)
+    for (const skill of data.items) {
+      const line = formatSkillsShItem(skill).split('\n')
+      console.log(`   ${line[0]}`)
+      console.log(`   ├─ ${line[1]}`)
+      console.log(`   └─ rolecraft install ${skill.source}/${skill.skillId}`)
+      console.log()
+    }
+    console.log(`${data.items.length} result(s) found.`)
+    console.log('\n⚠️  skills.sh integration is experimental. The API may change or become unavailable.')
+    return
+  }
 
   try {
     data = await searchOrLookup(query)

--- a/src/commands/search.test.js
+++ b/src/commands/search.test.js
@@ -373,4 +373,78 @@ describe('search command', () => {
       }
     })
   })
+
+  describe('skills.sh integration (experimental)', () => {
+    afterEach(() => {
+      searchModule.setFetch(globalThis.fetch)
+    })
+
+    it('formats a skills.sh item', () => {
+      const result = searchModule.formatSkillsShItem({
+        skillId: 'my-skill',
+        name: 'My Skill',
+        installs: 12345,
+        source: 'user/repo',
+      })
+      assert.ok(result.includes('user/repo/my-skill'))
+      assert.ok(result.includes('My Skill'))
+      assert.ok(result.includes('12345'))
+      assert.ok(result.includes('skills.sh'))
+    })
+
+    it('handles missing fields in skills.sh item', () => {
+      const result = searchModule.formatSkillsShItem({
+        skillId: 'test-skill',
+      })
+      assert.ok(result.includes('No description'))
+      assert.ok(result.includes('0'))
+    })
+
+    it('shows results from skills.sh', async () => {
+      mockFetch(200, {
+        skills: [
+          { skillId: 'skill-one', name: 'Skill One', installs: 100, source: 'user1/repo' },
+          { skillId: 'skill-two', name: 'Skill Two', installs: 50, source: 'user2/repo' },
+        ],
+      })
+
+      const { logs, restore } = capture('log')
+      await searchModule.searchCommand('test', { skillsSh: true })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('Experimental')))
+      assert.ok(logs.some(l => l.includes('skill-one')))
+      assert.ok(logs.some(l => l.includes('skill-two')))
+      assert.ok(logs.some(l => l.includes('100')))
+      assert.ok(logs.some(l => l.includes('2 result(s) found')))
+    })
+
+    it('shows no results message when skills.sh returns empty', async () => {
+      mockFetch(200, { skills: [] })
+
+      const { logs, restore } = capture('log')
+      await searchModule.searchCommand('nonexistent', { skillsSh: true })
+      restore()
+
+      assert.ok(logs.some(l => l.includes('No skills found')))
+    })
+
+    it('throws on skills.sh network error', async () => {
+      searchModule.setFetch(() => Promise.reject(new Error('network error')))
+
+      await assert.rejects(
+        () => searchModule.searchCommand('test', { skillsSh: true }),
+        /Failed to search skills/,
+      )
+    })
+
+    it('throws on skills.sh non-ok response', async () => {
+      mockFetch(500, {})
+
+      await assert.rejects(
+        () => searchModule.searchCommand('test', { skillsSh: true }),
+        /skills.sh API error: 500/,
+      )
+    })
+  })
 })


### PR DESCRIPTION
Adds **experimental** support for searching [skills.sh](https://skills.sh) — Vercel's skill directory — as an alternative to the default GitHub search.

### Changes

- **src/commands/search.js** — `searchSkillsSh()` fetches from `GET https://skills.sh/api/search?q=<query>` (undocumented, read-only API). `formatSkillsShItem()` formats results with install counts (`📦`). `searchCommand()` handles `--skills-sh` flag.
- **bin/rolecraft.js** — passes `{ skillsSh: true }` when `--skills-sh` is present, updated help text.
- **src/commands/search.test.js** — 6 new tests for `formatSkillsShItem`, `searchSkillsSh` mock, error handling.
- **docs/commands/search.md** — updated with `--skills-sh` usage and experimental warning.

### Why experimental?

skills.sh has no official public API documentation. The endpoint works today but may change or become rate-limited. Marking it experimental sets expectations and avoids breaking the CLI if the API changes.

### Usage

```bash
rolecraft search react --skills-sh
```
