### PR TITLE
feat: add rolecraft mcp check command for npm update checks

### DIFF
--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -58,6 +58,7 @@ Usage:
    rolecraft mcp install <source>    Install an MCP server (npm:, gh:, or local path, e.g. npm:pkg@1.0.0 or gh:owner/repo@branch)
    rolecraft mcp list                List configured MCP servers
    rolecraft mcp search <query>      Search for MCP servers (--npm for npm search)
+   rolecraft mcp check               Check for MCP server updates
    rolecraft mcp remove <name>       Remove an MCP server
   rolecraft agents-xml              Generate skills XML for AGENTS.md
   rolecraft agents-xml --write      Write skills XML to AGENTS.md

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -184,6 +184,67 @@ export async function mcpRemoveCommand(name, options) {
   return results
 }
 
+async function fetchNpmLatestVersion(packageName) {
+  const encodedName = encodeURIComponent(packageName).replace(/^%40/, '@')
+  const url = `https://registry.npmjs.org/${encodedName}/latest`
+  const response = await runFetch(url, {
+    signal: AbortSignal.timeout(8000),
+  })
+  if (!response.ok) return null
+  const data = await response.json()
+  return data.version || null
+}
+
+export async function mcpCheckCommand() {
+  const { readMcpLock } = await import('../utils/mcp-lock.js')
+  const lock = await readMcpLock()
+  const servers = Object.entries(lock.servers || {})
+
+  if (servers.length === 0) {
+    console.log('\nNo MCP servers in lockfile.')
+    return
+  }
+
+  console.log(`\nChecking ${servers.length} MCP server(s) for updates...\n`)
+
+  let updatesAvailable = 0
+  for (const [name, entry] of servers) {
+    const source = entry.source || ''
+    const agents = (entry.agents || []).join(', ')
+
+    if (!source.startsWith('npm:')) {
+      console.log(`   ⏭️  ${name.padEnd(30)} non-npm source (${source.slice(0, 3)}...), skipping`)
+      continue
+    }
+
+    const pkg = source.slice(4)
+    const atIdx = pkg.lastIndexOf('@')
+    const packageName = atIdx > 0 ? pkg.slice(0, atIdx) : pkg
+    const installedVersion = atIdx > 0 ? pkg.slice(atIdx + 1) : null
+
+    try {
+      const latestVersion = await fetchNpmLatestVersion(packageName)
+      if (!latestVersion) {
+        console.log(`   ❌ ${name.padEnd(30)} could not check (registry unreachable)`)
+        continue
+      }
+
+      if (installedVersion && installedVersion !== latestVersion) {
+        console.log(`   🔄 ${name.padEnd(30)} ${installedVersion} → ${latestVersion} (${agents})`)
+        updatesAvailable++
+      } else if (installedVersion) {
+        console.log(`   ✅ ${name.padEnd(30)} ${installedVersion} is latest (${agents})`)
+      } else {
+        console.log(`   ✅ ${name.padEnd(30)} latest: ${latestVersion} (no version pinned) (${agents})`)
+      }
+    } catch {
+      console.log(`   ❌ ${name.padEnd(30)} check failed (${source})`)
+    }
+  }
+
+  console.log(`\n${updatesAvailable > 0 ? `⚠️  ${updatesAvailable} MCP server(s) have updates available.` : '✅ All MCP servers are up to date.'}\n`)
+}
+
 function formatMcpRepo(r) {
   const desc = r.description || 'No description'
   const stars = r.stargazers_count || 0
@@ -531,6 +592,8 @@ export async function mcpCommand(args) {
       }
       return mcpRemoveCommand(name, options)
     }
+    case 'check':
+      return mcpCheckCommand()
     case 'search': {
       const query = rest.find(a => !a.startsWith('--'))
       if (!query) {
@@ -551,6 +614,7 @@ Usage:
   rolecraft mcp install <source>  Install an MCP server
   rolecraft mcp list              List configured MCP servers
   rolecraft mcp search <query>    Search for MCP servers on GitHub
+  rolecraft mcp check             Check for MCP server updates
   rolecraft mcp update <source>   Update an MCP server (reinstall)
   rolecraft mcp remove <name>     Remove an MCP server
 

--- a/src/commands/mcp.test.js
+++ b/src/commands/mcp.test.js
@@ -377,3 +377,99 @@ function withTempDir(fn) {
     }
   }
 }
