### PR TITLE
refactor: share slug normalization

### DIFF
--- a/src/api/agents-xml.js
+++ b/src/api/agents-xml.js
@@ -4,6 +4,7 @@ import {
   readLock,
   getProjectLockPath,
   getAgentsDir,
+  normalizeSlug,
 } from '../utils/lockfile.js'
 
 const SKILLS_SYSTEM_HEADER = `Only use skills listed in <available_skills> below.
@@ -52,7 +53,7 @@ async function generateXml(allSkills) {
 
   const skillsXml = await Promise.all(
     entries.map(async ([, entry]) => {
-      const normSlug = entry.slug.replace(/\//g, '-')
+      const normSlug = normalizeSlug(entry.slug)
       const searchDirs = [
         join(getAgentsDir(), normSlug),
         join(process.cwd(), '.agents', 'skills', normSlug),

--- a/src/api/doctor.js
+++ b/src/api/doctor.js
@@ -14,6 +14,7 @@ import {
   getProjectLockPath,
   getAgentsDir,
   computeContentHash,
+  normalizeSlug,
 } from '../utils/lockfile.js'
 import { detectAgents } from '../commands/setup.js'
 import { parseFrontmatter, splitSections } from '../utils/converter.js'
@@ -268,7 +269,7 @@ function parseSkillContent(skillDir) {
 function detectSkillConflicts(allSkills, agentsDir, cwd) {
   const skills = {}
   for (const slug of Object.keys(allSkills)) {
-    const normSlug = slug.replace(/\//g, '-')
+    const normSlug = normalizeSlug(slug)
     const searchDirs = [
       join(agentsDir, normSlug),
       join(cwd, '.agents', 'skills', normSlug),
@@ -482,7 +483,7 @@ export async function apiDoctor(cwd = process.cwd(), options = {}) {
   let brokenSymlinks = 0
 
   for (const [slug, entry] of Object.entries(allSkills)) {
-    const normSlug = slug.replace(/\//g, '-')
+    const normSlug = normalizeSlug(slug)
     const searchDirs = [
       join(getAgentsDir(), normSlug),
       join(cwd, '.agents', 'skills', normSlug),

--- a/src/api/init.js
+++ b/src/api/init.js
@@ -1,11 +1,12 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { normalizeSlug } from '../utils/lockfile.js'
 
 export async function initApi(name) {
   const skillName = name || 'my-skill'
   const slug = skillName.includes('/') ? skillName : skillName
   const displayName = slug.includes('/') ? slug.split('/')[1] : slug
-  const dirName = slug.replace(/\//g, '-')
+  const dirName = normalizeSlug(slug)
   const dir = join(process.cwd(), dirName)
   const owner = slug.includes('/') ? slug.split('/')[0] : 'local'
 

--- a/src/api/remove.js
+++ b/src/api/remove.js
@@ -5,12 +5,9 @@ import {
   removeSkillFromLock,
   getAgentsDir,
   getProjectLockPath,
+  normalizeSlug,
 } from '../utils/lockfile.js'
 import { assertSafeSlug } from '../utils/installer.js'
-
-function normalizeSlug(slug) {
-  return slug.replace(/\//g, '-')
-}
 
 function findActualSlug(slug, lock) {
   if (lock.skills[slug]) return slug

--- a/src/api/rollback.js
+++ b/src/api/rollback.js
@@ -7,6 +7,7 @@ import {
   getProjectLockPath,
   getSkillHistory,
   popHistory,
+  normalizeSlug,
 } from '../utils/lockfile.js'
 import {
   restoreSkill,
@@ -15,10 +16,6 @@ import {
 } from '../utils/installer.js'
 import { getAgentByFlag } from '../agents.js'
 import { UserError } from '../utils/errors.js'
-
-function normalizeSlug(slug) {
-  return slug.replace(/\//g, '-')
-}
 
 export async function apiRollback(slug, options = {}) {
   const { dryRun = false, list = false } = options

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from 'node:fs'
 import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
 import { parseFrontmatter } from '../utils/converter.js'
-import { readLock } from '../utils/lockfile.js'
+import { readLock, normalizeSlug } from '../utils/lockfile.js'
 
 const ASSERTIONS = [
   {
@@ -302,7 +302,7 @@ async function testAllSkills(options) {
   }
 
   for (const slug of allSlugs) {
-    const normSlug = slug.replace(/\//g, '-')
+    const normSlug = normalizeSlug(slug)
     let skillFile = join(agentsDir, normSlug, 'SKILL.md')
 
     if (!existsSync(skillFile)) {

--- a/src/api/update.js
+++ b/src/api/update.js
@@ -1,13 +1,9 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { readLock, getProjectLockPath } from '../utils/lockfile.js'
+import { readLock, getProjectLockPath, normalizeSlug } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import agents from '../agents.js'
-
-function normalizeSlug(slug) {
-  return slug.replace(/\//g, '-')
-}
 
 function findActualSlug(slug, lock) {
   if (lock.skills[slug]) return slug

--- a/src/api/update.js
+++ b/src/api/update.js
@@ -1,6 +1,10 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { readLock, getProjectLockPath, normalizeSlug } from '../utils/lockfile.js'
+import {
+  readLock,
+  getProjectLockPath,
+  normalizeSlug,
+} from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import agents from '../agents.js'

--- a/src/api/verify.js
+++ b/src/api/verify.js
@@ -3,6 +3,7 @@ import {
   getProjectLockPath,
   computeContentHash,
   getAgentsDir,
+  normalizeSlug,
 } from '../utils/lockfile.js'
 import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
@@ -75,7 +76,7 @@ export async function apiVerify(cwd = process.cwd(), frozen = false) {
       continue
     }
 
-    const normSlug = slug.replace(/\//g, '-')
+    const normSlug = normalizeSlug(slug)
     const dirsToCheck = (entry.agents || [])
       .map((name) => {
         if (name === 'project') return join(cwd, '.agents', 'skills', normSlug)

--- a/src/commands/agents-xml.js
+++ b/src/commands/agents-xml.js
@@ -5,6 +5,7 @@ import {
   readLock,
   getProjectLockPath,
   getAgentsDir,
+  normalizeSlug,
 } from '../utils/lockfile.js'
 
 const SKILLS_SYSTEM_HEADER = `Only use skills listed in <available_skills> below.
