### PR TITLE
chore: release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,43 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,41 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,39 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,49 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,42 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,44 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,47 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,45 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,46 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,38 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,40 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,48 @@ All notable changes to this project will be documented in this file.
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,36 @@ All notable changes to this project will be documented in this file.
 - enable docs deployment after release
 
 ### Changed
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,37 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - update changelog and version for v1.6.0
+- update changelog and version for v1.6.0
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- update changelog and version for v1.6.0
 - bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
 - bump github/codeql-action/init from 4.37.0 to 4.37.1
 - bump actions/setup-node from 6.4.0 to 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.6.0] - 2026-07-20
+
+### Added
+- add --json flag to list command (#120)
+- add git and npm availability checks
+- add skills.sh search with --skills-sh flag (experimental) (#101)
+- add convert command for SKILL.md <-> .mdc format conversion (#100)
+- add droid, chatgpt, codearts-agent, universal agents (86 total)
+
+### Fixed
+- log reinstall failure in watch command
+- document install yes flag in help
+- resolve CodeQL alerts and flaky ENOTEMPTY tests
+- enable docs deployment after release
+
+### Changed
+- bump github/codeql-action/analyze from 4.37.0 to 4.37.1 (#115)
+- bump github/codeql-action/init from 4.37.0 to 4.37.1
+- bump actions/setup-node from 6.4.0 to 7.0.0
+- add star CTA to README (#102)
+- update changelog and version for v1.5.0 [skip ci] (#97)
+
+### Documentation
+- add Benjamin Ayivoh to contributors, convert to grid layout
+- add star request to CONTRIBUTING.md
+- add Gaohar Imran and Ajay Krishnan to contributors table
+- add Yurii201811 to contributors table
+- add getting-started, use-cases, and CLI reference pages (#103)
+- streamline README for Show HN launch
 ## [v1.5.0] - 2026-07-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolecraft",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Install AI agent skills as roles & behaviors directly from any source — zero-dependency CLI for opencode, claude-code, cursor, and more",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This PR updates the changelog and version for `v1.6.0`.

## Changes
- Updated CHANGELOG.md with changes since the previous tag
- Updated package.json version to `v1.6.0`

> Auto-generated by the release-prep workflow.
