### PR TITLE
docs: add mcp update/check docs, add mcp to shell completions

### DIFF
--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -1,6 +1,6 @@
 # `rolecraft mcp` — MCP Server Management
 
-Install, list, search, and remove MCP servers for AI agents.
+Install, list, search, check, update, and remove MCP servers for AI agents.
 
 ## Usage
 
@@ -8,6 +8,8 @@ Install, list, search, and remove MCP servers for AI agents.
 rolecraft mcp install <source> [options]
 rolecraft mcp list [options]
 rolecraft mcp search <query> [options]
+rolecraft mcp check
+rolecraft mcp update <source> [options]
 rolecraft mcp remove <name> [options]
 ```
 
@@ -62,6 +64,53 @@ rolecraft mcp install npm:@test/mcp --name my-server --cursor
 - `--yes`, `-y` — Skip confirmation and security blocks
 - `--agents`, `--cursor`, `--claude`, `--copilot`, `--continue`, etc. — Target specific agents
 - `--all` — Install to all supported MCP agents
+
+### `update`
+
+Reinstall an MCP server, refreshing to the latest version (or a specified version).
+
+```bash
+# Update to latest
+rolecraft mcp update npm:@modelcontextprotocol/github --cursor
+
+# Update to a specific version
+rolecraft mcp update npm:@modelcontextprotocol/github@1.2.3 --cursor
+
+# Update and change target agents
+rolecraft mcp update npm:@modelcontextprotocol/github --cursor --claude
+
+# Dry-run
+rolecraft mcp update npm:@modelcontextprotocol/github --dry-run
+```
+
+**Options:**
+- `--name <name>` — Override the server name (default: auto-detected from source)
+- `--dry-run` — Preview without making changes
+- `--yes`, `-y` — Skip confirmation
+- `--agents`, `--cursor`, `--claude`, etc. — Target specific agents
+- `--all` — Update on all agents
+
+### `check`
+
+Check installed MCP servers for available updates.
+
+```bash
+rolecraft mcp check
+```
+
+Queries the npm registry for the latest version of each npm-sourced MCP server and reports which ones are outdated. Non-npm sources (local paths, GitHub repos) are skipped with a notice.
+
+**Example output:**
+
+```
+Checking 3 MCP server(s) for updates...
+
+   🔄 @modelcontextprotocol/github    1.0.0 → 2.0.0 (cursor, claude)
+   ✅ @anthropic/postgres-mcp         0.5.0 is latest (cursor)
+   ⏭️ ./local-server.js                non-npm source, skipping
+
+⚠️  1 MCP server(s) have updates available.
+```
 
 ### `list`
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -55,8 +55,17 @@ rolecraft mcp search postgres --npm
 # Interactive search + install
 rolecraft mcp search filesystem --interactive
 
+# Check for MCP server updates
+rolecraft mcp check
+
+# Update a MCP server to latest version
+rolecraft mcp update npm:@modelcontextprotocol/github --cursor
+
 # Remove an MCP server
 rolecraft mcp remove github-mcp-server --cursor
+
+# Validate MCP configurations
+rolecraft doctor
 ```
 
 ## Onboarding Example

--- a/src/commands/completions.js
+++ b/src/commands/completions.js
@@ -2,7 +2,10 @@ const COMMANDS = [
   'install', 'bundle', 'use', 'list', 'remove', 'update',
   'setup', 'init', 'search', 'verify', 'ci', 'completions',
   'agents-xml', 'doctor', 'upgrade', 'help', 'version',
+  'mcp',
 ]
+
+const MCP_SUBCOMMANDS = 'install list search check update remove'
 
 const SCOPE_FLAGS = [
   '--global', '--project', '--claude', '--cursor', '--windsurf',
@@ -51,6 +54,13 @@ _rolecraft() {
   case "\${COMP_WORDS[1]}" in
     install|bundle|use|setup|upgrade)
       COMPREPLY=($(compgen -W "$scope_flags $option_flags" -- "$cur"))
+      ;;
+    mcp)
+      if [[ $COMP_CWORD -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "${MCP_SUBCOMMANDS}" -- "$cur"))
+      else
+        COMPREPLY=($(compgen -W "--name --dry-run --yes -y --all" -- "$cur"))
+      fi
       ;;
     search)
       COMPREPLY=($(compgen -W "--interactive" -- "$cur"))
