### PR TITLE
feat: enhance doctor command with comprehensive health checks

### DIFF
--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -52,7 +52,7 @@ Usage:
   rolecraft verify                  Verify installed skill integrity
   rolecraft ci                      Install all skills from lockfile
   rolecraft completions <shell>     Generate shell completions (bash|zsh|fish)
-  rolecraft doctor                  Run system health check
+  rolecraft doctor                  Run system health check (--json, --network)
   rolecraft watch [<slug>]          Watch skills for changes and auto-sync
   rolecraft profile                 Manage agent configuration profiles
   rolecraft mcp install <source>    Install an MCP server (npm:, gh:, or local path)
@@ -271,10 +271,12 @@ export async function main() {
       break
     }
 
-    case 'doctor':
+    case 'doctor': {
       if (args.includes('--help') || args.includes('-h')) { usage(); return }
-      await doctorCommand()
+      const doctorFlags = args.filter(a => a.startsWith('-'))
+      await doctorCommand({ json: doctorFlags.includes('--json'), network: doctorFlags.includes('--network') })
       break
+    }
 
     case 'watch': {
       if (args.includes('--help') || args.includes('-h')) { usage(); return }

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -6,20 +6,33 @@ Run a system health check to diagnose common issues.
 
 ```bash
 rolecraft doctor
+rolecraft doctor --json          # JSON output
+rolecraft doctor --network       # include network connectivity check
 ```
 
 ## Description
 
 Scans your system and reports on:
 
-- **Node.js version** — verifies >= 20
-- **rolecraft version** — shows current installed version
-- **Home directory** — confirms HOME is set
-- **~/.agents directory** — checks if the global agents directory exists
-- **Global lockfile** — reads the lockfile and counts tracked skills
-- **Project lockfile** — reads the project-scoped lockfile (if any)
-- **Agent detection** — finds all installed AI agents by scanning known skill directories
-- **Skill integrity** — for each skill in the lockfile, verifies the skill directory exists and content hashes match
+- **Node.js version** — verifies >= 20, shows runtime path
+- **Platform** — OS and kernel release
+- **Git / npm availability** — needed for GitHub and npm sources
+- **~/.agents directory** — existence and permissions
+- **Lockfile schema** — validates global lockfile format
+- **Global & project lockfiles** — skill count per scope
+- **Disk usage** — total size of installed skills
+- **Agent detection** — finds installed agents among 86+ supported, per-agent skill count and directory permissions
+- **Orphaned skill dirs** — directories not tracked in any lockfile
+- **Skill integrity** — verifies skill directories exist, content hashes match, and checks for broken symlinks
+- **MCP servers** — counts configured MCP servers across detected agents
+- **Network** (with `--network`) — tests connectivity to GitHub
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output results as structured JSON |
+| `--network` | Include a network connectivity check (GitHub) |
 
 ## Example output
 
@@ -29,32 +42,50 @@ $ rolecraft doctor
 🔬 rolecraft doctor — System Health Check
 
    ✅ Node.js version                        v22.0.0
-   ✅ rolecraft version                      v1.2.0
+   ✅ Git availability                       detected
+   ✅ npm availability                       detected
+   ✅ rolecraft version                      v1.6.0
+   ✅ Node.js location                       /usr/local/bin/node
+   ✅ Platform                               darwin 24.0.0
    ✅ Home directory                         /home/user
    ✅ ~/.agents directory                    /home/user/.agents
+   ✅ ~/.agents permissions                  rwx
+   ✅ Global lockfile schema                 v3, valid
    ✅ Global lockfile                        3 skill(s) tracked
    ⚠️  Project lockfile                       no project skills
-   ✅ Agent detection                        2 agent(s) found
-     ✅  └ opencode                          2 skill(s)
-     ✅  └ claude-code                       1 skill(s)
-   ✅ Skill integrity                        3 checked, 0 hash mismatch(es), 0 missing director(ies)
+   ✅ Disk usage                             3 skill(s), 12.5 KB total
+   ✅ Agent detection                        14/86 supported agents detected
+     ✅  └ opencode                          2 skill(s) [rwx]
+     ✅  └ claude-code                       1 skill(s) [rwx]
+   ✅ Orphaned skill dirs                    none
+   ✅ Skill integrity                        3 checked, 0 hash mismatch(es)
+   ✅ MCP servers                            6 configured across 3 agent(s)
 
-📋 Summary: 9 passed, 1 warnings, 0 errors
+📋 Summary: 14/15 passed, 1 warnings, 0 errors
 ```
 
 ```bash
-$ rolecraft doctor
+$ rolecraft doctor --json
+
+{
+  "status": "degraded",
+  "checks": {
+    "Node.js version": { "status": "pass", "detail": "v22.0.0" },
+    "Agent detection": { "status": "pass", "detail": "14/86 supported agents detected" },
+    "Skill integrity": { "status": "warn", "detail": "3 checked, 1 missing director(ies)" },
+    "MCP servers": { "status": "warn", "detail": "none configured" }
+  },
+  "summary": { "passed": 12, "warnings": 3, "errors": 0 }
+}
+```
+
+```bash
+$ rolecraft doctor --network
 
 🔬 rolecraft doctor — System Health Check
 
-   ✅ Node.js version                        v20.11.0
-   ✅ rolecraft version                      v1.2.0
-   ✅ Home directory                         /home/user
-   ⚠️  ~/.agents directory                   not yet created
-   ⚠️  Global lockfile                       no global skills
-   ⚠️  Project lockfile                      no project skills
-   ⚠️  Agent detection                       no supported agents detected
-   ⚠️  Skill integrity                       no skills to verify
+   ...
+   ✅ Network (GitHub)                       reachable
 
-📋 Summary: 3 passed, 5 warnings, 0 errors
+📋 Summary: 15/15 passed, 0 warnings, 0 errors
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -209,7 +209,13 @@ Verifies SHA256 content hashes of all installed skills.
 
 ### `rolecraft doctor`
 
-Runs system health checks: Node.js version, agent directories, lockfile integrity, skill file existence.
+```bash
+rolecraft doctor                # standard health check
+rolecraft doctor --json         # JSON output for scripting
+rolecraft doctor --network      # include GitHub connectivity test
+```
+
+Runs comprehensive system health checks: Node.js version, platform info, Git/npm availability, agent directories, lockfile schema validation, disk usage, orphaned directory detection, skill integrity (hash + symlink), MCP server configuration, and optional network connectivity (`--network`).
 
 ### `rolecraft watch [<slug>]`
 

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,4 +1,4 @@
-import { accessSync, constants, readFileSync, readdirSync, statSync, lstatSync } from 'node:fs'
+import { accessSync, constants, readFileSync, readdirSync, statSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,9 +1,11 @@
-import { accessSync, constants, readFileSync, readdirSync } from 'node:fs'
+import { accessSync, constants, readFileSync, readdirSync, statSync, lstatSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
+import { homedir, platform, release } from 'node:os'
 import { readLock, getProjectLockPath, getAgentsDir } from '../utils/lockfile.js'
 import { detectAgents } from './setup.js'
+import agents from '../agents.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'))
@@ -12,83 +14,266 @@ function icon(status) {
   return status === 'pass' ? '✅' : status === 'warn' ? '⚠️' : '❌'
 }
 
-export async function doctorCommand() {
+function permString(dir) {
+  try {
+    const s = statSync(dir)
+    const mode = s.mode & parseInt('777', 8)
+    const r = (mode & 4) ? 'r' : '-'
+    const w = (mode & 2) ? 'w' : '-'
+    const x = (mode & 1) ? 'x' : '-'
+    return `${r}${w}${x}`
+  } catch {
+    return '---'
+  }
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function dirSize(dirPath) {
+  try {
+    let total = 0
+    const entries = readdirSync(dirPath, { withFileTypes: true })
+    for (const e of entries) {
+      const full = join(dirPath, e.name)
+      if (e.isDirectory()) {
+        total += dirSize(full)
+      } else if (e.isFile()) {
+        total += statSync(full).size
+      } else if (e.isSymbolicLink()) {
+        try {
+          total += statSync(full).size
+        } catch {}
+      }
+    }
+    return total
+  } catch {
+    return 0
+  }
+}
+
+function countBrokenSymlinks(dirPath) {
+  let count = 0
+  try {
+    const entries = readdirSync(dirPath, { withFileTypes: true })
+    for (const e of entries) {
+      const full = join(dirPath, e.name)
+      if (e.isDirectory()) {
+        count += countBrokenSymlinks(full)
+      } else if (e.isSymbolicLink()) {
+        try {
+          accessSync(full, constants.F_OK)
+        } catch {
+          count++
+        }
+      }
+    }
+  } catch {}
+  return count
+}
+
+function validateLockfileSchema(lock) {
+  if (typeof lock !== 'object' || lock === null) return 'not an object'
+  if (typeof lock.version !== 'number') return 'version missing or not a number'
+  if (typeof lock.skills !== 'object' || lock.skills === null) return 'skills missing or not an object'
+  for (const [slug, entry] of Object.entries(lock.skills)) {
+    if (typeof entry !== 'object' || entry === null) return `entry "${slug}" is not an object`
+  }
+  return null
+}
+
+async function readMcpServersForAllAgents(detected) {
+  const seenPaths = new Set()
+  let totalServers = 0
+  let configuredAgents = 0
+  for (const agent of agents) {
+    if (!agent.mcp || !detected.some(d => d.flag === agent.flag)) continue
+    try {
+      const configPath = agent.mcp.getPath()
+      if (seenPaths.has(configPath)) continue
+      seenPaths.add(configPath)
+      const raw = readFileSync(configPath, 'utf-8')
+      const data = JSON.parse(raw)
+      let servers = []
+      if (Array.isArray(data.experimental?.mcpServers)) {
+        servers = data.experimental.mcpServers
+      } else if (data.servers && typeof data.servers === 'object') {
+        servers = Object.keys(data.servers)
+      } else if (data.mcpServers && typeof data.mcpServers === 'object') {
+        servers = Object.keys(data.mcpServers)
+      }
+      if (servers.length > 0) {
+        totalServers += servers.length
+        configuredAgents++
+      }
+    } catch {}
+  }
+  return { totalServers, configuredAgents }
+}
+
+export async function doctorCommand(options = {}) {
+  const jsonMode = options.json
   let passed = 0
   let warnings = 0
   let errors = 0
 
   function report(label, status, detail = '') {
+    if (jsonMode) return { label, status, detail }
     console.log(`   ${icon(status)} ${label.padEnd(38)} ${detail}`)
     if (status === 'pass') passed++
     else if (status === 'warn') warnings++
     else errors++
   }
 
-  console.log('\n🔬 rolecraft doctor — System Health Check\n')
+  const jsonChecks = []
 
-  report('Node.js version', 'pass', `v${process.versions.node}`)
+  function checked(label, status, detail = '') {
+    if (jsonMode) {
+      jsonChecks.push({ label, status, detail })
+    } else {
+      console.log(`   ${icon(status)} ${label.padEnd(38)} ${detail}`)
+    }
+    if (status === 'pass') passed++
+    else if (status === 'warn') warnings++
+    else errors++
+  }
+
+  if (!jsonMode) {
+    console.log('\n🔬 rolecraft doctor — System Health Check\n')
+  }
+
+  // --- Environment ---
+  checked('Node.js version', 'pass', `v${process.versions.node}`)
   const [major] = process.versions.node.split('.').map(Number)
   if (major < 20) {
-    report('Node.js compatibility', 'error', '>= 20 required, please upgrade')
+    checked('Node.js compatibility', 'error', '>= 20 required, please upgrade')
   }
 
   try {
     execSync('git --version', { stdio: 'ignore' })
-    report('Git availability', 'pass', 'detected')
+    checked('Git availability', 'pass', 'detected')
   } catch {
-    report('Git availability', 'warn', 'not found (needed for GitHub sources)')
+    checked('Git availability', 'warn', 'not found (needed for GitHub sources)')
   }
 
   try {
     execSync('npm --version', { stdio: 'ignore' })
-    report('npm availability', 'pass', 'detected')
+    checked('npm availability', 'pass', 'detected')
   } catch {
-    report('npm availability', 'warn', 'not found (needed for npm sources)')
+    checked('npm availability', 'warn', 'not found (needed for npm sources)')
   }
 
-  report('rolecraft version', 'pass', `v${pkg.version}`)
-  report('Home directory', 'pass', process.env.HOME || '~')
+  checked('rolecraft version', 'pass', `v${pkg.version}`)
+  checked('Node.js location', 'pass', process.execPath)
+  checked('Platform', 'pass', `${platform()} ${release()}`)
+  checked('Home directory', 'pass', process.env.HOME || homedir())
 
-  const agentsDir = join(process.env.HOME || '~', '.agents')
+  // --- ~/.agents directory ---
+  const home = process.env.HOME || homedir()
+  const agentsDir = join(home, '.agents')
   try {
     accessSync(agentsDir, constants.F_OK)
-    report('~/.agents directory', 'pass', agentsDir)
+    checked('~/.agents directory', 'pass', agentsDir)
+    checked('~/.agents permissions', 'pass', permString(agentsDir))
   } catch {
-    report('~/.agents directory', 'warn', 'not yet created')
+    checked('~/.agents directory', 'warn', 'not yet created')
   }
 
+  // --- Lockfile checks ---
   const globalLock = await readLock()
   const globalSkillCount = Object.keys(globalLock.skills).length
-  if (globalSkillCount > 0) {
-    report('Global lockfile', 'pass', `${globalSkillCount} skill(s) tracked`)
+
+  const schemaErr = validateLockfileSchema(globalLock)
+  if (schemaErr) {
+    checked('Global lockfile schema', 'error', schemaErr)
   } else {
-    report('Global lockfile', 'warn', 'no global skills')
+    checked('Global lockfile schema', 'pass', `v${globalLock.version}, valid`)
+  }
+
+  if (globalSkillCount > 0) {
+    checked('Global lockfile', 'pass', `${globalSkillCount} skill(s) tracked`)
+  } else {
+    checked('Global lockfile', 'warn', 'no global skills')
   }
 
   const projectLock = await readLock(getProjectLockPath(process.cwd())).catch(() => null)
   const projectSkillCount = projectLock ? Object.keys(projectLock.skills).length : 0
   if (projectSkillCount > 0) {
-    report('Project lockfile', 'pass', `${projectSkillCount} skill(s) tracked`)
+    checked('Project lockfile', 'pass', `${projectSkillCount} skill(s) tracked`)
   } else {
-    report('Project lockfile', 'warn', 'no project skills')
+    checked('Project lockfile', 'warn', 'no project skills')
   }
 
-  const agents = detectAgents()
-  if (agents.length > 0) {
-    report('Agent detection', 'pass', `${agents.length} agent(s) found`)
-    for (const agent of agents) {
-      const skillCount = countAgentSkills(agent.dir())
-      const label = `  └ ${agent.label}`
-      if (skillCount > 0) {
-        report(label, 'pass', `${skillCount} skill(s)`)
-      } else {
-        report(label, 'warn', 'no skills installed')
+  // --- Disk usage ---
+  const skillDirs = [
+    ...(globalSkillCount > 0 || true ? [getAgentsDir()] : []),
+    ...(projectSkillCount > 0 ? [join(process.cwd(), '.agents', 'skills')] : []),
+  ]
+  let totalSize = 0
+  let totalSkillDirs = 0
+  for (const d of skillDirs) {
+    try {
+      const entries = readdirSync(d, { withFileTypes: true })
+      for (const e of entries) {
+        if (e.isDirectory() && !e.name.startsWith('.')) {
+          totalSkillDirs++
+          totalSize += dirSize(join(d, e.name))
+        }
       }
+    } catch {}
+  }
+  if (totalSkillDirs > 0 || globalSkillCount > 0 || projectSkillCount > 0) {
+    checked('Disk usage', 'pass', `${totalSkillDirs} skill(s), ${formatBytes(totalSize)} total`)
+  } else {
+    checked('Disk usage', 'warn', 'no skills installed')
+  }
+
+  // --- Agent detection ---
+  const detected = detectAgents()
+  const totalAgents = agents.length
+  if (detected.length > 0) {
+    checked('Agent detection', 'pass', `${detected.length}/${totalAgents} supported agents detected`)
+    for (const agent of detected) {
+      const dir = agent.dir()
+      const skillCount = countAgentSkills(dir)
+      const perms = permString(dir)
+      let detail = `${skillCount} skill(s)`
+      if (perms !== '---') detail += ` [${perms}]`
+      checked(`  └ ${agent.label}`, skillCount > 0 ? 'pass' : 'warn', detail)
     }
   } else {
-    report('Agent detection', 'warn', 'no supported agents detected')
+    checked('Agent detection', 'warn', 'no supported agents detected')
   }
 
+  // --- Orphaned skill directories ---
+  const allLockSlugs = new Set(Object.keys(globalLock.skills))
+  if (projectLock) {
+    for (const slug of Object.keys(projectLock.skills)) {
+      allLockSlugs.add(slug)
+    }
+  }
+  let orphanedDirs = 0
+  try {
+    const entries = readdirSync(getAgentsDir(), { withFileTypes: true })
+    for (const e of entries) {
+      if (e.isDirectory() && !e.name.startsWith('.')) {
+        const normSlug = allLockSlugs.has(e.name) || allLockSlugs.has(e.name.replace(/-/g, '/'))
+        if (!normSlug) {
+          orphanedDirs++
+        }
+      }
+    }
+  } catch {}
+  if (orphanedDirs > 0) {
+    checked('Orphaned skill dirs', 'warn', `${orphanedDirs} director(ies) not in any lockfile`)
+  } else {
+    checked('Orphaned skill dirs', 'pass', 'none')
+  }
+
+  // --- Skill integrity ---
   const allSkills = { ...globalLock.skills }
   if (projectLock) {
     for (const [slug, entry] of Object.entries(projectLock.skills)) {
@@ -99,6 +284,7 @@ export async function doctorCommand() {
   let missingDirs = 0
   let hashMismatches = 0
   let verifiedSkills = 0
+  let brokenSymlinks = 0
   for (const [slug, entry] of Object.entries(allSkills)) {
     const normSlug = slug.replace(/\//g, '-')
     const searchDirs = [join(getAgentsDir(), normSlug), join(process.cwd(), '.agents', 'skills', normSlug)]
@@ -109,6 +295,7 @@ export async function doctorCommand() {
       missingDirs++
       continue
     }
+    brokenSymlinks += countBrokenSymlinks(existingDir)
     if (entry.contentSha) {
       try {
         const files = readdirSync(existingDir).filter(f => f.endsWith('.md'))
@@ -131,13 +318,50 @@ export async function doctorCommand() {
   }
 
   if (Object.keys(allSkills).length > 0) {
-    report('Skill integrity', (hashMismatches + missingDirs) === 0 ? 'pass' : 'warn',
-      `${verifiedSkills} checked, ${hashMismatches} hash mismatch(es), ${missingDirs} missing director(ies)`)
+    const integrityIssues = (hashMismatches + missingDirs + brokenSymlinks) > 0
+    let detail = `${verifiedSkills} checked`
+    if (hashMismatches > 0) detail += `, ${hashMismatches} hash mismatch(es)`
+    if (missingDirs > 0) detail += `, ${missingDirs} missing director(ies)`
+    if (brokenSymlinks > 0) detail += `, ${brokenSymlinks} broken symlink(s)`
+    checked('Skill integrity', integrityIssues ? 'warn' : 'pass', detail)
   } else {
-    report('Skill integrity', 'warn', 'no skills to verify')
+    checked('Skill integrity', 'warn', 'no skills to verify')
   }
 
-  console.log(`\n📋 Summary: ${passed} passed, ${warnings} warnings, ${errors} errors\n`)
+  // --- MCP server health ---
+  const mcpInfo = await readMcpServersForAllAgents(detected)
+  if (mcpInfo.totalServers > 0) {
+    checked('MCP servers', 'pass', `${mcpInfo.totalServers} configured across ${mcpInfo.configuredAgents} agent(s)`)
+  } else {
+    checked('MCP servers', 'warn', 'none configured')
+  }
+
+  // --- Network check (optional) ---
+  if (options.network) {
+    try {
+      const resp = await fetch('https://github.com', { method: 'HEAD', signal: AbortSignal.timeout(5000) })
+      checked('Network (GitHub)', resp.ok ? 'pass' : 'warn', `HTTP ${resp.status}`)
+    } catch {
+      checked('Network (GitHub)', 'warn', 'unreachable')
+    }
+  }
+
+  // --- Output ---
+  if (jsonMode) {
+    const result = {}
+    for (const c of jsonChecks) {
+      result[c.label] = { status: c.status, detail: c.detail }
+    }
+    console.log(JSON.stringify({
+      status: errors > 0 ? 'unhealthy' : warnings > 0 ? 'degraded' : 'healthy',
+      checks: result,
+      summary: { passed, warnings, errors },
+    }, null, 2))
+    return
+  }
+
+  const total = passed + warnings + errors
+  console.log(`\n📋 Summary: ${passed}/${total} passed, ${warnings} warnings, ${errors} errors\n`)
 }
 
 function countAgentSkills(dir) {

--- a/src/commands/doctor.test.js
+++ b/src/commands/doctor.test.js
@@ -1,7 +1,7 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync } from 'node:fs'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, writeFile, symlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -308,5 +308,73 @@ describe('doctor command', () => {
     }
 
     assert.ok(logs.some(l => l.includes('hash mismatch') || l.includes('checked')))
+  })
+
+  it('shows platform info', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('Platform')))
+  })
+
+  it('shows node.js location', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('Node.js location')))
+    assert.ok(logs.some(l => l.includes(process.execPath)))
+  })
+
+  it('validates lockfile schema as valid', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('lockfile schema')))
+    assert.ok(logs.some(l => l.includes('valid')))
+  })
+
+  it('reports no orphaned skill dirs when clean', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('Orphaned skill dirs')))
+    assert.ok(logs.some(l => l.includes('none')))
+  })
+
+  it('reports mcp servers check', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some(l => l.includes('MCP servers')))
+  })
+
+  it('outputs json with --json flag', async () => {
+    const { logs, restore } = capture()
+    try {
+      await doctorModule.doctorCommand({ json: true })
+    } finally {
+      restore()
+    }
+    assert.ok(logs.length > 0)
+    const parsed = JSON.parse(logs.join(''))
+    assert.ok(typeof parsed.status === 'string')
+    assert.ok(typeof parsed.checks === 'object')
+    assert.ok(typeof parsed.summary === 'object')
+    assert.ok(typeof parsed.summary.passed === 'number')
   })
 })


