### PR TITLE
fix: report skipped and errored skill checks

### DIFF
--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -23,5 +23,11 @@ export async function checkCommand() {
     }
   }
 
-  console.log(`\n${updatesAvailable > 0 ? `⚠️  ${updatesAvailable} skill(s) have updates available. Run \`rolecraft update <slug>\` to update.` : '✅ All skills are up to date.'}\n`)
+  const skipped = skills.filter(s => s.status === 'skipped').length
+  const errors = skills.filter(s => s.status === 'error').length
+  const skillLabel = skills.length === 1 ? 'skill' : 'skills'
+  const updateLabel = updatesAvailable === 1 ? 'update' : 'updates'
+  const updateHint = updatesAvailable > 0 ? ' Run `rolecraft update <slug>` to update.' : ''
+
+  console.log(`\nChecked ${skills.length} ${skillLabel}: ${updatesAvailable} ${updateLabel} available, ${skipped} skipped (no source), ${errors} could not be checked.${updateHint}\n`)
 }

--- a/src/commands/check.test.js
+++ b/src/commands/check.test.js
@@ -58,6 +58,7 @@ describe('check command', () => {
       restore()
     }
     assert.ok(logs.some(l => l.includes('no source info')))
+    assert.ok(logs.some(l => l.includes('Checked 1 skill: 0 updates available, 1 skipped (no source), 0 could not be checked.')))
   })
 
   it('reports skill as up to date when hash matches', async () => {
@@ -119,6 +120,7 @@ describe('check command', () => {
       restore()
     }
     assert.ok(logs.some(l => l.includes('could not check')))
+    assert.ok(logs.some(l => l.includes('Checked 1 skill: 0 updates available, 0 skipped (no source), 1 could not be checked.')))
   })
 
   it('merges skills from global and project locks', async () => {


### PR DESCRIPTION
Reports skipped and errored skill checks in the final `rolecraft check` summary and adds focused regression coverage; fixes #109.