### PR TITLE
feat: add MCP lockfile for ci restore (P0)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@
 4. Computes a SHA256 content hash and stores it in the lockfile
 5. Updates `~/.agents/.skill-lock.json` so agents can discover the skill
 6. `rolecraft verify` checks installed files against the stored hash
-7. `rolecraft ci` re-installs all skills from the lockfile (e.g. in CI pipelines)
+7. `rolecraft ci` re-installs all skills and MCP servers from lockfiles (e.g. in CI pipelines)
 8. `rolecraft doctor` runs a system health check across Node.js, agent directories, and lockfiles
 9. `rolecraft profile` saves, applies, diffs, edits, exports, imports, and links multi-agent configuration profiles
 10. `rolecraft mcp` manages MCP server configurations (install, list, remove)
@@ -46,6 +46,7 @@ rolecraft/
 │   └── utils/
 │       ├── installer.js      # copy/symlink files to target dirs
 │       ├── lockfile.js       # read/write .skill-lock.json + content hash
+│       ├── mcp-lock.js       # read/write .mcp-lock.json for MCP restore
 │       ├── mcp.js            # MCP server config read/write
 │       ├── profile.js        # profile CRUD, capture, apply utilities
 │       ├── resolver.js       # source resolver (local / GitHub / GitLab / npm)

--- a/docs/commands/ci.md
+++ b/docs/commands/ci.md
@@ -1,6 +1,6 @@
 # `rolecraft ci`
 
-Re-install all skills from lockfile (CI mode).
+Re-install all skills and MCP servers from lockfile (CI mode).
 
 ## Usage
 
@@ -10,11 +10,13 @@ rolecraft ci
 
 ## Description
 
-Reads the lockfile and re-installs every skill, ensuring the installed state matches the locked state exactly. Designed for CI pipelines and team onboarding — run this after cloning a repository to restore all project skills.
+Reads both the skill lockfile (`~/.agents/.skill-lock.json`) and the MCP lockfile (`~/.agents/.mcp-lock.json`) and re-installs everything, ensuring the installed state matches the locked state exactly.
+
+Designed for CI pipelines and team onboarding — run this after cloning a repository to restore all project skills and their required MCP servers.
 
 ## Example
 
 ```bash
-# In CI or after git clone
+# In CI or after git clone — restores skills + MCP servers
 rolecraft ci
 ```

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -125,6 +125,24 @@ More agents will be added as their MCP standards solidify.
 | `cargo:` | `cargo:my-mcp-server` | Rust crate via `cargo run` |
 | Local path | `./my-mcp-server/index.js` | Run directly with `node` |
 
+## Lockfile & CI Restore
+
+Every MCP server you install is tracked in `~/.agents/.mcp-lock.json`. This lockfile records:
+- The original source string (e.g. `npm:@modelcontextprotocol/github`)
+- Which agents the server is installed to
+
+When you run `rolecraft ci`, MCP servers from the lockfile are automatically re-installed to their configured agents — just like skills.
+
+```bash
+# After git clone — restores skills + MCP servers
+rolecraft ci
+```
+
+The lockfile updates automatically:
+- **Install** → server is added to the lockfile
+- **Remove** → server is removed from the lockfile (or agents are unlinked if installed elsewhere)
+- **Update** → lockfile is refreshed with the new source
+
 ## Commands
 
 See [`docs/commands/mcp.md`](./commands/mcp.md) for the full command reference.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -201,7 +201,7 @@ No arguments. Checks all installed skills for newer versions.
 
 ### `rolecraft ci`
 
-Re-install all skills from lockfile. Use `--yes` in CI.
+Re-install all skills and MCP servers from lockfiles. Use `--yes` in CI.
 
 ### `rolecraft verify`
 

--- a/src/commands/ci.js
+++ b/src/commands/ci.js
@@ -1,11 +1,14 @@
 import { readLock, getProjectLockPath } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