### PR DESCRIPTION
## Summary

Enhances `rolecraft doctor` with comprehensive system health checks beyond the basic scan.

## New checks

| Check | Description |
|-------|-------------|
| **Node.js location** | Shows `process.execPath` |
| **Platform** | OS and kernel release |
| **Git / npm availability** | Detects required tooling |
| **~/.agents permissions** | Directory permission string |
| **Lockfile schema** | Validates global lockfile format (version, structure) |
| **Disk usage** | Total size and count of installed skills |
| **Agent detection ratio** | Shows `X/86 supported agents detected` instead of just count |
| **Per-agent permissions** | Directory permissions per detected agent |
| **Orphaned skill dirs** | Directories in skills path not tracked in any lockfile |
| **Broken symlinks** | Detected as part of integrity check |
| **MCP servers** | Counts configured MCP servers (deduplicated by config path) |
| **`--json` flag** | Structured JSON output for scripting |
| **`--network` flag** | Optional GitHub connectivity test |

## Agent count clarification

Previous doctor showed `49 agent(s) found` without context. Now shows `49/86 supported agents detected`, making clear that 86 are supported but only 49 are installed on the system.

## Docs

Updated:
- `docs/commands/doctor.md` — new output examples, `--json`/`--network` flags
- `docs/reference.md` — doctor entry with flag details

## Tests

6 new tests added (25 total for doctor): platform, node location, lockfile schema validation, orphaned dirs, MCP check, `--json` output. All 736 tests pass.