### PR TITLE
feat(doctor): add git and npm availability checks

### DIFF
--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,4 +1,5 @@
 import { accessSync, constants, readFileSync, readdirSync } from 'node:fs'
+import { execSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { readLock, getProjectLockPath, getAgentsDir } from '../utils/lockfile.js'
@@ -29,6 +30,20 @@ export async function doctorCommand() {
   const [major] = process.versions.node.split('.').map(Number)
   if (major < 20) {
     report('Node.js compatibility', 'error', '>= 20 required, please upgrade')
+  }
+
+  try {
+    execSync('git --version', { stdio: 'ignore' })
+    report('Git availability', 'pass', 'detected')
+  } catch {
+    report('Git availability', 'warn', 'not found (needed for GitHub sources)')
+  }
+
+  try {
+    execSync('npm --version', { stdio: 'ignore' })
+    report('npm availability', 'pass', 'detected')
+  } catch {
+    report('npm availability', 'warn', 'not found (needed for npm sources)')
   }
 
   report('rolecraft version', 'pass', `v${pkg.version}`)

--- a/src/commands/doctor.test.js
+++ b/src/commands/doctor.test.js
@@ -67,6 +67,26 @@ describe('doctor command', () => {
     assert.ok(logs.some(l => l.includes('rolecraft version')))
   })
 
+  it('reports git availability', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('Git availability')))
+  })
+
+  it('reports npm availability', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('npm availability')))
+  })
+
   it('reports home directory', async () => {
     const { logs, restore } = capture()
     try {


### PR DESCRIPTION
## Description
Adds `git` and `npm` availability checks to `rolecraft doctor`. Since GitHub repos and npm packages are the primary skill sources, `doctor` previously gave no signal about whether missing tooling could be causing skill-install failures. This adds two new checks — `Git availability` and `npm availability` — that run `git --version` / `npm --version` via `execSync`, reporting `pass` if found and `warn` (not `error`) if missing, since rolecraft can still function via other skill sources without them. Corresponding tests were added following the existing no-mock, real-execution pattern already used in `doctor.test.js`.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor

## Checklist
- [ ] Tests pass locally (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [x] No new dependencies added
- [ ] Docs updated if needed

## Related issue
Closes #108