### PR TITLE
fix: resolve CodeQL alerts 88 and 89

### DIFF
--- a/src/api/test.js
+++ b/src/api/test.js
@@ -191,7 +191,7 @@ function runAssertions(attrs, body, raw, filterNames) {
       continue
     }
 
-    if (pass !== null && typeof pass === 'object') {
+    if (typeof pass === 'object') {
       detail = pass.detail || ''
       pass = pass.pass
     }

--- a/src/commands/test.js
+++ b/src/commands/test.js
@@ -52,7 +52,6 @@ function printSingleResult(result, options) {
   const color = useColor(options)
 
   const getIcon = emoji ? icon : iconAscii
-  const getGradeIcon = emoji ? gradeIcon : gradeIconAscii
 
   if (options.json) {
     console.log(JSON.stringify(result, null, 2))


### PR DESCRIPTION
Fixes 2 remaining CodeQL alerts:\n- #89: Remove unused `getGradeIcon` variable in `printSingleResult`\n- #88: Remove redundant `pass !== null` check (already guaranteed by earlier `continue`)