### PR TITLE
feat: add rolecraft mcp search command for GitHub and npm (P1) (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ See the [CI guide](docs/guides/ci.md) for more examples.
 | `rolecraft list`                        | Show all installed skills                                                   | [docs](docs/commands/list.md)        |
 | `rolecraft doctor`                      | Run system health check                                                     | [docs](docs/commands/doctor.md)      |
 | `rolecraft agents-xml [--write]`        | Generate skills XML for AGENTS.md                                           | [docs](docs/commands/agents-xml.md)  |
-| `rolecraft mcp install/remove/list`     | Install, remove, and list MCP servers for AI agents                         | [docs](docs/commands/mcp.md)         |
+| `rolecraft mcp install/remove/list/search` | Install, remove, list, or search MCP servers for AI agents              | [docs](docs/commands/mcp.md)         |
 | `rolecraft profile save/apply/list`     | Save, apply, and share multi-agent configuration profiles                   | [docs](docs/commands/profile.md)     |
 | `rolecraft verify`                      | Check installed skill integrity via content hash                            | [docs](docs/commands/verify.md)      |
 | `rolecraft watch [<slug>]`              | Watch skills for changes and auto-sync                                      | [docs](docs/commands/watch.md)       |

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -55,9 +55,10 @@ Usage:
   rolecraft doctor                  Run system health check (--json, --network)
   rolecraft watch [<slug>]          Watch skills for changes and auto-sync
   rolecraft profile                 Manage agent configuration profiles
-  rolecraft mcp install <source>    Install an MCP server (npm:, gh:, or local path)
-  rolecraft mcp list                List configured MCP servers
-  rolecraft mcp remove <name>       Remove an MCP server
+   rolecraft mcp install <source>    Install an MCP server (npm:, gh:, or local path)
+   rolecraft mcp list                List configured MCP servers
+   rolecraft mcp search <query>      Search for MCP servers (--npm for npm search)
+   rolecraft mcp remove <name>       Remove an MCP server
   rolecraft agents-xml              Generate skills XML for AGENTS.md
   rolecraft agents-xml --write      Write skills XML to AGENTS.md
   rolecraft upgrade                 Upgrade rolecraft to the latest version

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@
 7. `rolecraft ci` re-installs all skills and MCP servers from lockfiles (e.g. in CI pipelines)
 8. `rolecraft doctor` runs a system health check across Node.js, agent directories, and lockfiles
 9. `rolecraft profile` saves, applies, diffs, edits, exports, imports, and links multi-agent configuration profiles
-10. `rolecraft mcp` manages MCP server configurations (install, list, remove)
+10. `rolecraft mcp` manages MCP server configurations (install, list, search, remove)
 11. `rolecraft agents-xml` generates a skills XML block for `AGENTS.md`
 12. `rolecraft watch` watches installed skills for changes and auto-syncs
 13. `rolecraft convert` converts between SKILL.md and .mdc formats

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -1,12 +1,13 @@
 # `rolecraft mcp` — MCP Server Management
 
-Install, list, and remove MCP servers for AI agents.
+Install, list, search, and remove MCP servers for AI agents.
 
 ## Usage
 
 ```bash
 rolecraft mcp install <source> [options]
 rolecraft mcp list [options]
+rolecraft mcp search <query> [options]
 rolecraft mcp remove <name> [options]
 ```
 
@@ -70,6 +71,42 @@ Remove an MCP server.
 ```bash
 rolecraft mcp remove github-mcp-server --cursor
 rolecraft mcp remove postgres --all
+```
+
+### `search`
+
+Search for MCP servers on GitHub or npm.
+
+```bash
+# Search GitHub for repos with topic:mcp-server
+rolecraft mcp search github
+
+# Search npm registry for MCP packages
+rolecraft mcp search postgres --npm
+
+# Interactive picker with install
+rolecraft mcp search github --interactive
+```
+
+**Options:**
+- `--interactive` — Pick a result and install it
+- `--npm` — Search npm registry instead of GitHub
+
+**Example output:**
+```
+$ rolecraft mcp search github
+
+🔍 MCP server search results for "github":
+
+   github/github-mcp-server
+   ├─ Official GitHub MCP server  ⭐ 8500  Go
+   └─ rolecraft mcp install gh:github/github-mcp-server
+
+   modelcontextprotocol/servers
+   ├─ MCP server implementations  ⭐ 12000  TypeScript
+   └─ rolecraft mcp install gh:modelcontextprotocol/servers
+
+12 result(s) found.
 ```
 
 ## Sources

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -39,6 +39,15 @@ rolecraft mcp install ./my-mcp-server --cursor
 # List configured MCP servers
 rolecraft mcp list
 
+# Search for MCP servers (GitHub)
+rolecraft mcp search github
+
+# Search npm registry for MCP packages
+rolecraft mcp search postgres --npm
+
+# Interactive search + install
+rolecraft mcp search filesystem --interactive
+
 # Remove an MCP server
 rolecraft mcp remove github-mcp-server --cursor
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -256,6 +256,7 @@ profile link [name]           # link to project
 ```bash
 mcp install <source> [flags]    # install MCP server
 mcp list                        # list all MCP servers
+mcp search <query> [flags]      # search MCP servers (--npm, --interactive)
 mcp remove <name> [flags]       # remove MCP server
 ```
 

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -3,6 +3,26 @@ import { createInterface } from 'node:readline'
 import { stdin as input, stdout as output } from 'node:process'
 import agents from '../agents.js'
 
+const CSI = '\x1b['
+const sgr = (n) => `${CSI}${n}m`
+const cursorTo = (r, c) => `${CSI}${r};${c}H`
+const eraseLine = `${CSI}K`
+const hideCursor = `${CSI}?25l`
+const showCursor = `${CSI}?25h`
+const clearScreen = `${CSI}2J${CSI}H`
+
+const text = (code, s) => `${code}${s}${sgr(0)}`
+const cyan = s => text(sgr(36), s)
+const yellow = s => text(sgr(33), s)
+const dim = s => text(sgr(2), s)
+const bold = s => text(sgr(1), s)
+
+let runFetch = globalThis.fetch
+
+export function setFetch(fn) {
+  runFetch = fn
+}
+
 function askConfirmation(query) {
   const rl = createInterface({ input, output })
   return new Promise(resolve => {
@@ -151,6 +171,295 @@ export async function mcpRemoveCommand(name, options) {
   return results
 }
 
+function formatMcpRepo(r) {
+  const desc = r.description || 'No description'
+  const stars = r.stargazers_count || 0
+  const lang = r.language || 'N/A'
+  const topics = r.topics && r.topics.length > 0 ? r.topics.slice(0, 3).join(', ') : ''
+  return `${bold(r.full_name)}\n  ${dim(desc)}  ${yellow(`⭐ ${stars}`)}  ${cyan(lang)}${topics ? `  ${dim(topics)}` : ''}`
+}
+
+function formatMcpNpmItem(pkg) {
+  const desc = pkg.description || 'No description'
+  const keywords = pkg.keywords && pkg.keywords.length > 0 ? pkg.keywords.slice(0, 3).join(', ') : ''
+  return `${bold(pkg.name)}\n  ${dim(desc)}${keywords ? `  ${dim(keywords)}` : ''}`
+}
+
+const MCP_ITEM_LINES = 2
+
+function mcpTuiFormat(item, selected, sourceType) {
+  const sel = selected ? `${sgr(7)} > ${sgr(0)}` : '   '
+  const name = selected ? bold(item.name) : dim(item.name)
+  const desc = item.description || 'No description'
+  const installCmd = sourceType === 'npm'
+    ? `rolecraft mcp install npm:${item.name}`
+    : `rolecraft mcp install gh:${item.name}`
+  return [
+    `${sel}${name}`,
+    `   ├─ ${desc}`,
+    `   └─ ${installCmd}`,
+  ]
+}
+
+async function mcpRunTUI(items, sourceType) {
+  const wasRaw = input.isRaw
+  input.setRawMode(true)
+  input.resume()
+
+  let selectedIndex = 0
+  let scrollOffset = 0
+  const termRows = output.rows || 24
+  const reservedRows = 2
+  const availRows = termRows - reservedRows
+  const visibleCount = Math.min(Math.max(1, Math.floor(availRows / MCP_ITEM_LINES)), items.length)
+  const statusRow = termRows
+
+  function render() {
+    let out = clearScreen + hideCursor
+    out += '\n'
+    const end = Math.min(scrollOffset + visibleCount, items.length)
+    for (let i = scrollOffset; i < end; i++) {
+      const lines = mcpTuiFormat(items[i], i === selectedIndex, sourceType)
+      for (const line of lines) out += line + '\n'
+    }
+    out += cursorTo(statusRow, 1) + eraseLine + sgr(7) + '  ↑/↓ move · Enter select · q quit  ' + sgr(0)
+    output.write(out)
+  }
+
+  function ensureVisible(index) {
+    if (index < scrollOffset) {
+      scrollOffset = index
+      return true
+    }
+    if (index >= scrollOffset + visibleCount) {
+      scrollOffset = index - visibleCount + 1
+      return true
+    }
+    return false
+  }
+
+  render()
+
+  return new Promise((resolve) => {
+    function onData(buf) {
+      const key = buf.toString()
+
+      if (key === '\u001b[A') {
+        if (selectedIndex > 0) {
+          selectedIndex--
+          ensureVisible(selectedIndex)
+          render()
+        }
+      } else if (key === '\u001b[B') {
+        if (selectedIndex < items.length - 1) {
+          selectedIndex++
+          ensureVisible(selectedIndex)
+          render()
+        }
+      } else if (key === '\r' || key === '\n') {
+        cleanup()
+        resolve(selectedIndex)
+      } else if (key === '\u0003' || key === 'q' || key === 'Q') {
+        cleanup()
+        resolve(-1)
+      }
+    }
+
+    function cleanup() {
+      input.removeListener('data', onData)
+      input.pause()
+      input.setRawMode(wasRaw)
+      output.write(showCursor)
+    }
+
+    input.on('data', onData)
+  })
+}
+
+async function mcpPromptSelect(items, sourceType) {
+  console.log()
+  for (let i = 0; i < items.length; i++) {
+    const line = sourceType === 'npm' ? formatMcpNpmItem(items[i]).split('\n') : formatMcpRepo(items[i]).split('\n')
+    console.log(`  ${bold(cyan(String(i + 1).padStart(2, ' ')))} ${line[0]}`)
+    console.log(`     ${line[1]}`)
+    console.log()
+  }
+
+  const { createInterface } = await import('node:readline')
+  const rl = createInterface({ input, output })
+  const answer = await new Promise(resolve => {
+    rl.question(`Which MCP server to install? [1-${items.length}, q to quit]: `, a => {
+      rl.close()
+      resolve(a.trim().toLowerCase())
+    })
+  })
+
+  if (answer === 'q') return -1
+  const index = parseInt(answer, 10)
+  if (isNaN(index) || index < 1 || index > items.length) {
+    console.log(`Invalid choice. Enter a number between 1 and ${items.length}.`)
+    return -2
+  }
+  return index - 1
+}
+
+async function mcpPickAndInstall(items, sourceType, installOptions) {
+  let selectedIndex
+
+  if (output.isTTY && items.length > 0) {
+    selectedIndex = await mcpRunTUI(items, sourceType)
+  } else {
+    selectedIndex = await mcpPromptSelect(items, sourceType)
+  }
+
+  if (selectedIndex === -1) {
+    console.log('Aborted.')
+    return
+  }
+  if (selectedIndex === -2) return
+
+  const item = items[selectedIndex]
+  const source = sourceType === 'npm' ? `npm:${item.name}` : `gh:${item.name}`
+  console.log(`\n📦 Installing MCP server "${source}"...`)
+  try {
+    await mcpInstallCommand(source, installOptions)
+  } catch (err) {
+    console.error('❌ Failed to install: %s', err?.message)
+  }
+}
+
+async function searchMcpGitHub(query) {
+  const q = query
+    ? `topic:mcp-server+${encodeURIComponent(query)}`
+    : 'topic:mcp-server'
+  const url = `https://api.github.com/search/repositories?q=${q}&per_page=20&sort=stars`
+
+  const response = await runFetch(url, {
+    headers: { Accept: 'application/vnd.github.v3+json' },
+    signal: AbortSignal.timeout(10000),
+  })
+
+  if (response.status === 403) {
+    return { rateLimited: true }
+  }
+
+  if (!response.ok) {
+    return { error: `GitHub API error: ${response.status}` }
+  }
+
+  return await response.json()
+}
+
+async function searchMcpNpm(query) {
+  const q = query
+    ? `keywords:mcp+${encodeURIComponent(query)}`
+    : 'keywords:mcp'
+  const url = `https://registry.npmjs.org/-/v1/search?text=${q}&size=20`
+
+  const response = await runFetch(url, {
+    signal: AbortSignal.timeout(10000),
+  })
+
+  if (!response.ok) {
+    return { error: `npm API error: ${response.status}` }
+  }
+
+  const data = await response.json()
+  return {
+    objects: data.objects || [],
+    total: data.total || 0,
+  }
+}
+
+export async function mcpSearchCommand(query, options = {}) {
+  const sourceType = options.npm ? 'npm' : 'github'
+  let results
+
+  if (sourceType === 'npm') {
+    try {
+      results = await searchMcpNpm(query)
+    } catch {
+      throw new Error('Failed to search npm registry. Check your internet connection.')
+    }
+
+    if (results.error) {
+      throw new Error(results.error)
+    }
+
+    const items = (results.objects || []).map(o => ({
+      name: o.package.name,
+      description: o.package.description,
+      keywords: o.package.keywords,
+      version: o.package.version,
+    }))
+
+    if (items.length === 0) {
+      console.log(`\nNo MCP packages found on npm for "${query}".`)
+      return
+    }
+
+    if (options.interactive) {
+      await mcpPickAndInstall(items, 'npm', options)
+      return
+    }
+
+    console.log(`\n🔍 npm MCP packages for "${query}":\n`)
+    for (const pkg of items) {
+      const line = formatMcpNpmItem(pkg).split('\n')
+      console.log(`   ${line[0]}`)
+      console.log(`   ├─ ${line[1]}`)
+      console.log(`   └─ rolecraft mcp install npm:${pkg.name}`)
+      console.log()
+    }
+    console.log(`${items.length} result(s) found.`)
+    return
+  }
+
+  try {
+    results = await searchMcpGitHub(query)
+  } catch {
+    throw new Error('Failed to search GitHub. Check your internet connection.')
+  }
+
+  if (results.rateLimited) {
+    console.log('\n⚠️  GitHub API rate limit reached. Try again later.\n')
+    return
+  }
+
+  if (results.error) {
+    throw new Error(results.error)
+  }
+
+  if (results.items && results.items.length === 0) {
+    console.log(`\nNo MCP servers found for "${query}".`)
+    return
+  }
+
+  const items = (results.items || []).map(r => ({
+    name: r.full_name,
+    description: r.description,
+    stargazers_count: r.stargazers_count,
+    language: r.language,
+    topics: r.topics,
+  }))
+
+  if (options.interactive) {
+    await mcpPickAndInstall(items, 'github', options)
+    return
+  }
+
+  console.log(`\n🔍 MCP server search results for "${query}":\n`)
+  for (const repo of items) {
+    const line = formatMcpRepo(repo).split('\n')
+    console.log(`   ${line[0]}`)
+    console.log(`   ├─ ${line[1]}`)
+    console.log(`   └─ rolecraft mcp install gh:${repo.name}`)
+    console.log()
+  }
+  console.log(`${items.length} result(s) found.`)
+  return items
+}
+
 export async function mcpCommand(args) {
   const subcommand = args[0]
   const rest = args.slice(1)
@@ -209,6 +518,18 @@ export async function mcpCommand(args) {
       }
       return mcpRemoveCommand(name, options)
     }
+    case 'search': {
+      const query = rest.find(a => !a.startsWith('--'))
+      if (!query) {
+        console.error('Usage: rolecraft mcp search <query> [--interactive] [--npm]')
+        throw new Error('Missing query argument.')
+      }
+      return mcpSearchCommand(query, {
+        interactive: rest.includes('--interactive'),
+        npm: rest.includes('--npm'),
+        ...options,
+      })
+    }
     default:
       console.log(`
 rolecraft mcp — Manage MCP servers for AI agents
@@ -216,6 +537,7 @@ rolecraft mcp — Manage MCP servers for AI agents
 Usage:
   rolecraft mcp install <source>  Install an MCP server
   rolecraft mcp list              List configured MCP servers
+  rolecraft mcp search <query>    Search for MCP servers on GitHub
   rolecraft mcp update <source>   Update an MCP server (reinstall)
   rolecraft mcp remove <name>     Remove an MCP server
 
@@ -231,9 +553,15 @@ Options:
   --yes, -y                                       Skip confirmation for external sources
   --dry-run                                       Preview without making changes
 
+Search options:
+  --interactive                                   Pick and install from results
+  --npm                                           Search npm registry instead of GitHub
+
 Examples:
   rolecraft mcp install npm:@modelcontextprotocol/github --cursor --claude
   rolecraft mcp install npm:@anthropic/postgres-mcp --all
+  rolecraft mcp search github --interactive
+  rolecraft mcp search postgres --npm
   rolecraft mcp list
   rolecraft mcp remove github-mcp-server --cursor
 `)

--- a/src/commands/mcp.test.js
+++ b/src/commands/mcp.test.js
@@ -242,6 +242,125 @@ describe('mcp command', () => {
   })
 })
 
+describe('mcpSearchCommand', () => {
+  it('searches GitHub for MCP servers', async () => {
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        items: [
+          { full_name: 'owner/mcp-server', description: 'Test MCP', stargazers_count: 10, language: 'Go', topics: ['mcp-server'] },
+        ],
+      }),
+    }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpSearchCommand('test')
+    restore()
+    assert.ok(logs.some(l => l.includes('MCP server search results')))
+    assert.ok(logs.some(l => l.includes('owner/mcp-server')))
+  })
+
+  it('searches npm for MCP packages', async () => {
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        objects: [
+          { package: { name: '@scope/mcp-pkg', description: 'MCP pkg', keywords: ['mcp'] } },
+        ],
+        total: 1,
+      }),
+    }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpSearchCommand('test', { npm: true })
+    restore()
+    assert.ok(logs.some(l => l.includes('npm MCP packages')))
+    assert.ok(logs.some(l => l.includes('@scope/mcp-pkg')))
+  })
+
+  it('handles GitHub rate limit', async () => {
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({}),
+    }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpSearchCommand('test')
+    restore()
+    assert.ok(logs.some(l => l.includes('rate limit')))
+  })
+
+  it('handles GitHub API error', async () => {
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    }))
+
+    await assert.rejects(
+      () => mcpModule.mcpSearchCommand('test'),
+      /GitHub API error/,
+    )
+  })
+
+  it('handles npm API error', async () => {
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: false,
+      status: 500,
+    }))
+
+    await assert.rejects(
+      () => mcpModule.mcpSearchCommand('test', { npm: true }),
+      /npm API error/,
+    )
+  })
+
+  it('handles network error on GitHub search', async () => {
+    mcpModule.setFetch(() => Promise.reject(new Error('network error')))
+
+    await assert.rejects(
+      () => mcpModule.mcpSearchCommand('test'),
+      /Failed to search GitHub/,
+    )
+  })
+
+  it('handles network error on npm search', async () => {
+    mcpModule.setFetch(() => Promise.reject(new Error('network error')))
+
+    await assert.rejects(
+      () => mcpModule.mcpSearchCommand('test', { npm: true }),
+      /Failed to search npm/,
+    )
+  })
+
+  it('shows no results for empty GitHub search', async () => {
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ items: [] }),
+    }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpSearchCommand('nonexistent-mcp')
+    restore()
+    assert.ok(logs.some(l => l.includes('No MCP servers found')))
+  })
+
+  it('shows no results for empty npm search', async () => {
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ objects: [], total: 0 }),
+    }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpSearchCommand('nonexistent-mcp', { npm: true })
+    restore()
+    assert.ok(logs.some(l => l.includes('No MCP packages found')))
+  })
+})
+
 function withTempDir(fn) {
   return async () => {
     const td = mkdtempSync(join(tmpdir(), 'rolecraft-mcp-cmd-test-'))


### PR DESCRIPTION
## Description

Adds `rolecraft mcp search <query>` command to discover MCP servers from GitHub and npm.

### Features
- **GitHub search**: Searches repos with `topic:mcp-server`, sorted by stars
- **npm search**: Searches npm registry for packages with `keywords:mcp` (via `--npm` flag)
- **Interactive TUI**: `--interactive` flag opens a picker to select and install directly
- Full test coverage (9 new tests) and documentation

### Usage
```
rolecraft mcp search github                  # GitHub repos with topic:mcp-server
rolecraft mcp search postgres --npm          # npm packages with mcp keyword
rolecraft mcp search filesystem --interactive # Pick + install from results
```

### Files Changed
- `src/commands/mcp.js` — search functions, TUI, command handler + dispatcher
- `src/commands/mcp.test.js` — 9 new tests
- `bin/rolecraft.js` — usage updated
- `docs/commands/mcp.md`, `docs/mcp.md`, `docs/reference.md`, `docs/architecture.md` — documentation
- `README.md` — command table updated

Closes #18