### PR TITLE
fix: reject empty convert sources

### DIFF
--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -75,6 +75,9 @@ export async function convertCommand(source, options = {}) {
 
 async function convertSingleFile(inputPath, format, outDir, options) {
   const content = await readFile(inputPath, 'utf-8')
+  if (!content.trim()) {
+    throw new Error(`Source is empty: ${inputPath}`)
+  }
 
   if (options.dryRun) {
     console.log(`  Would convert: ${inputPath}`)

--- a/src/commands/convert.test.js
+++ b/src/commands/convert.test.js
@@ -138,6 +138,16 @@ describe('convert command', () => {
     )
   })
 
+  it('throws for an empty source file', async () => {
+    const emptyPath = join(tempDir, 'empty-SKILL.md')
+    await writeFile(emptyPath, '')
+
+    await assert.rejects(
+      () => commandModule.convertCommand(emptyPath, { output: tempDir }),
+      /Source is empty/,
+    )
+  })
+
   it('preserves mcp_servers during round-trip', async () => {
     const skillContent =
       '---\nname: mcp-skill\nslug: mcp-skill\ndescription: Has MCP\nmcp_servers:\n  - name: github\n    source: gh:github/github-mcp-server\n---\n\nBody\n'


### PR DESCRIPTION
Rejects empty conversion source files with a clear error and regression test. Closes #107.