### PR TITLE
feat: add --json flag to list command

### DIFF
--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -135,12 +135,12 @@ export async function main() {
 
     case 'list': {
       const options = {
-      json: args.includes('--json'),
-    }
+        json: args.includes('--json'),
+      }
 
-    await listCommand(process.cwd(), options)
-    break
-  }
+      await listCommand(process.cwd(), options)
+      break
+    }
 
     case 'remove': {
       if (args.includes('--help') || args.includes('-h')) { usage(); return }

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -133,9 +133,14 @@ export async function main() {
       break
     }
 
-    case 'list':
-      await listCommand(process.cwd())
-      break
+    case 'list': {
+      const options = {
+      json: args.includes('--json'),
+    }
+
+    await listCommand(process.cwd(), options)
+    break
+  }
 
     case 'remove': {
       if (args.includes('--help') || args.includes('-h')) { usage(); return }

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -6,8 +6,17 @@ Show all installed skills.
 
 ```bash
 rolecraft list
+rolecraft list --json
 ```
 
 ## Description
 
 Displays every skill currently installed across all agent directories, along with their metadata (slug, name, source, target path).
+
+### `--json`
+
+Output the skill list as JSON for machine consumption (scripts, CI, `jq`):
+
+```bash
+rolecraft list --json | jq '.skills | keys'
+```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -159,6 +159,7 @@ rolecraft use ./my-skill | head -50  # pipe to pager
 
 ```bash
 rolecraft list                  # all installed skills
+rolecraft list --json            # machine-readable JSON output
 rolecraft list --project         # project-level only
 rolecraft list --global          # global only
 ```

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,6 +1,6 @@
 import { readLock, getProjectLockPath } from '../utils/lockfile.js'
 
-export async function listCommand(cwd) {
+export async function listCommand(cwd, options = {}) {
   const [globalLock, projectLock] = await Promise.all([
     readLock(),
     cwd ? readLock(getProjectLockPath(cwd)) : Promise.resolve(null),
@@ -14,6 +14,32 @@ export async function listCommand(cwd) {
   }
 
   const skills = Object.entries(mergedSkills)
+  if (options.json) {
+  const jsonSkills = {}
+
+  for (const [slug, entry] of skills) {
+    const inProject = projectSkills.has(slug)
+    const inGlobal = slug in globalLock.skills
+
+    const scope = inProject && inGlobal
+      ? 'global, project'
+      : inProject
+        ? 'project'
+        : 'global'
+
+    jsonSkills[slug] = {
+      ...entry,
+      scope,
+    }
+  }
+
+  console.log(JSON.stringify({
+    skills: jsonSkills,
+    total: skills.length,
+  }, null, 2))
+
+  return
+}
 
   if (skills.length === 0) {
     console.log('No skills installed.')

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -15,31 +15,31 @@ export async function listCommand(cwd, options = {}) {
 
   const skills = Object.entries(mergedSkills)
   if (options.json) {
-  const jsonSkills = {}
+    const jsonSkills = {}
 
-  for (const [slug, entry] of skills) {
-    const inProject = projectSkills.has(slug)
-    const inGlobal = slug in globalLock.skills
+    for (const [slug, entry] of skills) {
+      const inProject = projectSkills.has(slug)
+      const inGlobal = slug in globalLock.skills
 
-    const scope = inProject && inGlobal
-      ? 'global, project'
-      : inProject
-        ? 'project'
-        : 'global'
+      const scope = inProject && inGlobal
+        ? 'global, project'
+        : inProject
+          ? 'project'
+          : 'global'
 
-    jsonSkills[slug] = {
-      ...entry,
-      scope,
+      jsonSkills[slug] = {
+        ...entry,
+        scope,
+      }
     }
+
+    console.log(JSON.stringify({
+      skills: jsonSkills,
+      total: skills.length,
+    }, null, 2))
+
+    return
   }
-
-  console.log(JSON.stringify({
-    skills: jsonSkills,
-    total: skills.length,
-  }, null, 2))
-
-  return
-}
 
   if (skills.length === 0) {
     console.log('No skills installed.')

--- a/src/commands/list.test.js
+++ b/src/commands/list.test.js
@@ -39,19 +39,54 @@ describe('list command', () => {
     assert.ok(logs.some(l => l.includes('No skills installed')))
   })
 
-  it('lists installed skills with details', async () => {
-    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3,
-      skills: {
-        'test/skill': {
-          installedAt: '2025-01-15T10:00:00.000Z',
-          source: 'owner/repo',
-          sourceType: 'github',
+  it('outputs JSON when json option is enabled', async () => {
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'test/skill': {
+            installedAt: '2025-01-15T10:00:00.000Z',
+            source: 'owner/repo',
+            sourceType: 'github',
+            agents: ['cursor', 'claude'],
+          },
         },
-      },
-      dismissed: {},
-      lastSelectedAgents: [],
-    }))
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
+
+    const logs = captureLogs()
+
+    await listModule.listCommand(undefined, { json: true })
+
+    const output = JSON.parse(logs.join('\n'))
+
+    assert.equal(output.total, 1)
+    assert.ok(output.skills['test/skill'])
+    assert.equal(output.skills['test/skill'].scope, 'global')
+    assert.equal(output.skills['test/skill'].source, 'owner/repo')
+    assert.equal(output.skills['test/skill'].sourceType, 'github')
+    assert.deepEqual(output.skills['test/skill'].agents, ['cursor', 'claude'])
+  })
+
+  it('lists installed skills with details', async () => {
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'test/skill': {
+            installedAt: '2025-01-15T10:00:00.000Z',
+            source: 'owner/repo',
+            sourceType: 'github',
+          },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
     const logs = captureLogs()
 
@@ -64,12 +99,19 @@ describe('list command', () => {
   })
 
   it('handles skill without optional fields', async () => {
-    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3,
-      skills: { 'minimal/skill': { installedAt: '2025-01-01T00:00:00.000Z' } },
-      dismissed: {},
-      lastSelectedAgents: [],
-    }))
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'minimal/skill': {
+            installedAt: '2025-01-01T00:00:00.000Z',
+          },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
     const logs = captureLogs()
 
@@ -80,12 +122,17 @@ describe('list command', () => {
   })
 
   it('handles skill with unknown installedAt', async () => {
-    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3,
-      skills: { 'nodate/skill': {} },
-      dismissed: {},
-      lastSelectedAgents: [],
-    }))
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'nodate/skill': {},
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
     const logs = captureLogs()
 
@@ -95,40 +142,67 @@ describe('list command', () => {
   })
 
   it('merges project-scoped skills when cwd is given', async () => {
-    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3,
-      skills: { 'global/only': { installedAt: '2025-01-01T00:00:00.000Z' } },
-      dismissed: {},
-      lastSelectedAgents: [],
-    }))
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'global/only': {
+            installedAt: '2025-01-01T00:00:00.000Z',
+          },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
-    await writeFile(join(projectDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3,
-      skills: { 'project/only': { installedAt: '2025-06-01T00:00:00.000Z' } },
-      dismissed: {},
-      lastSelectedAgents: [],
-    }))
+    await writeFile(
+      join(projectDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'project/only': {
+            installedAt: '2025-06-01T00:00:00.000Z',
+          },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
     const logs = captureLogs()
 
     await listModule.listCommand(projectDir)
 
-    assert.ok(logs.some(l => l.includes('global/only')), 'should show global skill')
-    assert.ok(logs.some(l => l.includes('project/only')), 'should show project skill')
+    assert.ok(logs.some(l => l.includes('global/only')))
+    assert.ok(logs.some(l => l.includes('project/only')))
     assert.ok(logs.some(l => l.includes('2 skill(s)')))
   })
 
   it('shows scope as project for skills only in project lock', async () => {
-    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3, skills: {}, dismissed: {}, lastSelectedAgents: [],
-    }))
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {},
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
-    await writeFile(join(projectDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3,
-      skills: { 'proj/skill': { installedAt: '2025-06-01T00:00:00.000Z' } },
-      dismissed: {},
-      lastSelectedAgents: [],
-    }))
+    await writeFile(
+      join(projectDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'proj/skill': {
+            installedAt: '2025-06-01T00:00:00.000Z',
+          },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
     const logs = captureLogs()
 
@@ -138,19 +212,33 @@ describe('list command', () => {
   })
 
   it('shows scope as global, project when skill exists in both', async () => {
-    await writeFile(join(tempDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3,
-      skills: { 'shared/skill': { installedAt: '2025-01-01T00:00:00.000Z' } },
-      dismissed: {},
-      lastSelectedAgents: [],
-    }))
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'shared/skill': {
+            installedAt: '2025-01-01T00:00:00.000Z',
+          },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
-    await writeFile(join(projectDir, '.agents', '.skill-lock.json'), JSON.stringify({
-      version: 3,
-      skills: { 'shared/skill': { installedAt: '2025-06-01T00:00:00.000Z' } },
-      dismissed: {},
-      lastSelectedAgents: [],
-    }))
+    await writeFile(
+      join(projectDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'shared/skill': {
+            installedAt: '2025-06-01T00:00:00.000Z',
+          },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      })
+    )
 
     const logs = captureLogs()
 


### PR DESCRIPTION
## Summary

Adds support for a `--json` flag to the `rolecraft list` command.

## Changes

- Adds a `--json` option to the CLI.
- Outputs installed skills as JSON when `--json` is used.
- Preserves the existing tree output for `rolecraft list`.
- Includes computed `scope` together with lockfile fields such as `installedAt`, `source`, `sourceType`, and `agents`.
- Adds tests for JSON output.

---

Closes #118
