### PR TITLE
fix: log reinstall failure in watch command

### DIFF
--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -84,9 +84,7 @@ export async function watchCommand(slug, cwd = process.cwd(), options = {}) {
         const timestamp = new Date().toLocaleTimeString()
         console.log(`  [${timestamp}] ${s}: ${filename} changed, syncing...`)
         const ok = await reinstallSkill(s, mergedSkills, cwd)
-        if (ok) {
-          console.log(`  [${timestamp}] ${s}: synced successfully`)
-        }
+        console.log(`  [${timestamp}] ${s}: ${ok ? 'synced successfully' : 'sync failed'}`)
       }, 300)
     }
 

--- a/src/commands/watch.test.js
+++ b/src/commands/watch.test.js
@@ -303,6 +303,7 @@ describe('watch command', () => {
 
       assert.ok(logs.some(l => l.includes('syncing')))
       assert.ok(!logs.some(l => l.includes('synced')), 'Should NOT log synced on failure')
+      assert.ok(logs.some(l => l.includes('sync failed')), `Expected 'sync failed' in logs: ${logs.join('; ')}`)
     } finally {
       console.log = origLog
       process.env.HOME = tempDir


### PR DESCRIPTION
## Description

Watch mode previously stopped at `syncing...` when reinstalling a changed skill returned `false`, leaving the failure silent. This logs `sync failed` for that path and adds a focused assertion to the existing reinstall-failure test.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] Tests pass locally (`npm test`): 711 passed
- [x] Lint passes (`npm run lint`)
- [x] No new dependencies added
- [x] Docs updated if needed (no interface or usage change)

## Related issue

Fixes #111