### PR TITLE
docs: add getting-started, use-cases, and CLI reference pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ rolecraft convert ./my-skill
 rolecraft convert --help
 ```
 
-**Requirements:** Node.js >= 20 · 4 KB · zero dependencies · 86+ agents · [Full install guide →](docs/install.md)
+**Requirements:** Node.js >= 20 · 4 KB · zero dependencies · 86+ agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
 
 > **Why zero dependencies?** Every dependency is a supply-chain risk. rolecraft uses only Node.js built-ins (`fs`, `path`, `crypto`, `https`) — no `node_modules` surprises.
 
@@ -169,6 +169,7 @@ No other CLI combines both. npx skills has no MCP support. ags has a separate MC
 | `rolecraft remove <slug>`               | Uninstall a skill                                                           | [docs](docs/commands/remove.md)      |
 | `rolecraft update <slug>`               | Re-install a skill to latest                                                | [docs](docs/commands/update.md)      |
 | `rolecraft --version`                   | Show version                                                                |                                      |
+| `rolecraft --help`                      | Show full command reference                                                 | [CLI Reference](docs/reference.md)   |
 
 ---
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -21,9 +21,11 @@ export default defineConfig({
     logo: '/rolecraft_logo.png',
     siteTitle: `RoleCraft v${version}`,
     nav: [
+      { text: 'Getting Started', link: '/guides/getting-started' },
       { text: 'Onboarding', link: '/guides/onboarding' },
       { text: 'Install', link: '/install' },
       { text: 'Commands', link: '/commands/install' },
+      { text: 'Reference', link: '/reference' },
       { text: 'MCP', link: '/mcp' },
       { text: 'Benchmark', link: '/benchmark/RESULTS' },
       { text: 'Security', link: '/security' },
@@ -32,7 +34,15 @@ export default defineConfig({
       '/': [
         { text: 'Introduction', link: '/' },
         { text: 'Install Guide', link: '/install' },
-        { text: 'Onboarding Guide', link: '/guides/onboarding' },
+        {
+          text: 'Guides',
+          items: [
+            { text: 'Getting Started', link: '/guides/getting-started' },
+            { text: 'Onboarding Guide', link: '/guides/onboarding' },
+            { text: 'Use Cases', link: '/guides/use-cases' },
+          ],
+        },
+        { text: 'CLI Reference', link: '/reference' },
         {
           text: 'Commands',
           items: [

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,120 @@
+# Getting Started
+
+Welcome to **rolecraft** — a zero-dependency CLI for installing AI agent skills as roles & behaviors from any source.
+
+This guide gets you from zero to productive in 5 minutes.
+
+---
+
+## What is rolecraft?
+
+A skill is a reusable capability for your AI coding agent. Think of it as a plugin or a role:
+
+- **Code review assistant** — install a skill, every agent knows your review standards
+- **React best practices** — Cursor, Claude Code, and Copilot all follow the same rules
+- **Team conventions** — one command sets up every agent on every developer's machine
+- **MCP servers** — skills can declare and install MCP servers alongside themselves
+
+rolecraft manages all of this across **86+ AI agents** with a single CLI and **zero runtime dependencies**.
+
+---
+
+## Quick start
+
+### 1. Install
+
+```bash
+npm install -g rolecraft
+```
+
+Or run without installing:
+
+```bash
+npx rolecraft install <source>
+```
+
+> **Requirements:** Node.js >= 20. That's it. No other dependencies.
+
+### 2. Find a skill
+
+Search GitHub for skills:
+
+```bash
+rolecraft search code-review
+```
+
+This returns repositories containing `SKILL.md` files — the standard skill format.
+
+### 3. Install a skill
+
+Install to your default agent (project scope):
+
+```bash
+rolecraft install sametcelikbicak/task-decomposer
+```
+
+Or install to specific agents:
+
+```bash
+rolecraft install sametcelikbicak/task-decomposer --cursor --claude
+```
+
+Or install to **every** agent on your machine:
+
+```bash
+rolecraft install sametcelikbicak/task-decomposer --all
+```
+
+### 4. List installed skills
+
+```bash
+rolecraft list
+```
+
+Shows all skills with their scope (global vs project), target agents, and install date.
+
+### 5. Remove a skill
+
+```bash
+rolecraft remove task-decomposer
+```
+
+---
+
+## What just happened?
+
+When you ran `rolecraft install`:
+
+1. **Source resolution** — cloned/downloaded the source, found `SKILL.md`
+2. **Security scan** — analyzed every file for prompt injection, command injection, obfuscated code, and credential harvesting. Scored 0–100. Blocked if dangerous.
+3. **Install** — copied files to the target agent's skill directory
+4. **Lockfile update** — stored SHA256 content hashes for future verification
+
+You can verify integrity anytime:
+
+```bash
+rolecraft verify
+```
+
+---
+
+## Create your own skill
+
+```bash
+rolecraft init my-skill
+```
+
+This scaffolds a `SKILL.md` in `./my-skill/`. Edit the metadata and rules, then:
+
+```bash
+rolecraft install ./my-skill --all
+```
+
+---
+
+## Next steps
+
+- **[Onboarding Guide](./onboarding)** — set up your whole team in one command
+- **[Install Guide](../install)** — full reference for all install options
+- **[Security Scoring](../security)** — understand the static analysis
+- **[Comparison](../comparison)** — how rolecraft stacks up against other tools

--- a/docs/guides/use-cases.md
+++ b/docs/guides/use-cases.md
@@ -1,0 +1,202 @@
+# Use Cases
+
+rolecraft solves one problem: **getting AI agents to follow the same rules, conventions, and tools across your entire stack.** Here's when it shines.
+
+---
+
+## 1. Team onboarding
+
+**Problem:** Every new developer spends hours configuring cursor, claude-code, copilot, aider, and other agents. Each agent has a different config format, different skill directory, different MCP setup.
+
+**Solution:** One `rolecraft setup` command detects all agents and installs everything.
+
+```bash
+# New team member runs this once:
+npm install -g rolecraft
+rolecraft setup ./team-conventions
+```
+
+The team commits a `SKILL.md` with their conventions, MCP servers, and rules to the repo. New hires are productive in minutes.
+
+```yaml
+# team-conventions/SKILL.md
+name: frontend-conventions
+description: Frontend coding standards for the team
+mcp_servers:
+  - name: filesystem
+    source: npm:@modelcontextprotocol/server-filesystem
+rules: |
+  - Use TypeScript strict mode
+  - All components must have tests
+  - Follow the existing naming conventions
+```
+
+**Who it's for:** Engineering leads, platform teams, anyone on onboarding duty.
+
+---
+
+## 2. CI/CD pipeline standardization
+
+**Problem:** CI pipelines need deterministic environments. Manual skill installation breaks reproducibility. Different team members have different agent setups.
+
+**Solution:** Lockfile-based deterministic re-install with `rolecraft ci`.
+
+```bash
+# CI pipeline
+rolecraft ci --yes
+```
+
+The lockfile (`~/.agents/.skill-lock.json`) pins exact sources and content hashes. Same install every time.
+
+```yaml
+# GitHub Actions workflow
+- run: npm install -g rolecraft
+- run: rolecraft ci --yes
+```
+
+Use `--dry-run` to preview changes before applying:
+
+```bash
+rolecraft ci --yes --dry-run
+```
+
+**Who it's for:** DevOps engineers, platform teams, CI/CD maintainers.
+
+---
+
+## 3. Multi-agent consistency
+
+**Problem:** You use Cursor for daily development, Claude Code for complex refactoring, and Copilot for code reviews. Each agent has its own skill directory and format. Keeping them in sync is manual.
+
+**Solution:** Install once, target all agents.
+
+```bash
+rolecraft install ./my-rules --all
+```
+
+This installs to every agent rolecraft knows about. Add a new agent later? Re-run with `--all` and it fills in the gaps.
+
+Check what's installed where:
+
+```bash
+rolecraft list --global
+```
+
+**Who it's for:** Developers using 2+ AI agents regularly.
+
+---
+
+## 4. MCP server fleet management
+
+**Problem:** Installing MCP servers requires editing JSON configs for each agent. The format differs between cursor (`mcp_config.json`), claude-code (`claude_code.json`), and copilot (`.mcp.json`). Multiply by N agents and it's unmanageable.
+
+**Solution:** Declare MCP servers in `SKILL.md` frontmatter. rolecraft handles the per-agent config format automatically.
+
+```yaml
+# SKILL.md
+name: data-science
+mcp_servers:
+  - name: postgres
+    source: npm:@modelcontextprotocol/server-postgres
+  - name: filesystem
+    source: npm:@modelcontextprotocol/server-filesystem
+```
+
+```bash
+rolecraft install ./data-science --all
+# Installs skill + postgres MCP + filesystem MCP to every agent
+```
+
+Manage MCP servers standalone:
+
+```bash
+rolecraft mcp list                          # what's installed
+rolecraft mcp install npm:@modelcontextprotocol/server-github --cursor
+rolecraft mcp remove postgres --claude
+```
+
+**Who it's for:** Developers who use multiple agents and MCP-enabled tools.
+
+---
+
+## 5. Skill migration & format conversion
+
+**Problem:** Cursor uses `.mdc` files. Claude Code uses `SKILL.md`. You're switching agents or maintaining both. Manually converting between formats is error-prone.
+
+**Solution:** `rolecraft convert` handles bidirectional conversion.
+
+```bash
+# Convert a Cursor .mdc rule to SKILL.md
+rolecraft convert ./cursor-rule.mdc
+
+# Convert a SKILL.md to .mdc
+rolecraft convert ./my-skill/SKILL.md
+
+# Convert a directory (auto-detects format)
+rolecraft convert ./my-skill/
+```
+
+MCP server declarations are preserved in both directions.
+
+**Who it's for:** Developers migrating between agents, or maintaining skills for multiple agent types.
+
+---
+
+## 6. Security auditing
+
+**Problem:** Anyone can publish a skill. Skills run with access to your codebase, environment variables, and file system. Malicious skills can exfiltrate data, inject commands, or override agent behavior.
+
+**Solution:** Every install triggers a static security scan scoring 0–100.
+
+```
+❌ Security scan: 58/100 — DANGER
+   ❌ [critical] Command injection: download-and-execute pattern (SKILL.md)
+   ❌ [critical] Prompt injection: attempts to override instructions (SKILL.md)
+   ⚪ [low] No owner specified for this skill
+```
+
+- **Score 90–100:** Installs silently
+- **Score 70–89:** Shows warning, asks for confirmation
+- **Score 0–69:** Blocks install (use `--yes` to force)
+
+```bash
+rolecraft install unknown/repo   # blocked by default
+rolecraft install ./trusted-skill --yes  # force install
+```
+
+**Who it's for:** Security-conscious teams, anyone installing third-party skills.
+
+---
+
+## 7. Personal productivity
+
+**Problem:** You have a set of prompts, rules, and MCP servers you use every day. Setting them up on a new machine is tedious. Sharing them between personal and work machines is manual.
+
+**Solution:** Install your personal skill with one command:
+
+```bash
+rolecraft install github.com/you/your-personal-skill --all
+```
+
+Backup and restore your entire agent setup:
+
+```bash
+rolecraft profile save my-setup --all
+rolecraft profile export my-setup --file ./backup.json
+```
+
+On a new machine:
+
+```bash
+rolecraft profile import ./backup.json
+```
+
+**Who it's for:** Solo developers, freelancers, anyone with multiple machines.
+
+---
+
+## Who should NOT use rolecraft?
+
+- **You use one agent with no custom rules** — you don't need it
+- **You prefer manual config** — rolecraft automates what you can do by hand
+- **Your agents don't support skills** — check [agent discovery](../agents) for compatibility

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,269 @@
+# CLI Reference
+
+Complete reference for all rolecraft commands, flags, and options.
+
+---
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `init [name]` | Scaffold a new `SKILL.md` in `./<name>/` |
+| `install <source>` | Install a skill with security scan |
+| `bundle <sources...>` | Install multiple skills from inline sources |
+| `bundle create [name]` | Create a new bundle JSON file |
+| `use <source>` | Preview a skill's files without installing |
+| `list` | Show all installed skills |
+| `remove <slug>` | Uninstall a skill |
+| `update <slug>` | Re-install a skill to latest version |
+| `setup [source]` | Detect agents and optionally install a skill |
+| `search <query>` | Search GitHub for skills (`--skills-sh` for skills.sh) |
+| `check` | Check for available updates |
+| `ci` | Re-install all skills from lockfile (CI mode) |
+| `verify` | Check installed skill integrity via content hash |
+| `doctor` | Run system health check |
+| `watch [slug]` | Watch skills for changes and auto-sync |
+| `convert <source>` | Convert between SKILL.md and .mdc formats |
+| `profile save/apply/list` | Save, apply, and manage multi-agent profiles |
+| `mcp install/list/remove` | Install, list, and remove MCP servers |
+| `agents-xml [--write]` | Generate skills XML for AGENTS.md |
+| `completions bash\|zsh\|fish` | Generate shell completion scripts |
+| `upgrade` | Upgrade rolecraft to latest version |
+| `--help`, `-h` | Show usage |
+| `--version`, `-v` | Show version |
+
+---
+
+## Common flags
+
+These flags work across multiple commands:
+
+| Flag | Affects | Description |
+|------|---------|-------------|
+| `--yes` / `-y` | install, setup, bundle, ci | Non-interactive: accept all defaults, bypass security prompts |
+| `--dry-run` | install, setup, bundle, remove, update, profile | Preview without making changes |
+| `--global` | install, use, setup | Install to `~/.agents/skills/` (user-wide) |
+| `--project` | install, use, setup | Install to `./.agents/skills/` (repo-scoped, default) |
+| `--all` | install, setup, profile | Install to every supported agent |
+| `--symlink` | install, setup | Symlink instead of copy |
+| `--copy` | install, setup | Force copy (default) |
+| `--frozen-lockfile` | install | Fail if skill is already installed |
+| `--no-mcp` | install, setup | Skip MCP server installation |
+| `--interactive` | search | Open TUI for browsing and selecting results |
+
+---
+
+## Agent-specific flags
+
+Pass any of these to `install`, `setup`, or `profile` to target specific agents:
+
+| Flag | Agent | Skill directory |
+|------|-------|-----------------|
+| `--agents` | opencode | `~/.agents/skills/` |
+| `--claude` | claude-code | `~/.claude/skills/` |
+| `--cursor` | cursor | `~/.cursor/skills/` |
+| `--windsurf` | windsurf | `~/.windsurf/skills/` |
+| `--devin` | devin | `~/.devin/skills/` |
+| `--codex` | codex | `~/.codex/skills/` |
+| `--copilot` | copilot | `./.github/copilot/skills/` |
+| `--aider` | aider | `~/.aider/skills/` |
+| `--cline` | cline | `~/.cline/skills/` |
+| `--gemini` | gemini-cli | `~/.gemini/skills/` |
+| `--cody` | cody | `~/.cody/skills/` |
+| `--continue` | continue | `~/.continue/skills/` |
+| `--warp` | warp | `~/.warp/skills/` |
+| `--codeium` | codeium | `~/.codeium/skills/` |
+| `--fabric` | fabric | `~/.fabric/skills/` |
+| `--goose` | goose | `~/.goose/skills/` |
+| `--tabnine` | tabnine | `~/.tabnine/skills/` |
+| `--supermaven` | supermaven | `~/.supermaven/skills/` |
+| `--pr-pilot` | pr-pilot | `~/.pr-pilot/skills/` |
+| `--loom` | loom | `~/.loom/skills/` |
+| `--roo` | roo | `~/.roo/skills/` |
+| `--trae` | trae | `~/.trae/skills/` |
+| `--hermes` | hermes | `~/.hermes/skills/` |
+| `--kiro` | kiro | `~/.kiro/skills/` |
+| `--augment` | augment | `~/.augment/skills/` |
+| `--kilo` | kilo | `~/.kilo/skills/` |
+| `--openhands` | openhands | `~/.openhands/skills/` |
+| `--junie` | junie | `~/.junie/skills/` |
+| `--factory` | factory | `~/.factory/skills/` |
+| `--command-code` | command-code | `~/.commandcode/skills/` |
+| `--cortex` | cortex | `~/.snowflake/cortex/skills/` |
+| `--mistral-vibe` | mistral-vibe | `~/.vibe/skills/` |
+| `--qwen-code` | qwen-code | `~/.qwen/skills/` |
+| `--openclaw` | openclaw | `~/.openclaw/skills/` |
+| `--codebuddy` | codebuddy | `~/.codebuddy/skills/` |
+| `--mux` | mux | `~/.mux/skills/` |
+| `--pi` | pi | `~/.pi/agent/skills/` |
+| `--autohand-code` | autohand-code | `~/.autohand/skills/` |
+| `--rovo` | rovo-dev | `~/.rovodev/skills/` |
+| `--firebender` | firebender | `~/.firebender/skills/` |
+| `--bob` | ibm-bob | `~/.bob/skills/` |
+| `--aider-desk` | aider-desk | `~/.aider-desk/skills/` |
+| *(and 44+ more — see [full list](agents))* | | |
+
+Combine multiple flags in one command:
+
+```bash
+rolecraft install ./my-skill --cursor --claude --devin --copilot
+```
+
+---
+
+## Subcommand detail
+
+### `rolecraft init [name]`
+
+Scaffold a new skill:
+
+```bash
+rolecraft init my-skill     # creates ./my-skill/SKILL.md
+rolecraft init              # creates ./SKILL.md
+```
+
+### `rolecraft install <source>`
+
+Install a skill from any source:
+
+```bash
+rolecraft install ./path                             # local directory
+rolecraft install owner/repo                         # GitHub shorthand
+rolecraft install https://gitlab.com/org/project     # Git URL
+rolecraft install git@github.com:owner/repo.git      # SSH URL
+rolecraft install npm:package                        # npm package
+```
+
+Accepts: `--yes`, `--dry-run`, `--global`, `--project`, `--all`, `--symlink`, `--frozen-lockfile`, `--no-mcp`, agent flags.
+
+### `rolecraft bundle <sources...>`
+
+```bash
+rolecraft bundle owner/skill1 owner/skill2 ./local
+rolecraft bundle bundle.json
+rolecraft bundle bundle.txt
+rolecraft bundle create [name]
+```
+
+### `rolecraft use <source>`
+
+Preview without installing. Same source types as `install`.
+
+```bash
+rolecraft use ./my-skill         # show files
+rolecraft use owner/repo         # from GitHub
+rolecraft use ./my-skill | head -50  # pipe to pager
+```
+
+### `rolecraft list`
+
+```bash
+rolecraft list                  # all installed skills
+rolecraft list --project         # project-level only
+rolecraft list --global          # global only
+```
+
+### `rolecraft remove <slug>`
+
+```bash
+rolecraft remove my-skill
+rolecraft remove my-skill --dry-run
+```
+
+### `rolecraft update <slug>`
+
+Re-install from original source:
+
+```bash
+rolecraft update my-skill
+```
+
+### `rolecraft setup [<source>]`
+
+```bash
+rolecraft setup                  # detect agents only
+rolecraft setup ./my-skill       # detect + install
+rolecraft setup owner/repo --yes
+```
+
+### `rolecraft search <query>`
+
+```bash
+rolecraft search code-review                  # GitHub search
+rolecraft search code-review --interactive     # TUI picker
+rolecraft search react --skills-sh             # skills.sh (experimental)
+```
+
+### `rolecraft check`
+
+No arguments. Checks all installed skills for newer versions.
+
+### `rolecraft ci`
+
+Re-install all skills from lockfile. Use `--yes` in CI.
+
+### `rolecraft verify`
+
+Verifies SHA256 content hashes of all installed skills.
+
+### `rolecraft doctor`
+
+Runs system health checks: Node.js version, agent directories, lockfile integrity, skill file existence.
+
+### `rolecraft watch [<slug>]`
+
+```bash
+rolecraft watch                 # watch all skills
+rolecraft watch my-skill        # watch specific skill
+```
+
+### `rolecraft convert <source>`
+
+Converts between formats. Auto-detects direction:
+
+```bash
+rolecraft convert ./skill/SKILL.md     # → .mdc
+rolecraft convert ./rule.mdc            # → SKILL.md
+rolecraft convert ./dir/                # directory, auto-detects format
+rolecraft convert ./dir/ --output ./out
+rolecraft convert ./skill --dry-run
+```
+
+### `rolecraft profile`
+
+```bash
+profile save <name>           # capture current config
+profile apply <name>          # apply saved config
+profile list                  # list all profiles
+profile show <name>           # show profile details
+profile diff <name>           # compare with current
+profile edit <name>           # edit with $EDITOR
+profile delete <name>         # remove profile
+profile export <name>         # export as JSON
+profile import <path>         # import from file/URL
+profile link [name]           # link to project
+```
+
+### `rolecraft mcp`
+
+```bash
+mcp install <source> [flags]    # install MCP server
+mcp list                        # list all MCP servers
+mcp remove <name> [flags]       # remove MCP server
+```
+
+### `rolecraft agents-xml [--write]`
+
+Generates XML block for AGENTS.md. Use `--write` to auto-insert.
+
+### `rolecraft completions bash|zsh|fish`
+
+```bash
+rolecraft completions bash >> ~/.bashrc
+rolecraft completions zsh >> ~/.zshrc
+rolecraft completions fish >> ~/.config/fish/completions/rolecraft.fish
+```
+
+### `rolecraft upgrade`
+
+Upgrades rolecraft to the latest npm version.


### PR DESCRIPTION
Adds three new documentation pages to address the 'documentation gaps' identified in the project analysis.

### New pages

- **docs/guides/getting-started.md** — 5-minute quick start for new users: install → search → install → list → remove. Fills the gap between 'never heard of rolecraft' and the existing onboarding guide.
- **docs/guides/use-cases.md** — 7 scenarios with problem/solution format: team onboarding, CI/CD, multi-agent consistency, MCP fleet management, format migration, security auditing, personal productivity. Includes 'who should NOT use rolecraft' section.
- **docs/reference.md** — Single-page CLI reference: all 21 commands, common flags, agent-specific flags table, per-command usage with examples.

### Changes

-  — nav bar reordered (Getting Started first), sidebar restructured with Guides section
-  — added Getting Started link next to install guide, CLI Reference link in commands table