### PR TITLE
feat: add multi-skill support to use and setup commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest in contributing! Here's how you can help.
 git clone https://github.com/sametcelikbicak/rolecraft.git
 cd rolecraft
 npm link                  # now `rolecraft` runs from your local checkout
-npm test                  # 721+ tests should pass
+npm test                  # 730+ tests should pass
 ```
 
 **Requirements:** Node.js >= 20, no other dependencies.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ cd rolecraft
 npm link                   # rolecraft CLI runs from local checkout
 npm install                # for docs site (VitePress)
 npm run docs:dev           # local docs preview
-npm test                   # 721+ tests, 0 fails expected
+npm test                   # 730+ tests, 0 fails expected
 ```
 
 [→ Contributing guide](CONTRIBUTING.md)

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -69,6 +69,14 @@ Options:
   --dry-run      Preview without making changes (install, setup, bundle, upgrade, profile, mcp, update, remove, watch)
   --no-mcp       Skip MCP server installation from skills (install, bundle)
 
+Options for use:
+  --list         List available skills from a source without previewing
+  --skill <names> Preview specific skills by name (comma-separated)
+
+Options for setup:
+  --list         List available skills from a source without installing
+  --skill <names> Install specific skills by name (comma-separated)
+
 Options for install:
   --yes, -y      Non-interactive: accept all defaults and skip prompts
   --global       Install to ~/.agents/skills/
@@ -181,7 +189,15 @@ export async function main() {
         console.error('Source can be a local path (./, /, ~), GitHub ref (owner/repo), or npm package (npm:package)')
         throw new Error('Missing source argument.')
       }
-      await useCommand(source)
+      const useFlags = args.filter(a => a.startsWith('-'))
+      const useOptions = {
+        list: useFlags.includes('--list'),
+      }
+      const skillIndex = useFlags.indexOf('--skill')
+      if (skillIndex !== -1 && useFlags[skillIndex + 1] && !useFlags[skillIndex + 1].startsWith('-')) {
+        useOptions.skill = useFlags[skillIndex + 1].split(',').map(s => s.trim())
+      }
+      await useCommand(source, useOptions)
       break
     }
 
@@ -235,7 +251,16 @@ export async function main() {
       const setupFlags = args.filter(a => a.startsWith('-'))
       const setupPos = args.filter(a => !a.startsWith('-'))
       const source = setupPos[0]
-      await setupCommand(source, { dryRun: setupFlags.includes('--dry-run'), yes: setupFlags.includes('--yes') || setupFlags.includes('-y') })
+      const setupOptions = {
+        dryRun: setupFlags.includes('--dry-run'),
+        yes: setupFlags.includes('--yes') || setupFlags.includes('-y'),
+        list: setupFlags.includes('--list'),
+      }
+      const skillIndex = setupFlags.indexOf('--skill')
+      if (skillIndex !== -1 && setupFlags[skillIndex + 1] && !setupFlags[skillIndex + 1].startsWith('-')) {
+        setupOptions.skill = setupFlags[skillIndex + 1].split(',').map(s => s.trim())
+      }
+      await setupCommand(source, setupOptions)
       break
     }
 

--- a/docs/commands/setup.md
+++ b/docs/commands/setup.md
@@ -9,6 +9,8 @@ Detect every AI agent on your machine and install a skill — plus its MCP serve
 ```bash
 rolecraft setup                    # detect agents only
 rolecraft setup <source>           # detect + install skill + MCP to all agents
+rolecraft setup <source> --list    # list skills without installing
+rolecraft setup <source> --skill <names>  # install specific skills
 ```
 
 ## Description
@@ -16,9 +18,20 @@ rolecraft setup <source>           # detect + install skill + MCP to all agents
 `rolecraft setup` is the **onboarding command**. It:
 
 1. Scans your system for all installed AI agent directories (opencode, cursor, claude-code, copilot, aider, etc.)
