### PR TITLE
fix: validate MCP agent support — only 7 of 86+ agents have MCP

### DIFF
--- a/docs/guides/use-cases.md
+++ b/docs/guides/use-cases.md
@@ -88,7 +88,7 @@ rolecraft list --global
 
 ## 4. MCP server fleet management
 
-**Problem:** Installing MCP servers requires editing JSON configs for each agent. The format differs between cursor (`mcp_config.json`), claude-code (`claude_code.json`), and copilot (`.mcp.json`). Multiply by N agents and it's unmanageable.
+**Problem:** Installing MCP servers requires editing JSON configs for each agent. The format differs between cursor (`mcp_config.json`), claude-code (`~/.claude.json`), and copilot (`.mcp.json`). Multiply by N agents and it's unmanageable.
 
 **Solution:** Declare MCP servers in `SKILL.md` frontmatter. rolecraft handles the per-agent config format automatically.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -76,7 +76,7 @@ This does **three things** automatically:
 2. **MCP installation** → reads `mcp_servers` from SKILL.md, resolves the sources
 3. **Config wiring** → writes MCP config in each agent's native format:
    - Cursor: `~/.cursor/mcp.json`
-   - Claude Code: `~/.claude/claude_code.json`
+   - Claude Code: `~/.claude.json`
    - Windsurf: `~/.windsurf/mcp_config.json`
 
 ### 3. Each agent can now
@@ -103,11 +103,10 @@ rolecraft bundle install team-onboarding.json
 | Agent | Config File | Format |
 |-------|------------|--------|
 | opencode | `~/.agents/mcp.json` | Standard `mcpServers` object |
-| claude-code | `~/.claude/claude_code.json` | Standard `mcpServers` object |
+| claude-code | `~/.claude.json` | Standard `mcpServers` object |
 | cursor | `~/.cursor/mcp.json` | Standard `mcpServers` object |
 | windsurf | `~/.windsurf/mcp_config.json` | Standard `mcpServers` object |
 | devin | `~/.devin/mcp.json` | Standard `mcpServers` object |
-| codex | `~/.codex/mcp.json` | Standard `mcpServers` object |
 | copilot | `./.github/copilot/.mcp.json` | `{ inputs: [], servers: {} }` |
 | continue | `~/.continue/config.json` | `{ experimental: { mcpServers: [] } }` |
 

--- a/src/agents.js
+++ b/src/agents.js
@@ -105,19 +105,34 @@ const AGENTS_DATA = [
   { flag: 'promptscript', name: 'promptscript', getDir: () => proj('agent', 'skills'), label: './agent/skills/' },
 ]
 
+const MCP_SUPPORTED = [
+  'agents',
+  'claude',
+  'cursor',
+  'windsurf',
+  'devin',
+  'copilot',
+  'continue',
+]
+
+const MCP_PATHS = {
+  claude: () => home('.claude.json'),
+  windsurf: () => home('.windsurf', 'mcp_config.json'),
+  copilot: () => proj('.github', 'copilot', '.mcp.json'),
+  continue: () => home('.continue', 'config.json'),
+}
+
 for (const a of AGENTS_DATA) {
-  a.mcp = { getPath: mcpFromSkillDir(a.getDir) }
+  if (!MCP_SUPPORTED.includes(a.flag)) {
+    a.mcp = null
+    continue
+  }
+  if (MCP_PATHS[a.flag]) {
+    a.mcp = { getPath: MCP_PATHS[a.flag] }
+  } else {
+    a.mcp = { getPath: mcpFromSkillDir(a.getDir) }
+  }
 }
-
-function find(flag) {
-  return AGENTS_DATA.findIndex(a => a.flag === flag)
-}
-
-// Override non-standard MCP paths
-AGENTS_DATA[find('claude')].mcp = { getPath: () => home('.claude', 'claude_code.json') }
-AGENTS_DATA[find('windsurf')].mcp = { getPath: () => home('.windsurf', 'mcp_config.json') }
-AGENTS_DATA[find('copilot')].mcp = { getPath: () => proj('.github', 'copilot', '.mcp.json') }
-AGENTS_DATA[find('continue')].mcp = { getPath: () => home('.continue', 'config.json') }
 
 export function getAgentByFlag(flag) {
   return AGENTS_DATA.find(a => a.flag === flag)

--- a/src/commands/mcp.test.js
+++ b/src/commands/mcp.test.js
@@ -47,7 +47,7 @@ describe('mcp command', () => {
 
       const cursorConfig = join(process.env.HOME, '.cursor', 'mcp.json')
       assert.ok(existsSync(cursorConfig))
-      const ccConfig = join(process.env.HOME, '.claude', 'claude_code.json')
+      const ccConfig = join(process.env.HOME, '.claude.json')
       assert.ok(existsSync(ccConfig))
     }))
 

--- a/src/utils/mcp.test.js
+++ b/src/utils/mcp.test.js
@@ -27,12 +27,13 @@ function withTempDir(fn) {
 
 describe('mcp', () => {
   describe('getSupportedMcpAgents', () => {
-    it('returns list of supported agents', () => {
+    it('returns only agents with MCP support', () => {
       const agents = mcpModule.getSupportedMcpAgents()
-      assert.ok(agents.includes('claude'))
-      assert.ok(agents.includes('cursor'))
-      assert.ok(agents.includes('copilot'))
-      assert.ok(agents.includes('continue'))
+      const supported = ['agents', 'claude', 'cursor', 'windsurf', 'devin', 'copilot', 'continue']
+      assert.equal(agents.length, supported.length)
+      for (const flag of supported) {
+        assert.ok(agents.includes(flag), `expected ${flag} to be in supported list`)
+      }
     })
   })
 
@@ -71,7 +72,7 @@ describe('mcp', () => {
         args: ['-y', '@modelcontextprotocol/github'],
       })
 
-      const configPath = join(process.env.HOME, '.claude', 'claude_code.json')
+      const configPath = join(process.env.HOME, '.claude.json')
       assert.ok(existsSync(configPath))
       const config = JSON.parse(readFileSync(configPath, 'utf-8'))
       assert.ok(config.mcpServers['github-server'])


### PR DESCRIPTION
- Research each agent's MCP support and correct config paths\n- Set mcp: null for 80 agents without MCP capability\n- Fix Claude Code MCP path: ~/.claude/claude_code.json → ~/.claude.json\n- Remove codex from MCP supported list (uses TOML, not JSON)\n- Update tests and docs to match corrected agent list