@@ -102,6 +112,9 @@ _rolecraft() {
       ;;
     args)
       case $words[1] in
+        mcp)
+          _arguments '1:subcommand:(install list search check update remove)'
+          ;;
         install|bundle|use|setup|upgrade)
           _arguments \\
             '--global[Install to ~/.agents/skills/]' \\
@@ -167,7 +180,7 @@ _rolecraft() {
         completions)
           _arguments '::shell:(bash zsh fish)'
           ;;
-        remove|update)
+        remove|update|mcp)
           _arguments '*:slug:'
           ;;
         bundle)
@@ -287,6 +300,22 @@ for cmd in install bundle use setup upgrade
 end
 
 # search flags
+# mcp subcommands
+complete -f -c rolecraft -n '__fish_rolecraft_using_command mcp' -a install -d 'Install an MCP server'
+complete -f -c rolecraft -n '__fish_rolecraft_using_command mcp' -a list    -d 'List MCP servers'
+complete -f -c rolecraft -n '__fish_rolecraft_using_command mcp' -a search  -d 'Search for MCP servers'
+complete -f -c rolecraft -n '__fish_rolecraft_using_command mcp' -a check   -d 'Check for MCP updates'
+complete -f -c rolecraft -n '__fish_rolecraft_using_command mcp' -a update  -d 'Update an MCP server'
+complete -f -c rolecraft -n '__fish_rolecraft_using_command mcp' -a remove  -d 'Remove an MCP server'
+
+# mcp flags
+for cmd in install list search check update remove
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command mcp; and __fish_rolecraft_using_command $cmd" -l name -d 'Server name'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command mcp; and __fish_rolecraft_using_command $cmd" -l dry-run -d 'Preview without changes'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command mcp; and __fish_rolecraft_using_command $cmd" -l yes -d 'Skip confirmation'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command mcp; and __fish_rolecraft_using_command $cmd" -l all -d 'All agents'
+end
+
 complete -f -c rolecraft -n '__fish_rolecraft_using_command search' -l interactive -d 'Choose and install from results'
 
 # completions subcommands

--- a/src/commands/completions.test.js
+++ b/src/commands/completions.test.js
@@ -34,6 +34,10 @@ describe('completions command', () => {
     assert.ok(output.includes('_rolecraft'))
     assert.ok(output.includes('compgen'))
     assert.ok(output.includes('complete -F _rolecraft rolecraft'))
+    assert.ok(output.includes('mcp'))
+    ;['install', 'list', 'search', 'check', 'update', 'remove'].forEach(cmd => {
+      assert.ok(output.includes(cmd), `bash completions should include ${cmd}`)
+    })
   })
 
   it('generates zsh completions', async () => {
@@ -44,6 +48,7 @@ describe('completions command', () => {
     const output = logs.join('\n')
     assert.ok(output.includes('#compdef rolecraft'))
     assert.ok(output.includes('_arguments'))
+    assert.ok(output.includes('(install list search check update remove)'))
   })
 
   it('generates fish completions', async () => {
@@ -54,6 +59,9 @@ describe('completions command', () => {
     const output = logs.join('\n')
     assert.ok(output.includes('complete -f -c rolecraft'))
     assert.ok(output.includes('__fish_rolecraft_needs_command'))
+    assert.ok(output.includes('Install an MCP server'))
+    assert.ok(output.includes('Search for MCP servers'))
+    assert.ok(output.includes('Check for MCP updates'))
   })
 
   it('errors on unknown shell', async () => {


### PR DESCRIPTION
P3 documentation and shell completion tasks:

- Adds `mcp update` and `mcp check` subcommand docs to `docs/commands/mcp.md`
- Adds `mcp check`, `mcp update`, and `rolecraft doctor` to quick start in `docs/mcp.md`
- Adds `mcp` as a top-level command in bash/zsh/fish completions with all 6 subcommands