@@ -35,7 +36,7 @@ function generateXml(allSkills) {
 
   const skillsXml = entries
     .map(([, entry]) => {
-      const normSlug = entry.slug.replace(/\//g, '-')
+      const normSlug = normalizeSlug(entry.slug)
       const searchDirs = [
         join(getAgentsDir(), normSlug),
         join(process.cwd(), '.agents', 'skills', normSlug),

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -5,6 +5,7 @@ import {
   getTemplate,
   generateSkill,
 } from '../utils/templates/index.js'
+import { normalizeSlug } from '../utils/lockfile.js'
 
 export async function initCommand(name, options = {}) {
   // Handle --list
@@ -21,7 +22,7 @@ export async function initCommand(name, options = {}) {
   const skillName = name || 'my-skill'
   const slug = skillName.includes('/') ? skillName : skillName
   const displayName = slug.includes('/') ? slug.split('/')[1] : slug
-  const dirName = slug.replace(/\//g, '-')
+  const dirName = normalizeSlug(slug)
   const dir = join(process.cwd(), dirName)
   const owner = slug.includes('/') ? slug.split('/')[0] : 'local'
 

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -16,14 +16,11 @@ import {
   getGlobalLockPath,
   getProjectLockPath,
   computeFileHashes,
+  normalizeSlug,
 } from './lockfile.js'
 import { getAgentByFlag } from '../agents.js'
 
 import { resolve, sep } from 'node:path'
-
-function normalizeSlug(slug) {
-  return slug.replace(/\//g, '-')
-}
 
 /**
  * Reject slugs that could escape their base directory.

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -1259,6 +1259,9 @@ describe('installer', () => {
     })
 
     it('listBackups returns backups newest-first', async () => {
+      // Ensure the first backup gets a distinct timestamp from the
+      // previous test's backup (backup filenames are ms-precision).
+      await new Promise((r) => setTimeout(r, 10))
       await installerModule.backupSkill(backupSlug, { 'file1.md': 'v1' })
       // Small delay to ensure distinct timestamps
       await new Promise((r) => setTimeout(r, 10))
@@ -1267,7 +1270,7 @@ describe('installer', () => {
       await installerModule.backupSkill(backupSlug, { 'file3.md': 'v3' })
 
       const backups = await installerModule.listBackups(backupSlug)
-      assert.ok(backups.length >= 4) // at least 3 new + 1 from previous test
+      assert.equal(backups.length, 4) // 3 from this test + 1 from previous test
       // Newest first
       assert.ok(backups[0].timestamp >= backups[1].timestamp)
       assert.ok(backups[2].path.endsWith('.json'))

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -4,6 +4,10 @@ import { createHash } from 'node:crypto'
 import { getAgentByFlag } from '../agents.js'
 import { home } from './paths.js'
 
+export function normalizeSlug(slug) {
+  return slug.replace(/\//g, '-')
+}
+
 export function getGlobalLockPath() {
   return home('.agents', '.skill-lock.json')
 }

--- a/src/utils/lockfile.test.js
+++ b/src/utils/lockfile.test.js
@@ -22,6 +22,11 @@ after(async () => {
 })
 
 describe('lockfile', () => {
+  it('normalizeSlug converts path separators to hyphens', () => {
+    assert.equal(lockModule.normalizeSlug('owner/group/skill'), 'owner-group-skill')
+    assert.equal(lockModule.normalizeSlug('already-normalized'), 'already-normalized')
+  })
+
   it('getGlobalLockPath returns path inside homedir', () => {
     assert.equal(
       lockModule.getGlobalLockPath(),

--- a/src/utils/lockfile.test.js
+++ b/src/utils/lockfile.test.js
@@ -23,8 +23,14 @@ after(async () => {
 
 describe('lockfile', () => {
   it('normalizeSlug converts path separators to hyphens', () => {
-    assert.equal(lockModule.normalizeSlug('owner/group/skill'), 'owner-group-skill')
-    assert.equal(lockModule.normalizeSlug('already-normalized'), 'already-normalized')
+    assert.equal(
+      lockModule.normalizeSlug('owner/group/skill'),
+      'owner-group-skill',
+    )
+    assert.equal(
+      lockModule.normalizeSlug('already-normalized'),
+      'already-normalized',
+    )
   })
 
   it('getGlobalLockPath returns path inside homedir', () => {


### PR DESCRIPTION
Moves `normalizeSlug` into the shared lockfile utility, updates its three callers, and adds focused regression coverage while preserving existing behavior; verified with `npm test`, `npm run lint`, and `npm run test:coverage`; fixes #92.