-2. When a source is provided: resolves the skill, runs a security scan, installs to every detected agent, and sets up any MCP servers declared in `SKILL.md`
+2. When a source is provided: resolves the skill(s), installs to every detected agent, and sets up any MCP servers declared in `SKILL.md`
+
+For sources with multiple skills (e.g. `mattpocock/skills`), you'll be prompted to select which skills to install. Use `--yes` to install all, or `--skill` to pick specific ones.
 
 This is the fastest way to go from zero to productive — one command configures every AI agent you use.
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--yes`, `-y` | Install all skills without prompt |
+| `--dry-run` | Preview without installing |
+| `--list` | List available skills without installing |
+| `--skill <names>` | Install specific skills by name (comma-separated) |
 
 ## Examples
 
@@ -39,6 +52,19 @@ rolecraft setup npm:@org/agent-rules
 ```
 
 Installs the skill to every detected agent automatically. No need to specify `--cursor`, `--claude`, etc.
+
+### Multi-skill source
+
+```bash
+# Show skills in a multi-skill source without installing
+rolecraft setup mattpocock/skills --list
+
+# Install specific skills
+rolecraft setup mattpocock/skills --skill "typescript-rules,react-rules"
+
+# Install all with --yes
+rolecraft setup mattpocock/skills -y
+```
 
 ### With MCP servers
 

--- a/docs/commands/use.md
+++ b/docs/commands/use.md
@@ -6,11 +6,22 @@ Preview a skill's files without installing.
 
 ```bash
 rolecraft use <source>
+rolecraft use <source> --list
+rolecraft use <source> --skill <name>
 ```
 
 ## Description
 
 Resolves the source, shows metadata, and prints all file contents to stdout — without writing anything to disk. Useful for inspecting a skill before installing, or piping content into other tools.
