### PR TITLE
fix: remove unused imports flagged by CodeQL

### DIFF
--- a/src/api/mcp.js
+++ b/src/api/mcp.js
@@ -1,4 +1,4 @@
-import { addMcpServer, removeMcpServer, updateMcpServer, listMcpServers, getSupportedMcpAgents, resolveMcpSource, classifyMcpSource } from '../utils/mcp.js'
+import { addMcpServer, removeMcpServer, updateMcpServer, listMcpServers, getSupportedMcpAgents, resolveMcpSource } from '../utils/mcp.js'
 import { scanMcpServer } from '../utils/security.js'
 
 let runFetch = globalThis.fetch

--- a/src/api/profile.js
+++ b/src/api/profile.js
@@ -121,12 +121,9 @@ export async function apiProfileDelete(name, options = {}) {
 }
 
 export async function apiProfileImport(path) {
-  const { readFile } = await import('node:fs/promises')
-  const { resolve } = await import('node:path')
-  const { writeFile } = await import('node:fs/promises')
+  const { readFile, writeFile } = await import('node:fs/promises')
+  const { resolve, join } = await import('node:path')
   const { homedir } = await import('node:os')
-  const { join, dirname } = await import('node:path')
-  const { mkdir } = await import('node:fs/promises')
 
   let content
   const isUrl = path.startsWith('http://') || path.startsWith('https://')

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -6,7 +6,6 @@ import {
 import { classifyMcpSource, getSupportedMcpAgents } from '../utils/mcp.js'
 
 export { setFetch } from '../api/mcp.js'
-import { classifyScore } from '../utils/security.js'
 import agents from '../agents.js'
 
 const CSI = '\x1b['

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -8,9 +8,7 @@ import {
   apiProfileDelete, apiProfileImport,
 } from '../api/profile.js'
 import {
-  readProfile, captureAllAgents, captureAgentFull, writeProfile,
-  listProfiles, profilePath, validateProfile, ensureProfileDir,
-  PROFILE_SCHEMA_VERSION,
+  readProfile, captureAllAgents, writeProfile,
 } from '../utils/profile.js'
 import agents from '../agents.js'
 


### PR DESCRIPTION
Fixes 5 of 6 CodeQL alerts from PR #159.

### Fixed
- `src/commands/mcp.js`: removed unused `classifyScore` import
- `src/commands/profile.js`: removed unused `captureAgentFull`, `listProfiles`, `profilePath`, `validateProfile`, `ensureProfileDir`, `PROFILE_SCHEMA_VERSION` imports
- `src/api/profile.js`: removed unused `dirname` and `mkdir` dynamic imports; deduplicated `node:path` and `node:fs/promises` imports
- `src/api/mcp.js`: removed unused `classifyMcpSource` import

### Not fixed (#76 — by design)
`src/api/profile.js` network-to-file access: the profile import feature intentionally fetches from URL and saves to disk. Path traversal protection is already in place via `startsWith` check.

### Verification
- ✅ 805/805 tests passing
- ✅ `npm run lint` clean