### PR TITLE
fix: resolve CodeQL alerts in test command

### DIFF
--- a/src/api/test.js
+++ b/src/api/test.js
@@ -1,5 +1,5 @@
-import { readFileSync, readdirSync, existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync, existsSync } from 'node:fs'
+import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
 import { parseFrontmatter } from '../utils/converter.js'
 import { readLock } from '../utils/lockfile.js'
@@ -191,7 +191,7 @@ function runAssertions(attrs, body, raw, filterNames) {
       continue
     }
 
-    if (typeof pass === 'object' && pass !== null) {
+    if (pass !== null && typeof pass === 'object') {
       detail = pass.detail || ''
       pass = pass.pass
     }
@@ -252,7 +252,7 @@ export async function apiTest(skillPath, options = {}) {
   const { score, grade, label } = calculateScore(assertions)
   const suggestions = generateSuggestions(assertions)
 
-  const skillName = attrs.name || skillPath.replace(/.*\//, '')
+  const skillName = attrs.name || basename(skillPath)
 
   return {
     skill: skillName,

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -74,7 +74,6 @@ function printSingleResult(result, options) {
     }
   }
 
-  const gradeMark = getGradeIcon(result.grade)
   const scoreColor = result.score >= 75 ? 'green' : result.score >= 50 ? 'yellow' : 'red'
   console.log(`\n${colorize(`Score: ${result.score}/100 → ${result.grade} (${result.label})`, scoreColor, color)}`)
 


### PR DESCRIPTION
Fixes 4 CodeQL alerts:\n- #87: Remove unused `gradeMark` variable in commands/test.js\n- #86: Remove unused `readdirSync` import in api/test.js\n- #85: Reorder null check before typeof in api/test.js\n- #84: Replace regex with `path.basename()` in api/test.js