+import { readMcpLock, getMcpLockPath } from '../utils/mcp-lock.js'
+import { resolveMcpSource, addMcpServer } from '../utils/mcp.js'
 
 export async function ciCommand() {
-  const [globalLock, projectLock] = await Promise.all([
+  const [globalLock, projectLock, mcpLock] = await Promise.all([
     readLock(),
     readLock(getProjectLockPath(process.cwd())).catch(() => ({ skills: {} })),
+    readMcpLock(),
   ])
 
   const allSkills = { ...globalLock.skills }
@@ -13,38 +16,65 @@ export async function ciCommand() {
     if (!allSkills[slug]) allSkills[slug] = entry
   }
 
-  const entries = Object.entries(allSkills)
-  if (entries.length === 0) {
-    console.log('No skills in lockfile to install.')
+  const skillEntries = Object.entries(allSkills)
+  const mcpEntries = Object.entries(mcpLock.servers)
+
+  let allPassed = true
+
+  if (skillEntries.length > 0) {
+    console.log('\n🔒 Installing %s skill(s) from lockfile...\n', skillEntries.length)
+    for (const [slug, entry] of skillEntries) {
+      if (!entry.source) {
+        console.error('   ❌ %s: missing source in lockfile', slug)
+        allPassed = false
+        continue
+      }
+      console.log('   📦 %s → %s', slug, entry.source)
+      try {
+        const resolved = await resolveSource(entry.source)
+        const targets = entry.sourceType === 'local' ? ['project'] : ['agents']
+        await installSkill(resolved, targets)
+        console.log('   ✅ %s installed', slug)
+      } catch (err) {
+        console.error('   ❌ %s: %s', slug, err?.message)
+        allPassed = false
+      }
+    }
+    console.log()
+  }
+
+  if (mcpEntries.length > 0) {
+    console.log('🔌 Installing %s MCP server(s) from lockfile...\n', mcpEntries.length)
+    for (const [name, entry] of mcpEntries) {
+      if (!entry.source) {
+        console.error('   ❌ %s: missing source in lockfile', name)
+        allPassed = false
+        continue
+      }
+      console.log('   🔗 %s → %s', name, entry.source)
+      try {
+        const resolved = resolveMcpSource(entry.source)
+        for (const agent of entry.agents) {
+          await addMcpServer(agent, name, resolved, entry.source)
+        }
+        console.log('   ✅ %s installed to %d agent(s)', name, entry.agents.length)
+      } catch (err) {
+        console.error('   ❌ %s: %s', name, err?.message)
+        allPassed = false
+      }
+    }
+    console.log()
+  }
+
+  if (skillEntries.length === 0 && mcpEntries.length === 0) {
+    console.log('No skills or MCP servers in lockfile to install.')
     return
   }
 
-    console.log('\n🔒 Installing %s skill(s) from lockfile...\n', entries.length)
-
-  let allPassed = true
-  for (const [slug, entry] of entries) {
-    if (!entry.source) {
-      console.error('   ❌ %s: missing source in lockfile', slug)
-      allPassed = false
-      continue
-    }
-
-    console.log('   📦 %s → %s', slug, entry.source)
-    try {
-      const resolved = await resolveSource(entry.source)
-      const targets = entry.sourceType === 'local' ? ['project'] : ['agents']
-      await installSkill(resolved, targets)
-      console.log('   ✅ %s installed', slug)
-    } catch (err) {
-      console.error('   ❌ %s: %s', slug, err?.message)
-      allPassed = false
-    }
-  }
-
-  console.log()
   if (allPassed) {
-    console.log('✅ All %s skill(s) installed from lockfile.', entries.length)
+    const total = skillEntries.length + mcpEntries.length
+    console.log('✅ All %d item(s) installed from lockfile.', total)
   } else {
-    throw new Error('Some skills failed to install.')
+    throw new Error('Some items failed to install.')
   }
 }

--- a/src/commands/ci.js
+++ b/src/commands/ci.js
@@ -1,7 +1,7 @@
 import { readLock, getProjectLockPath } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
-import { readMcpLock, getMcpLockPath } from '../utils/mcp-lock.js'
+import { readMcpLock } from '../utils/mcp-lock.js'
 import { resolveMcpSource, addMcpServer } from '../utils/mcp.js'
 
 export async function ciCommand() {

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -47,7 +47,7 @@ export async function mcpInstallCommand(source, options) {
 
   const results = []
   for (const agent of targets) {
-    const success = await addMcpServer(agent, name, resolved)
+    const success = await addMcpServer(agent, name, resolved, source)
     results.push({ agent, name, success })
     if (success) {
       console.log(`   ✅ ${agent}: MCP server "${name}" installed`)
@@ -112,7 +112,7 @@ export async function mcpUpdateCommand(source, options) {
 
   const results = []
   for (const agent of targets) {
-    const success = await updateMcpServer(agent, name, resolved)
+    const success = await updateMcpServer(agent, name, resolved, source)
     results.push({ agent, name, success })
     if (success) {
       console.log(`   ✅ ${agent}: MCP server "${name}" updated`)

--- a/src/utils/mcp-lock.js
+++ b/src/utils/mcp-lock.js
@@ -1,0 +1,53 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { homedir } from 'node:os'
+
+function home(...parts) {
+  return join(homedir(), ...parts)
+}
+
+export function getMcpLockPath() {
+  return home('.agents', '.mcp-lock.json')
+}
+
+async function ensureParentDir(filePath) {
+  await mkdir(dirname(filePath), { recursive: true })
+}
+
+export async function readMcpLock(lockPath = getMcpLockPath()) {
+  try {
+    const raw = await readFile(lockPath, 'utf-8')
+    return JSON.parse(raw)
+  } catch {
+    return { version: 1, servers: {} }
+  }
+}
+
+export async function writeMcpLock(data, lockPath = getMcpLockPath()) {
+  await ensureParentDir(lockPath)
+  await writeFile(lockPath, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+}
+
+export async function addServerToMcpLock(serverName, entry, lockPath = getMcpLockPath()) {
+  const lock = await readMcpLock(lockPath)
+  const existing = lock.servers[serverName]
+  const mergedAgents = existing?.agents
+    ? [...new Set([...existing.agents, ...(entry.agents || [])])]
+    : (entry.agents || [])
+  lock.servers[serverName] = { ...entry, agents: mergedAgents }
+  await writeMcpLock(lock, lockPath)
+  return lock
+}
+
+export async function removeServerFromMcpLock(serverName, agentToRemove, lockPath = getMcpLockPath()) {
+  const lock = await readMcpLock(lockPath)
+  if (!lock.servers[serverName]) return lock
+  const remaining = (lock.servers[serverName].agents || []).filter(a => a !== agentToRemove)
+  if (remaining.length === 0) {
+    delete lock.servers[serverName]
+  } else {
+    lock.servers[serverName].agents = remaining
+  }
+  await writeMcpLock(lock, lockPath)
+  return lock
+}

--- a/src/utils/mcp.js
+++ b/src/utils/mcp.js
@@ -5,6 +5,7 @@ import { execSync as defaultExecSync, spawnSync as defaultSpawnSync } from 'node
 import { tmpdir } from 'node:os'
 import { mkdtempSync, readFileSync } from 'node:fs'
 import agents from '../agents.js'
+import { addServerToMcpLock, removeServerFromMcpLock } from './mcp-lock.js'
 
 let runExec = defaultExecSync
 let runSpawnSync = defaultSpawnSync
@@ -111,13 +112,20 @@ function listMcpServerEntries(data, agent) {
   }))
 }
 
-export async function addMcpServer(agent, name, serverConfig) {
+export async function addMcpServer(agent, name, serverConfig, source = null) {
   const result = await readMcpConfig(agent)
   if (!result) return false
   const { configPath, data } = result
   setMcpServerEntry(data, agent, name, serverConfig)
   await mkdir(dirname(configPath), { recursive: true })
   await writeFile(configPath, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+
+  await addServerToMcpLock(name, {
+    source: source || reconstructMcpSource(serverConfig, name),
+    sourceType: serverConfig.sourceType,
+    agents: [agent],
+  })
+
   return true
 }
 
@@ -131,12 +139,15 @@ export async function removeMcpServer(agent, name) {
   if (before === after) return false
   await mkdir(dirname(configPath), { recursive: true })
   await writeFile(configPath, JSON.stringify(data, null, 2) + '\n', 'utf-8')
+
+  await removeServerFromMcpLock(name, agent)
+
   return true
 }
 
-export async function updateMcpServer(agent, name, serverConfig) {
+export async function updateMcpServer(agent, name, serverConfig, source = null) {
   await removeMcpServer(agent, name)
-  return addMcpServer(agent, name, serverConfig)
+  return addMcpServer(agent, name, serverConfig, source)
 }
 
 export async function listMcpServers(agent) {
@@ -285,6 +296,19 @@ export function resolveMcpSource(source) {
   throw new Error(`Unknown MCP source format: ${source}. Use npm:package, gh:owner/repo, uvx:package, pipx:package, go:package, deno:module, cargo:crate, or a local path.`)
 }
 
+function reconstructMcpSource(serverConfig, name) {
+  const { sourceType, packageName, repo, path: mcpPath } = serverConfig
+  if (sourceType === 'npm') return `npm:${packageName}`
+  if (sourceType === 'github') return `gh:${repo}`
+  if (sourceType === 'uvx') return `uvx:${packageName}`
+  if (sourceType === 'pipx') return `pipx:${packageName}`
+  if (sourceType === 'go') return `go:${packageName}`
+  if (sourceType === 'deno') return `deno:${packageName}`
+  if (sourceType === 'cargo') return `cargo:${packageName}`
+  if (sourceType === 'local') return mcpPath || name
+  return name
+}
+
 export async function installMcpServersFromSkill(skillContent, targets) {
   const servers = parseMcpServersFromSkill(skillContent)
   if (servers.length === 0) return []
@@ -292,7 +316,7 @@ export async function installMcpServersFromSkill(skillContent, targets) {
   for (const server of servers) {
     const resolved = resolveMcpSource(server.source)
     for (const agent of targets) {
-      const success = await addMcpServer(agent, server.name, resolved)
+      const success = await addMcpServer(agent, server.name, resolved, server.source)
       results.push({ agent, name: server.name, success })
     }
   }

--- a/src/utils/mcp.test.js
+++ b/src/utils/mcp.test.js
@@ -526,4 +526,121 @@ mcp_servers:
       assert.ok(config.mcpServers['test-mcp'])
     }))
   })
+
+  describe('mcp-lock', () => {
+    let lockModule
+
+    before(async () => {
+      lockModule = await import('./mcp-lock.js')
+    })
+
+    describe('getMcpLockPath', () => {
+      it('returns path under .agents', () => {
+        const p = lockModule.getMcpLockPath()
+        assert.ok(p.endsWith('.agents/.mcp-lock.json'))
+      })
+    })
+
+    describe('readMcpLock and writeMcpLock', () => {
+      it('returns default for missing lockfile', withTempDir(async () => {
+        const lock = await lockModule.readMcpLock()
+        assert.deepEqual(lock, { version: 1, servers: {} })
+      }))
+
+      it('writes and reads lockfile', withTempDir(async () => {
+        const data = { version: 1, servers: { test: { source: 'npm:@test/pkg', agents: ['cursor'] } } }
+        await lockModule.writeMcpLock(data)
+        const read = await lockModule.readMcpLock()
+        assert.deepEqual(read, data)
+      }))
+    })
+
+    describe('addServerToMcpLock', () => {
+      it('adds a new server entry', withTempDir(async () => {
+        await lockModule.addServerToMcpLock('my-server', { source: 'npm:@test/pkg', agents: ['cursor'] })
+        const lock = await lockModule.readMcpLock()
+        assert.ok(lock.servers['my-server'])
+        assert.equal(lock.servers['my-server'].source, 'npm:@test/pkg')
+        assert.deepEqual(lock.servers['my-server'].agents, ['cursor'])
+      }))
+
+      it('merges agents when adding same server again', withTempDir(async () => {
+        await lockModule.addServerToMcpLock('my-server', { source: 'npm:@test/pkg', agents: ['cursor'] })
+        await lockModule.addServerToMcpLock('my-server', { source: 'npm:@test/pkg', agents: ['claude'] })
+        const lock = await lockModule.readMcpLock()
+        assert.deepEqual(lock.servers['my-server'].agents.sort(), ['claude', 'cursor'])
+      }))
+
+      it('deduplicates agents', withTempDir(async () => {
+        await lockModule.addServerToMcpLock('my-server', { source: 'npm:@test/pkg', agents: ['cursor'] })
+        await lockModule.addServerToMcpLock('my-server', { source: 'npm:@test/pkg', agents: ['cursor'] })
+        const lock = await lockModule.readMcpLock()
+        assert.deepEqual(lock.servers['my-server'].agents, ['cursor'])
+      }))
+    })
+
+    describe('removeServerFromMcpLock', () => {
+      it('removes agent from entry', withTempDir(async () => {
+        await lockModule.addServerToMcpLock('my-server', { source: 'npm:@test/pkg', agents: ['cursor', 'claude'] })
+        await lockModule.removeServerFromMcpLock('my-server', 'cursor')
+        const lock = await lockModule.readMcpLock()
+        assert.deepEqual(lock.servers['my-server'].agents, ['claude'])
+      }))
+
+      it('deletes entry when last agent removed', withTempDir(async () => {
+        await lockModule.addServerToMcpLock('my-server', { source: 'npm:@test/pkg', agents: ['cursor'] })
+        await lockModule.removeServerFromMcpLock('my-server', 'cursor')
+        const lock = await lockModule.readMcpLock()
+        assert.equal(lock.servers['my-server'], undefined)
+      }))
+
+      it('no-op for non-existent server', withTempDir(async () => {
+        const lock = await lockModule.removeServerFromMcpLock('nonexistent', 'cursor')
+        assert.deepEqual(lock.servers, {})
+      }))
+    })
+  })
+
+  describe('lockfile integration', () => {
+    let lockModule
+
+    before(async () => {
+      lockModule = await import('./mcp-lock.js')
+    })
+
+    it('addMcpServer creates lockfile entry', withTempDir(async () => {
+      mcpModule.addMcpServer('agents', 'locked-server', { command: 'npx', args: ['-y', '@test/locked'] })
+      await new Promise(r => setTimeout(r, 50))
+      const lock = await lockModule.readMcpLock()
+      assert.ok(lock.servers['locked-server'])
+      assert.ok(lock.servers['locked-server'].agents.includes('agents'))
+    }))
+
+    it('removeMcpServer removes agent from lockfile', withTempDir(async () => {
+      await mcpModule.addMcpServer('agents', 'to-remove-lock', { command: 'npx', args: ['-y', '@test/rm'] })
+      await new Promise(r => setTimeout(r, 50))
+      let lock = await lockModule.readMcpLock()
+      assert.ok(lock.servers['to-remove-lock'])
+
+      await mcpModule.removeMcpServer('agents', 'to-remove-lock')
+      await new Promise(r => setTimeout(r, 50))
+      lock = await lockModule.readMcpLock()
+      assert.equal(lock.servers['to-remove-lock'], undefined)
+    }))
+
+    it('installMcpServersFromSkill records source in lockfile', withTempDir(async () => {
+      const content = `---
+name: test
+mcp_servers:
+  - name: lock-skill-mcp
+    source: npm:@test/lock-skill
+---
+`
+      await mcpModule.installMcpServersFromSkill(content, ['agents'])
+      await new Promise(r => setTimeout(r, 50))
+      const lock = await lockModule.readMcpLock()
+      assert.ok(lock.servers['lock-skill-mcp'])
+      assert.equal(lock.servers['lock-skill-mcp'].source, 'npm:@test/lock-skill')
+    }))
+  })
 })


### PR DESCRIPTION
- New src/utils/mcp-lock.js with read/write/add/remove operations
- Integrate lockfile into addMcpServer, removeMcpServer, updateMcpServer
- Add MCP server restore to rolecraft ci command
- 12 new tests for lockfile module and integration
- Update docs: mcp.md, ci.md, architecture.md, reference.md
