### PR TITLE
fix: document install yes flag in help

### DIFF
--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -70,6 +70,7 @@ Options:
   --no-mcp       Skip MCP server installation from skills (install, bundle)
 
 Options for install:
+  --yes, -y      Non-interactive: accept all defaults and skip prompts
   --global       Install to ~/.agents/skills/
   --project      Install to ./.agents/skills/ (default)
   --windsurf     Also install to ~/.windsurf/skills/

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -102,7 +102,8 @@ describe('rolecraft CLI', () => {
     const logs = captureLogs()
     process.argv = ['node', 'rolecraft', 'install', '--help']
     await main()
-    assert.ok(logs.some(l => l.includes('rolecraft')))
+    const help = logs.join('\n')
+    assert.match(help, /Options for install:[\s\S]*--yes, -y/)
   })
 
   it('throws for install with no source', async () => {


### PR DESCRIPTION
## Description

Documents `--yes, -y` in the install command help and strengthens the help-output regression test.

## Type of change

- [x] Bug fix
- [x] Documentation update
- [ ] New feature
- [ ] Refactor

## Checklist

- [x] Tests pass locally (`npm test`): 711 passed
- [x] Lint passes (`npm run lint`)
- [x] No new dependencies added
- [x] Docs updated if needed

## Related issue

Fixes #93