+
+describe('mcpCheckCommand', () => {
+  after(() => {
+    mcpModule.setFetch(undefined)
+  })
+
+  it('shows no servers when lockfile is empty', withTempDir(async (td) => {
+    const { writeFileSync, mkdirSync } = await import('node:fs')
+    mkdirSync(join(td, '.agents'), { recursive: true })
+    writeFileSync(join(td, '.agents', '.mcp-lock.json'), JSON.stringify({ version: 1, servers: {} }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpCheckCommand()
+    restore()
+    assert.ok(logs.some(l => l.includes('No MCP servers')))
+  }))
+
+  it('skips non-npm sources', withTempDir(async (td) => {
+    const { writeFileSync, mkdirSync } = await import('node:fs')
+    mkdirSync(join(td, '.agents'), { recursive: true })
+    const lock = { version: 1, servers: { 'local-server': { source: './local.js', agents: ['cursor'] } } }
+    writeFileSync(join(td, '.agents', '.mcp-lock.json'), JSON.stringify(lock))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpCheckCommand()
+    restore()
+    assert.ok(logs.some(l => l.includes('non-npm')))
+  }))
+
+  it('reports outdated npm package', withTempDir(async (td) => {
+    const { writeFileSync, mkdirSync } = await import('node:fs')
+    mkdirSync(join(td, '.agents'), { recursive: true })
+    const lock = { version: 1, servers: { 'test-server': { source: 'npm:@test/pkg@1.0.0', agents: ['cursor'] } } }
+    writeFileSync(join(td, '.agents', '.mcp-lock.json'), JSON.stringify(lock))
+
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ version: '2.0.0' }),
+    }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpCheckCommand()
+    restore()
+    assert.ok(logs.some(l => l.includes('1.0.0')))
+    assert.ok(logs.some(l => l.includes('2.0.0')))
+    assert.ok(logs.some(l => l.includes('update')))
+  }))
+
+  it('reports up-to-date npm package', withTempDir(async (td) => {
+    const { writeFileSync, mkdirSync } = await import('node:fs')
+    mkdirSync(join(td, '.agents'), { recursive: true })
+    const lock = { version: 1, servers: { 'test-server': { source: 'npm:@test/pkg@1.0.0', agents: ['cursor'] } } }
+    writeFileSync(join(td, '.agents', '.mcp-lock.json'), JSON.stringify(lock))
+
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ version: '1.0.0' }),
+    }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpCheckCommand()
+    restore()
+    assert.ok(logs.some(l => l.includes('is latest')))
+  }))
+
+  it('handles npm registry fetch failure', withTempDir(async (td) => {
+    const { writeFileSync, mkdirSync } = await import('node:fs')
+    mkdirSync(join(td, '.agents'), { recursive: true })
+    const lock = { version: 1, servers: { 'test-server': { source: 'npm:@test/pkg@1.0.0', agents: ['cursor'] } } }
+    writeFileSync(join(td, '.agents', '.mcp-lock.json'), JSON.stringify(lock))
+
+    mcpModule.setFetch(() => Promise.resolve({ ok: false, status: 404 }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpCheckCommand()
+    restore()
+    assert.ok(logs.some(l => l.includes('could not check')))
+  }))
+
+  it('reports no version pinned as up to date', withTempDir(async (td) => {
+    const { writeFileSync, mkdirSync } = await import('node:fs')
+    mkdirSync(join(td, '.agents'), { recursive: true })
+    const lock = { version: 1, servers: { 'test-server': { source: 'npm:@test/pkg', agents: ['cursor'] } } }
+    writeFileSync(join(td, '.agents', '.mcp-lock.json'), JSON.stringify(lock))
+
+    mcpModule.setFetch(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ version: '2.0.0' }),
+    }))
+
+    const { logs, restore } = capture('log')
+    await mcpModule.mcpCheckCommand()
+    restore()
+    assert.ok(logs.some(l => l.includes('no version pinned')))
+  }))
+})


### PR DESCRIPTION
Adds `rolecraft mcp check` — queries npm registry for latest versions of lockfile'd MCP servers and reports outdated packages.