+
+For sources with multiple skills (e.g. `mattpocock/skills`), all skills are shown sequentially. Use `--skill` to filter or `--list` to see only metadata.
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--list` | List available skills without previewing content |
+| `--skill <names>` | Preview specific skills by name (comma-separated) |
 
 ## Examples
 
@@ -20,6 +31,12 @@ rolecraft use ./my-skill
 
 # Preview a GitHub skill
 rolecraft use sametcelikbicak/task-decomposer
+
+# List skills in a multi-skill source
+rolecraft use mattpocock/skills --list
+
+# Preview a specific skill from a multi-skill source
+rolecraft use mattpocock/skills --skill "typescript-rules"
 
 # Pipe content
 rolecraft use ./my-skill | head -50

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -1,11 +1,19 @@
 import { accessSync, readdirSync, constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { createInterface as defaultCreateInterface } from 'node:readline'
+import { stdin as input, stdout as output } from 'node:process'
 import { getAgentsDir, getClaudeDir, getCursorDir, getWindsurfDir, getCodexDir, getCopilotProjectDir, getAiderDir, getClineDir, getDevinDir, getGeminiDir, getCodyDir, getContinueDir, getWarpDir, getCodeiumDir, getFabricDir, getGooseDir, getTabnineDir, getSupermavenDir, getPrPilotDir, getLoomDir, getRooDir, getTraeDir, getHermesDir, getKiroDir, getAugmentDir, getKiloDir, getOpenHandsDir, getJunieDir, getFactoryDir, getCommandCodeDir, getCortexDir, getMistralVibeDir, getQwenCodeDir, getOpenClawDir, getCodeBuddyDir, getMuxDir, getPiDir, getAutohandCodeDir, getRovoDevDir, getFirebenderDir, getBobDir, getAiderDeskDir, getCodeArtsDoerDir, getCodeMakerDir, getCodeStudioDir, getCrushDir, getEveDir, getForgeDir, getInferenceShDir, getJazzDir, getIFlowDir, getKiloCodeDir, getKodeDir, getLingmaDir, getMcpJamDir, getMoxbyDir, getOnaDir, getQoderDir, getReasonixDir, getTerraMindDir, getTinyCloudDir, getZencoderDir, getZapDir, getCodeepDir, getKimiCodeDir, getZCodeDir, getAstrbotDir, getQoderCnDir, getTraeCnDir, getZenflowDir, getNeovateDir, getPochiDir, getAdalDir, getDroidDir, getChatgptDir, getCodeartsAgentDir, getUniversalDir } from '../utils/lockfile.js'
-import { resolveSource } from '../utils/resolver.js'
+import { resolveSkills } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import { parseMcpServersFromSkill, resolveMcpSource, addMcpServer, getSupportedMcpAgents } from '../utils/mcp.js'
 import { createSpinner } from '../utils/spinner.js'
+
+let createInterface = defaultCreateInterface
+
+export function setCreateInterface(fn) {
+  createInterface = fn
+}
 
 const KNOWN_AGENTS = [
   { flag: 'agents', label: 'opencode', dir: getAgentsDir },
@@ -114,6 +122,56 @@ function globalAgentsDir() {
   return join(homedir(), '.agents', 'skills')
 }
 
+function askQuestion(query) {
+  const rl = createInterface({ input, output })
+  return new Promise(resolve => {
+    rl.question(query, answer => {
+      rl.close()
+      resolve(answer.trim().toLowerCase())
+    })
+  })
+}
+
+function selectSkillsInteractive(skills) {
+  console.log()
+  for (let i = 0; i < skills.length; i++) {
+    console.log(`  ${i + 1}. ${skills[i].name}`)
+    if (skills[i].description) {
+      console.log(`      ${skills[i].description}`)
+    }
+  }
+
+  return (async () => {
+    while (true) {
+      console.log()
+      const answer = await askQuestion('Enter numbers (space-separated) to select, "all" for all, or press Enter to confirm selection: ')
+
+      if (answer === '' || answer === null || answer === undefined) {
+        console.log('  No skills selected. Nothing to install.')
+        return null
+      }
+
+      if (answer === 'all') {
+        console.log(`  Selected all ${skills.length} skills.`)
+        return skills
+      }
+
+      const parts = answer.split(/\s+/).map(p => parseInt(p, 10))
+      const selected = []
+      for (const p of parts) {
+        if (!isNaN(p) && p >= 1 && p <= skills.length) {
+          selected.push(skills[p - 1])
+          console.log(`  ${skills[p - 1].name} selected`)
+        }
+      }
+
+      if (selected.length > 0) {
+        return selected
+      }
+    }
+  })()
+}
+
 export async function setupCommand(source, options = {}) {
   const agents = detectAgents()
   const projectDir = join(process.cwd(), '.agents', 'skills')
@@ -148,56 +206,108 @@ export async function setupCommand(source, options = {}) {
   console.log()
 
   if (source) {
-    const spinner = createSpinner(`📦 Installing ${source}...`)
+    if (options.list) {
+      const spinner = createSpinner('Resolving skills...')
+      spinner.start()
+      const skills = await resolveSkills(source)
+      spinner.succeed(`Found ${skills.length} skill(s)`)
+      console.log()
+      for (const s of skills) {
+        console.log(`  ${s.name}`)
+        console.log(`    Slug:       ${s.slug}`)
+        console.log(`    Owner:      ${s.owner}`)
+        if (s.description) console.log(`    Description: ${s.description}`)
+        console.log(`    Files:      ${s.files.join(', ')}`)
+        console.log()
+      }
+      return
+    }
+
+    const spinner = createSpinner(`📦 Resolving ${source}...`)
     spinner.start()
-    const resolved = await resolveSource(source)
-    spinner.succeed(`📦 Found: ${resolved.name} (${resolved.slug})`)
+    const allSkills = await resolveSkills(source)
+    spinner.succeed(`Found ${allSkills.length} skill(s)`)
+
+    let selectedSkills
+    if (options.skill && options.skill.length > 0) {
+      const skillNames = options.skill.map(n => n.toLowerCase())
+      selectedSkills = allSkills.filter(s =>
+        skillNames.includes(s.name.toLowerCase()) || skillNames.includes(s.slug.toLowerCase())
+      )
+      if (selectedSkills.length === 0) {
+        throw new Error(`No matching skills found for: ${options.skill.join(', ')}. Available: ${allSkills.map(s => s.name).join(', ')}`)
+      }
+    } else if (allSkills.length === 1) {
+      selectedSkills = allSkills
+    } else if (options.yes) {
+      selectedSkills = allSkills
+      console.log(`   Installing all ${allSkills.length} skills`)
+    } else {
+      const result = await selectSkillsInteractive(allSkills)
+      if (!result) {
+        console.log('Setup cancelled.')
+        return
+      }
+      selectedSkills = result
+    }
 
     const targets = agents.map(a => a.flag)
     targets.push('project')
 
     if (options.dryRun) {
-      console.log(`\n📋 [dry-run] Would install skill:\n`)
-      console.log(`   Skill:     ${resolved.name} (${resolved.slug})`)
-      console.log(`   Source:    ${source}`)
-      console.log(`   Mode:      copy`)
-      console.log(`   Files:     ${resolved.files.join(', ')}`)
-      console.log(`   Targets:   ${targets.join(', ')}\n`)
+      console.log(`\n📋 [dry-run] Would install ${selectedSkills.length} skill(s):\n`)
+      for (const skill of selectedSkills) {
+        console.log(`   Skill:     ${skill.name} (${skill.slug})`)
+        console.log(`   Source:    ${source}`)
+        console.log(`   Mode:      copy`)
+        console.log(`   Files:     ${skill.files.join(', ')}`)
+        console.log(`   Targets:   ${targets.join(', ')}\n`)
+      }
       return
     }
 
-    if (options.yes) {
-      // skip confirmation, proceed with install
-    }
+    for (const skill of selectedSkills) {
+      const resolved = {
+        ...skill,
+        sourcePath: skill.sourcePath || source,
+        sourceType: skill.sourceType || 'local',
+      }
 
-    const results = await installSkill(resolved, targets)
+      console.log()
+      console.log(`   Skill:    ${resolved.name}`)
+      console.log(`   Slug:     ${resolved.slug}`)
+      console.log(`   Owner:    ${resolved.owner}`)
+      console.log(`   Files:    ${resolved.files.join(', ')}`)
 
-    const pathCounts = new Map()
-    for (const r of results) {
-      const count = pathCounts.get(r.path) || 0
-      pathCounts.set(r.path, count + 1)
-    }
+      const results = await installSkill(resolved, targets)
 
-    console.log(`✅ Installed to ${results.length} agent(s):\n`)
-    for (const [path, count] of pathCounts) {
-      const detail = count > 1 ? ` (×${count} agents)` : ''
-      console.log(`   ${path}${detail}`)
-    }
+      const pathCounts = new Map()
+      for (const r of results) {
+        const count = pathCounts.get(r.path) || 0
+        pathCounts.set(r.path, count + 1)
+      }
 
-    if (resolved.content) {
-      const mcpServers = parseMcpServersFromSkill(resolved.content)
-      if (mcpServers.length > 0) {
-        console.log(`\n🔧 Skill includes ${mcpServers.length} MCP server(s). Installing...`)
-        const supported = getSupportedMcpAgents()
-        const mcpTargets = agents.filter(a => supported.includes(a.flag)).map(a => a.flag)
-        for (const server of mcpServers) {
-          const resolvedMcp = resolveMcpSource(server.source)
-          let installedCount = 0
-          for (const agent of mcpTargets) {
-            const ok = await addMcpServer(agent, server.name, resolvedMcp)
-            if (ok) installedCount++
+      console.log(`   Installed to ${results.length} agent(s):`)
+      for (const [path, count] of pathCounts) {
+        const detail = count > 1 ? ` (×${count} agents)` : ''
+        console.log(`     ${path}${detail}`)
+      }
+
+      if (resolved.content) {
+        const mcpServers = parseMcpServersFromSkill(resolved.content)
+        if (mcpServers.length > 0) {
+          console.log(`\n   Skill includes ${mcpServers.length} MCP server(s). Installing...`)
+          const supported = getSupportedMcpAgents()
+          const mcpTargets = agents.filter(a => supported.includes(a.flag)).map(a => a.flag)
+          for (const server of mcpServers) {
+            const resolvedMcp = resolveMcpSource(server.source)
+            let installedCount = 0
+            for (const agent of mcpTargets) {
+              const ok = await addMcpServer(agent, server.name, resolvedMcp)
+              if (ok) installedCount++
+            }
+            console.log(`     ${installedCount}/${mcpTargets.length} agents: MCP server "${server.name}" installed`)
           }
-          console.log(`   ${installedCount}/${mcpTargets.length} agents: MCP server "${server.name}" installed`)
         }
       }
     }
@@ -207,6 +317,11 @@ export async function setupCommand(source, options = {}) {
     console.log('Examples:')
     console.log('  rolecraft setup ./my-skill')
     console.log('  rolecraft setup sametcelikbicak/task-decomposer')
+    console.log('\nOptions:')
+    console.log('  --list        List available skills from a source without installing')
+    console.log('  --skill <n>   Install specific skills by name (comma-separated)')
+    console.log('  --yes, -y     Install all skills without prompt')
+    console.log('  --dry-run     Preview without installing')
   }
 }
 

--- a/src/commands/setup.test.js
+++ b/src/commands/setup.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -123,5 +123,90 @@ describe('setup command', () => {
     restoreLog()
 
     assert.ok(logs.some(l => l.includes('opencode')))
+  }))
+
+  it('installs from multi-skill source with --skill flag', withTempCwd(async () => {
+    rmSync(join(tempDir, '.agents'), { recursive: true, force: true })
+    mkdirSync(join(tempDir, '.agents', 'skills'), { recursive: true })
+    const multiDir = join(tempDir, 'multi-setup-skill')
+    mkdirSync(join(multiDir, 'skills', 'pick-me'), { recursive: true })
+    mkdirSync(join(multiDir, 'skills', 'not-me'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 'pick-me', 'SKILL.md'), '---\nname: pick-me\nslug: multi/pick\ndescription: Pick\n---\nContent')
+    writeFileSync(join(multiDir, 'skills', 'not-me', 'SKILL.md'), '---\nname: not-me\nslug: multi/not\n---\nContent')
+
+    capture()
+    await setupModule.setupCommand(multiDir, { skill: ['pick-me'] })
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('pick-me')))
+    assert.ok(logs.some(l => l.includes('Installed')))
+    assert.ok(!logs.some(l => l.includes('not-me')))
+  }))
+
+  it('--list flag shows skills from source without installing', withTempCwd(async () => {
+    rmSync(join(tempDir, '.agents'), { recursive: true, force: true })
+    mkdirSync(join(tempDir, '.agents', 'skills'), { recursive: true })
+    const multiDir = join(tempDir, 'multi-setup-list')
+    mkdirSync(join(multiDir, 'skills', 'show-me'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 'show-me', 'SKILL.md'), '---\nname: show-me\ndescription: Visible\n---\nHidden')
+
+    capture()
+    await setupModule.setupCommand(multiDir, { list: true })
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('show-me')))
+    assert.ok(logs.some(l => l.includes('Visible')))
+    assert.ok(!logs.some(l => l.includes('Hidden')))
+    assert.ok(!logs.some(l => l.includes('Installed')))
+  }))
+
+  it('--yes installs all skills from multi-skill source without prompt', withTempCwd(async () => {
+    rmSync(join(tempDir, '.agents'), { recursive: true, force: true })
+    mkdirSync(join(tempDir, '.agents', 'skills'), { recursive: true })
+    const multiDir = join(tempDir, 'multi-setup-yes')
+    mkdirSync(join(multiDir, 'skills', 's1'), { recursive: true })
+    mkdirSync(join(multiDir, 'skills', 's2'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 's1', 'SKILL.md'), '---\nname: s1\nslug: multi/s1\n---\nA')
+    writeFileSync(join(multiDir, 'skills', 's2', 'SKILL.md'), '---\nname: s2\nslug: multi/s2\n---\nB')
+
+    capture()
+    await setupModule.setupCommand(multiDir, { yes: true })
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('s1')))
+    assert.ok(logs.some(l => l.includes('s2')))
+    assert.ok(logs.some(l => l.includes('Installed')))
+  }))
+
+  it('dry-run with multi-skill source shows all skills', withTempCwd(async () => {
+    rmSync(join(tempDir, '.agents'), { recursive: true, force: true })
+    mkdirSync(join(tempDir, '.agents', 'skills'), { recursive: true })
+    const multiDir = join(tempDir, 'multi-setup-dry')
+    mkdirSync(join(multiDir, 'skills', 'd1'), { recursive: true })
+    mkdirSync(join(multiDir, 'skills', 'd2'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 'd1', 'SKILL.md'), '---\nname: d1\nslug: multi/d1\n---\nD1')
+    writeFileSync(join(multiDir, 'skills', 'd2', 'SKILL.md'), '---\nname: d2\nslug: multi/d2\n---\nD2')
+
+    capture()
+    await setupModule.setupCommand(multiDir, { skill: ['d1', 'd2'], dryRun: true })
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('[dry-run]')))
+    assert.ok(logs.some(l => l.includes('d1')))
+    assert.ok(logs.some(l => l.includes('d2')))
+    assert.ok(!logs.some(l => l.includes('Installed')))
+  }))
+
+  it('--skill flag throws for non-matching names', withTempCwd(async () => {
+    rmSync(join(tempDir, '.agents'), { recursive: true, force: true })
+    mkdirSync(join(tempDir, '.agents', 'skills'), { recursive: true })
+    const multiDir = join(tempDir, 'multi-setup-nomatch')
+    mkdirSync(join(multiDir, 'skills', 'exists'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 'exists', 'SKILL.md'), '---\nname: exists\n---\nX')
+
+    await assert.rejects(
+      () => setupModule.setupCommand(multiDir, { skill: ['nope'] }),
+      /No matching skills found/,
+    )
   }))
 })

--- a/src/commands/use.js
+++ b/src/commands/use.js
@@ -1,23 +1,47 @@
-import { resolveSource } from '../utils/resolver.js'
+import { resolveSkills } from '../utils/resolver.js'
 
-export async function useCommand(source) {
-  console.log(`\n🔍 Resolving skill from: ${source}`)
-  const resolved = await resolveSource(source)
+export async function useCommand(source, options = {}) {
+  const allSkills = await resolveSkills(source)
 
-  console.log(`\n📦 Skill: ${resolved.name}`)
-  console.log(`   Slug:     ${resolved.slug}`)
-  console.log(`   Owner:    ${resolved.owner}`)
-  if (resolved.description) console.log(`   Desc:     ${resolved.description}`)
-  console.log(`   Files:    ${resolved.files.join(', ')}\n`)
+  if (options.list) {
+    console.log(`\nFound ${allSkills.length} skill(s) from: ${source}\n`)
+    for (const s of allSkills) {
+      console.log(`  ${s.name}`)
+      console.log(`    Slug:       ${s.slug}`)
+      console.log(`    Owner:      ${s.owner}`)
+      if (s.description) console.log(`    Description: ${s.description}`)
+      console.log(`    Files:      ${s.files.join(', ')}`)
+      console.log()
+    }
+    return
+  }
 
-  for (const file of resolved.files) {
-    const content = resolved.fileContents?.[file]
-    if (!content) continue
+  let selectedSkills = allSkills
+  if (options.skill && options.skill.length > 0) {
+    const skillNames = options.skill.map(n => n.toLowerCase())
+    selectedSkills = allSkills.filter(s =>
+      skillNames.includes(s.name.toLowerCase()) || skillNames.includes(s.slug.toLowerCase())
+    )
+    if (selectedSkills.length === 0) {
+      throw new Error(`No matching skills found for: ${options.skill.join(', ')}. Available: ${allSkills.map(s => s.name).join(', ')}`)
+    }
+  }
 
-    const separator = `─── ${file} ${'─'.repeat(Math.max(0, 50 - file.length))}`
-    console.log(separator)
-    console.log(content)
-    if (!content.endsWith('\n')) console.log()
-    console.log()
+  for (const resolved of selectedSkills) {
+    console.log(`\n📦 Skill: ${resolved.name}`)
+    console.log(`   Slug:     ${resolved.slug}`)
+    console.log(`   Owner:    ${resolved.owner}`)
+    if (resolved.description) console.log(`   Desc:     ${resolved.description}`)
+    console.log(`   Files:    ${resolved.files.join(', ')}\n`)
+
+    for (const file of resolved.files) {
+      const content = resolved.fileContents?.[file]
+      if (!content) continue
+      const separator = `─── ${file} ${'─'.repeat(Math.max(0, 50 - file.length))}`
+      console.log(separator)
+      console.log(content)
+      if (!content.endsWith('\n')) console.log()
+      console.log()
+    }
   }
 }

--- a/src/commands/use.test.js
+++ b/src/commands/use.test.js
@@ -102,4 +102,61 @@ Content here
     assert.ok(logs.some(l => l.includes('A skill with description')))
     assert.ok(logs.some(l => l.includes('desc/skill')))
   })
+
+  it('shows all skills from multi-skill source', async () => {
+    const multiDir = join(tempDir, 'multi-use')
+    mkdirSync(join(multiDir, 'skills', 'alpha'), { recursive: true })
+    mkdirSync(join(multiDir, 'skills', 'beta'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 'alpha', 'SKILL.md'), '---\nname: alpha\nslug: multi/alpha\ndescription: First\n---\nContent A')
+    writeFileSync(join(multiDir, 'skills', 'beta', 'SKILL.md'), '---\nname: beta\nslug: multi/beta\ndescription: Second\n---\nContent B')
+
+    capture()
+    await useModule.useCommand(multiDir)
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('alpha')))
+    assert.ok(logs.some(l => l.includes('beta')))
+    assert.ok(logs.some(l => l.includes('Content A')))
+    assert.ok(logs.some(l => l.includes('Content B')))
+  })
+
+  it('--list flag shows all skills without content', async () => {
+    const multiDir = join(tempDir, 'multi-use-list')
+    mkdirSync(join(multiDir, 'skills', 'skill-x'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 'skill-x', 'SKILL.md'), '---\nname: skill-x\ndescription: Extra\n---\nSecret')
+
+    capture()
+    await useModule.useCommand(multiDir, { list: true })
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('skill-x')))
+    assert.ok(logs.some(l => l.includes('Extra')))
+    assert.ok(!logs.some(l => l.includes('Secret')))
+  })
+
+  it('--skill flag filters to specific skill', async () => {
+    const multiDir = join(tempDir, 'multi-use-skill')
+    mkdirSync(join(multiDir, 'skills', 'filter-a'), { recursive: true })
+    mkdirSync(join(multiDir, 'skills', 'filter-b'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 'filter-a', 'SKILL.md'), '---\nname: filter-a\nslug: f/a\n---\nAAA')
+    writeFileSync(join(multiDir, 'skills', 'filter-b', 'SKILL.md'), '---\nname: filter-b\nslug: f/b\n---\nBBB')
+
+    capture()
+    await useModule.useCommand(multiDir, { skill: ['filter-a'] })
+    restoreLog()
+
+    assert.ok(logs.some(l => l.includes('AAA')))
+    assert.ok(!logs.some(l => l.includes('BBB')))
+  })
+
+  it('--skill flag throws for non-matching names', async () => {
+    const multiDir = join(tempDir, 'multi-use-nomatch')
+    mkdirSync(join(multiDir, 'skills', 'exists'), { recursive: true })
+    writeFileSync(join(multiDir, 'skills', 'exists', 'SKILL.md'), '---\nname: exists\n---\nX')
+
+    await assert.rejects(
+      () => useModule.useCommand(multiDir, { skill: ['nope'] }),
+      /No matching skills found/,
+    )
+  })
 })


### PR DESCRIPTION
## Summary

Extends multi-skill source support (previously added to `install`) to `use` and `setup` commands.

## Changes

- **`use.js`**: Replaced `resolveSource` with `resolveSkills`; shows all skills sequentially from multi-skill sources. Added `--list` (list metadata without content) and `--skill` (filter by name) flags.
- **`setup.js`**: Replaced `resolveSource` with `resolveSkills`; interactive skill selection for multi-skill sources. Added `--list`, `--skill`, and `--yes` support.
- **`bin/rolecraft.js`**: Flag parsing for `--list` and `--skill` on both commands. Updated usage text.
- **New tests**: 4 for `use` (multi-skill, `--list`, `--skill`, `--skill` error) + 5 for `setup` (`--skill`, `--list`, `--yes`, dry-run multi, `--skill` error). 730 total, all pass.
- **Docs**: Updated `docs/commands/use.md` and `docs/commands/setup.md` with multi-skill examples. Updated test counts in README/CONTRIBUTING.
- **Issues**: Commented on #112 and #95 about needed updates after previous multi-skill PR.