### PR TITLE
fix: remove unused imports flagged by CodeQL

### DIFF
--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,10 +1,4 @@
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
-import { readFileSync } from 'node:fs'
 import { apiDoctor } from '../api/doctor.js'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'))
 
 function icon(status) {
   return status === 'pass' ? '✅' : status === 'warn' ? '⚠️' : '❌'

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -2,7 +2,7 @@ import { spawnSync } from 'node:child_process'
 import { tmpdir, homedir } from 'node:os'
 import { join, relative, resolve, dirname } from 'node:path'
 import { mkdtempSync, writeFileSync, readFileSync, unlinkSync, rmdirSync, existsSync } from 'node:fs'
-import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { writeFile, mkdir } from 'node:fs/promises'
 import {
   apiProfileSave, apiProfileApply, apiProfileDiff, apiProfileList, apiProfileShow,
   apiProfileDelete, apiProfileImport,


### PR DESCRIPTION
Fixes 2 of 3 open CodeQL alerts.

### Fixed
- `src/commands/doctor.js`: removed unused `pkg` variable and its imports (`fileURLToPath`, `readFileSync`, `dirname`, `join`)
- `src/commands/profile.js`: removed unused `readFile` import from `node:fs/promises`

### Not fixed (#76 — by design)
`src/api/profile.js` network-to-file access: profile import intentionally fetches from URL and saves to disk. Path traversal protection already in place.

### Verification
- ✅ 805/805 tests passing
- ✅ `npm run lint` clean