### PR TITLE
feat: add GitHub Registry MVP — search, publish, install by slug, version check, API exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ rolecraft convert --help
 
 ---
 
+## Registry (optional community marketplace)
+
+Discover and install skills by short names from the [rolecraft Registry](https://github.com/rolecraft-sh/registry) — a GitHub-powered, zero-backend index of published skills:
+
+```bash
+# Search the registry
+rolecraft search react --registry
+
+# Install by short slug (auto-resolves to underlying repo)
+rolecraft install react-rules
+
+# Publish your skill
+rolecraft publish ./my-skill/ --repo user/my-skill
+```
+
+PRs to the registry are auto-validated and auto-merged — no manual review. The registry is **completely optional**; every other feature works without it.
+
+---
+
 ## Skills + MCP in one command
 
 rolecraft is the **only CLI** that installs both agent skills and MCP servers together.
@@ -133,7 +152,7 @@ No other CLI combines both. npx skills has no MCP support. ags has a separate MC
 - **MCP + Skills in one command** — install skills and their MCP servers together. Unique.
 - **Any source** — local folder, GitHub/GitLab/SSH URL, npm package
 - **86+ agents** — opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more
-- **No registry required** — no signup, no marketplace, no vendor lock-in
+- **No registry required** — works fully without a marketplace; community-driven [registry](https://github.com/rolecraft-sh/registry) optional
 - **Security scoring** — static analysis: detects prompt injection, command injection, obfuscated code, credential harvesting. Scores 0–100. Blocks dangerous skills
 - **CI-ready** — lockfile-based re-install (`rolecraft ci`), `--yes` flag, `--dry-run`
 - **Shell completions** — bash, zsh, fish auto-completion
@@ -254,8 +273,8 @@ All API functions return plain objects (no side-effects). Available exports:
 | GitLab / SSH git URL                 | ✅               | ✅              | ❌                  |
 | npm package source                   | ✅               | ✅              | ❌                  |
 | **MCP server management**            | ✅               | ❌              | ❌                  |
-| Agent targets                        | **82**           | 72              | 15+                 |
-| Skills.sh listed                     | ✅               | ✅              | ⚠️ (registry only)  |
+| Agent targets                        | **87**           | 72              | 15+                 |
+| **Registry / marketplace**            | ✅               | ✅ (skills.sh)  | ⚠️ (registry only)  |
 | Bundle install + create              | ✅               | ❌              | ✅ (skillset only)  |
 | Interactive TUI search + install     | ✅               | ✅              | ❌                  |
 | Security scoring (0–100)             | ✅               | ✅ (Snyk)       | ✅ (server + local) |
@@ -270,6 +289,7 @@ All API functions return plain objects (no side-effects). Available exports:
 | Watch mode (auto-sync)               | ✅               | ❌              | ❌                  |
 | AGENTS.md XML generation             | ✅               | ❌              | ❌                  |
 | Self-upgrade command                 | ✅               | ❌              | ❌                  |
+| **Publish to registry**              | ✅               | ❌              | ❌                  |
 | File size                            | ~4 KB            | ~465 KB         | ~84 KB              |
 
 [See full table →](docs/comparison.md)

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -26,6 +26,7 @@ import { profileCommand } from '../src/commands/profile.js'
 import { testCommand } from '../src/commands/test.js'
 import { diffCommand } from '../src/commands/diff.js'
 import { composeCommand } from '../src/commands/compose.js'
+import { publishCommand } from '../src/commands/publish.js'
 import agents from '../src/agents.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -45,7 +46,8 @@ Zero dependencies, no marketplace required.
 Works with ${agents.length} agents: ${agents.map((a) => a.name).join(', ')}, and all spec-compliant agents.
 
 Usage:
-  rolecraft install <source>        Install a skill (local path, owner/repo, or npm:package)
+  rolecraft install <source>        Install a skill (local path, owner/repo, npm:package, or registry slug)
+  rolecraft publish <source>        Publish a skill to the rolecraft Registry
   rolecraft bundle <source> [...]   Install skills from a file or inline sources
   rolecraft bundle create [<name>]  Create a new bundle file
   rolecraft use <source>            Preview a skill without installing
@@ -56,6 +58,7 @@ Usage:
   rolecraft init [<name>]           Scaffold a new SKILL.md
   rolecraft search <query>          Search for skills on GitHub
   rolecraft search <query> --skills-sh  Search skills.sh (experimental)
+  rolecraft search <query> --registry  Search the rolecraft Registry
   rolecraft check                   Check for available skill updates
   rolecraft verify                  Verify installed skill integrity
   rolecraft ci                      Install all skills from lockfile
@@ -115,6 +118,7 @@ Options for use:
 Options for search:
   --interactive  Interactive TUI picker
   --skills-sh    Search skills.sh instead of GitHub
+  --registry     Search the rolecraft Registry
 
 Options for setup:
   --list         List available skills from a source without installing
@@ -135,7 +139,17 @@ ${agentFlags.join('\n')}
   --list             List available skills from a source without installing
   --skill <names>    Install specific skills by name (comma-separated, e.g. "skill1,skill2")
 
+Options for publish:
+  --dry-run      Preview what would be published without creating a PR
+  --yes, -y      Skip confirmation prompt
+  --repo <ref>   GitHub repository (owner/repo) to associate with the skill
+  --slug <slug>  Override the skill slug from SKILL.md frontmatter
+  --name <name>  Override the skill name from SKILL.md frontmatter
+
 Examples:
+  rolecraft publish ./my-skill
+  rolecraft publish ./my-skill --dry-run
+  rolecraft publish ./my-skill --repo owner/repo
   rolecraft install ./my-skill
   rolecraft install sametcelikbicak/task-decomposer
   rolecraft install npm:lodash
@@ -297,12 +311,15 @@ export async function main() {
       const query = args[0]
       const flags = args.slice(1)
       if (!query) {
-        console.error('Usage: rolecraft search <query> [--interactive]')
+        console.error(
+          'Usage: rolecraft search <query> [--interactive] [--registry]',
+        )
         throw new Error('Missing query argument.')
       }
       await searchCommand(query, {
         interactive: flags.includes('--interactive'),
         skillsSh: flags.includes('--skills-sh'),
+        registry: flags.includes('--registry'),
       })
       break
     }
@@ -577,6 +594,46 @@ export async function main() {
       } else {
         await bundleCommand(sources, opts)
       }
+      break
+    }
+
+    case 'publish': {
+      if (args.includes('--help') || args.includes('-h')) {
+        usage()
+        return
+      }
+
+      const publishOpts = {
+        dryRun: false,
+        yes: false,
+        repo: '',
+        slug: '',
+        name: '',
+      }
+      const publishPos = []
+      for (let i = 0; i < args.length; i++) {
+        const a = args[i]
+        if (a === '--dry-run') publishOpts.dryRun = true
+        else if (a === '--yes' || a === '-y') publishOpts.yes = true
+        else if (a === '--repo') {
+          i++
+          publishOpts.repo = args[i] || ''
+        } else if (a === '--slug') {
+          i++
+          publishOpts.slug = args[i] || ''
+        } else if (a === '--name') {
+          i++
+          publishOpts.name = args[i] || ''
+        } else if (!a.startsWith('-')) publishPos.push(a)
+      }
+      const source = publishPos[0]
+      if (!source) {
+        console.error(
+          'Usage: rolecraft publish <source> [--repo owner/repo] [--dry-run]',
+        )
+        throw new Error('Missing source argument.')
+      }
+      await publishCommand(source, publishOpts)
       break
     }
 

--- a/docs/commands/check.md
+++ b/docs/commands/check.md
@@ -12,6 +12,15 @@ rolecraft check
 
 Reads the lockfile and compares each skill's stored content hash against the current source. Skills whose content hash differs from the lockfile are flagged as having updates available. Works with both global and project-scoped skills.
 
+If the [rolecraft Registry](./registry.md) is reachable, `check` also looks up version information for each installed skill. When a newer version is published in the registry, it shows up in the output with `(registry)` suffix:
+
+```
+   🔄 testing-guide              v1.0.0 → v1.1.0 (registry)
+   ✅ react-rules                up to date
+```
+
+Run `rolecraft update <slug>` to apply the update.
+
 ## Example
 
 ```bash

--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -1,6 +1,6 @@
 # `rolecraft install`
 
-Install a skill from a local path, GitHub repository, or npm package.
+Install a skill from a local path, GitHub repository, npm package, or registry slug.
 
 Supports **single-skill** and **multi-skill** repositories. If a source contains
 multiple `SKILL.md` files (e.g. under `skills/`), you will be prompted to
@@ -36,6 +36,16 @@ rolecraft install mattpocock/skills
 
 The CLI clones with `--depth 1`, discovers all `SKILL.md` files (including
 those under `skills/`, `.agents/skills/`, etc.), and lets you choose.
+
+### Registry slug
+
+The [rolecraft Registry](https://github.com/rolecraft-sh/registry) provides short, versioned names for published skills:
+
+```bash
+rolecraft install my-skill
+```
+
+If `my-skill` isn't a local path, GitHub ref, git URL, or npm ref, rolecraft looks it up in the registry and resolves it to the underlying repo URL. See [`registry.md`](./registry.md) for details.
 
 ### npm package
 

--- a/docs/commands/publish.md
+++ b/docs/commands/publish.md
@@ -1,0 +1,151 @@
+# `rolecraft publish`
+
+Publish a skill to the rolecraft Registry.
+
+## Usage
+
+```bash
+rolecraft publish <source> [--repo <owner/repo>] [--dry-run] [--yes]
+                     [--slug <slug>] [--name <name>]
+```
+
+## Description
+
+Publishes a `SKILL.md` to the centralised [rolecraft Registry](https://github.com/rolecraft-sh/registry). The registry acts as a community-driven index of skills, similar to npm for Node.js packages or PyPI for Python.
+
+### Option A: CLI publish (recommended)
+
+When you publish via CLI:
+
+1. **Reads** the SKILL.md metadata from your local skill directory.
+2. **Detects** the GitHub repository from your local git remote (or `--repo` flag).
+3. **Forks** the rolecraft-sh/registry repository (one-time setup, automatic).
+4. **Updates** `index.json` with a new entry.
+5. **Opens** a pull request via GitHub API.
+6. **Auto-merge** happens automatically once CI validation passes.
+
+### Option B: Manual PR (without CLI)
+
+Don't use rolecraft CLI? You can add your skill by editing `index.json` directly on GitHub:
+
+1. Go to https://github.com/rolecraft-sh/registry
+2. Click **Fork**
+3. Edit `index.json` — add your skill entry to the `skills` array
+4. Commit to a new branch
+5. Open a **Pull Request**
+
+Entry format:
+
+```json
+{
+  "slug": "my-skill",
+  "name": "My Skill",
+  "description": "What this skill does",
+  "repo": "your-username/your-skill-repo",
+  "author": "your-username",
+  "versions": ["v1.0.0"],
+  "latest": "v1.0.0"
+}
+```
+
+### Constraints
+
+| Rule | Details |
+|------|---------|
+| **Slug format** | kebab-case: `^[a-z0-9]+(-[a-z0-9]+)*$`, e.g. `react-rules` |
+| **Unique slug** | Every slug must be unique across all skills |
+| **Author match** | The `author` field must be **your GitHub username** (checked by CI) |
+| **Repo must exist** | The `repo` must be a valid GitHub repo that contains a `SKILL.md` |
+| **Schema validation** | Entry must match `schema.json` in the registry repo |
+
+### Validation checks (auto)
+
+Each PR triggers:
+
+1. **JSON syntax** check
+2. **Schema validation** against `schema.json`
+3. **Duplicate slug** check
+4. **Owner verification** — PR author must match the `author` field
+
+If all pass, the PR is **auto-merged**. No manual review needed.
+
+After publish, your skill becomes available via:
+
+```bash
+rolecraft search <query> --registry
+rolecraft install <your-slug>
+```
+
+## Authentication
+
+To publish, you need **your own** GitHub personal access token (PAT) with `repo` scope. This token is used by the CLI to fork the registry and open a PR on your behalf — it does NOT give rolecraft access to your account.
+
+```bash
+# 1. Create a token at: https://github.com/settings/tokens (scope: repo)
+# 2. Set it as an environment variable:
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+
+# Or pass it inline (one-off):
+GITHUB_TOKEN=ghp_xxxxx rolecraft publish ./my-skill
+```
+
+> **Note:** If `GITHUB_TOKEN` is missing, the CLI will show a clear error with the setup link.
+
+## Flags
+
+| Flag           | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
+| `--dry-run`    | Preview what would be published without creating a PR               |
+| `--yes, -y`    | Skip the confirmation prompt                                       |
+| `--repo <ref>` | Specify the GitHub repo (owner/repo). Otherwise auto-detected       |
+| `--slug <slug>`| Override the skill slug from SKILL.md frontmatter                  |
+| `--name <name>`| Override the skill name from SKILL.md frontmatter                  |
+
+## Examples
+
+```bash
+# Publish from current directory (auto-detect git remote)
+rolecraft publish .
+
+# Publish from a skill directory
+rolecraft publish ./my-skill/
+
+# Specify the repo explicitly
+rolecraft publish ./my-skill --repo sametcelikbicak/my-skill
+
+# Preview without publishing
+rolecraft publish ./my-skill --dry-run
+
+# Non-interactive mode
+rolecraft publish ./my-skill --yes
+```
+
+## Versioning
+
+Each publish creates a new version entry in the registry. The registry tracks every version you've published, and `rolecraft update` can detect newer versions for installed skills.
+
+If a skill with the same slug already exists in the registry, the new version is appended to the `versions` array and `latest` is updated. To publish a major version bump, manually edit `versions` before submitting your PR (e.g. `['v1.0.0', 'v2.0.0']`).
+
+## Registry Schema
+
+Each skill entry in `index.json` looks like:
+
+```json
+{
+  "slug": "my-skill",
+  "name": "My Skill",
+  "description": "What this skill does",
+  "repo": "user/my-skill",
+  "author": "user",
+  "versions": ["v1.0.0"],
+  "latest": "v1.0.0",
+  "installs": 0,
+  "stars": 0
+}
+```
+
+The full schema is at: https://github.com/rolecraft-sh/registry/blob/main/schema.json
+
+## Cache
+
+The registry index is cached in-memory for 5 minutes. Use `clearCache()` from the API (`src/utils/registry-client.js`) or restart your CLI session to force a refresh.

--- a/docs/commands/registry.md
+++ b/docs/commands/registry.md
@@ -1,0 +1,148 @@
+# rolecraft Registry
+
+The rolecraft Registry is a centralised skill index powered by GitHub. Skills are published via PRs, validated, and auto-merged — no manual review needed.
+
+**Registry repo:** https://github.com/rolecraft-sh/registry
+
+## Usage overview
+
+| Command                                          | What it does                                |
+| ------------------------------------------------ | ------------------------------------------- |
+| `rolecraft search <query> --registry`            | Search the registry                         |
+| `rolecraft install <slug>`                       | Install a skill by its registry slug        |
+| `rolecraft publish <source>`                     | Publish your skill to the registry          |
+| `rolecraft check`                                | Updates include registry version checks     |
+
+## Search the registry
+
+```bash
+rolecraft search code-review --registry
+```
+
+Sample output:
+
+```
+📦 Registry results for "code-review":
+
+   code-review
+   ├─ Best practices for code review
+   └─ rolecraft install code-review
+
+1 result(s) found.
+```
+
+The `--registry` flag filters the registry index by `slug`, `name`, or `description`.
+
+## Install by slug
+
+```bash
+# Instead of: rolecraft install user/full-repo-name
+rolecraft install my-skill
+```
+
+When you pass a slug that isn't a local path, GitHub ref, git URL, or npm ref, rolecraft automatically looks it up in the registry and resolves it to the underlying GitHub repo.
+
+This works through the existing `install` flow, so all flags like `--yes`, `--global`, `--dry-run`, `--frozen-lockfile`, and `--symlink` continue to work.
+
+## Publish a skill
+
+### Using CLI (recommended)
+
+You need **your own** [GitHub token](https://github.com/settings/tokens) (scope: `repo`) to publish. See [`publish.md`](./publish.md) for full details.
+
+Quick start:
+
+```bash
+# 1. Create a token at: https://github.com/settings/tokens
+export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+
+# 2. Publish your skill
+rolecraft publish ./my-skill/ --repo user/my-skill --yes
+```
+
+> The token is used only to fork the registry and open a PR on your behalf. It never leaves your machine.
+
+### Manual PR (no CLI needed)
+
+Don't use rolecraft CLI? Just edit `index.json` directly:
+
+1. Fork https://github.com/rolecraft-sh/registry
+2. Edit `index.json` — add your entry to the `skills` array
+3. Commit and open a PR
+
+Example entry:
+
+```json
+{
+  "slug": "my-skill",
+  "name": "My Skill",
+  "description": "Does something",
+  "repo": "your-username/your-skill",
+  "author": "your-username",
+  "versions": ["v1.0.0"],
+  "latest": "v1.0.0"
+}
+```
+
+**Constraints:**
+- `slug`: kebab-case only (`^[a-z0-9]+(-[a-z0-9]+)*$`), must be unique
+- `author`: must match your GitHub username (CI enforces this)
+- `repo`: must be a real GitHub repo containing a `SKILL.md`
+- Full JSON Schema at [`schema.json`](https://github.com/rolecraft-sh/registry/blob/main/schema.json)
+
+## Update checking
+
+`rolecraft check` automatically queries the registry for version updates on every installed skill. If a newer version is available, you'll see it marked with `(registry)` in the output:
+
+```
+   🔄 testing-guide              v1.0.0 → v1.1.0 (registry)
+```
+
+## Behind the scenes
+
+### Why GitHub?
+
+The registry is a normal GitHub repository (`rolecraft-sh/registry`). We deliberately chose this over building a custom backend because:
+
+- **Zero infrastructure to maintain** — no servers, no databases, no auth systems
+- **Tamper-evident** — every change is a signed git commit
+- **Community-owned** — anyone can submit improvements via PR
+- **Free hosting** — no monthly costs
+
+### index.json format
+
+See [`schema.json`](https://github.com/rolecraft-sh/registry/blob/main/schema.json) for the full JSON Schema. Each skill has:
+
+| Field         | Type          | Required | Description                                  |
+| ------------- | ------------- | -------- | -------------------------------------------- |
+| `slug`        | string        | yes      | kebab-case unique identifier                 |
+| `name`        | string        | yes      | Human-readable name                          |
+| `description` | string        | no       | Short description                            |
+| `repo`        | string        | yes      | GitHub repo (owner/repo)                     |
+| `author`      | string        | yes      | GitHub username                              |
+| `versions`    | array<string> | yes      | Published semver versions                    |
+| `latest`      | string        | yes      | Latest version                               |
+| `installs`    | number        | no       | Install count (best-effort)                  |
+| `stars`       | number        | no       | GitHub stars                                 |
+
+### Validation & auto-merge
+
+Each PR to `index.json` triggers GitHub Actions:
+
+1. **JSON syntax check** — `node -e "JSON.parse(...)"`
+2. **Schema validation** — `ajv-cli` against `schema.json`
+3. **Duplicate check** — no two skills with the same slug
+4. **Owner verification** — PR author must own the skill's GitHub repo
+
+If all checks pass, the PR is auto-merged via `gh pr merge --auto --squash`. **No manual review needed.**
+
+### Local caching
+
+The registry index is fetched from the GitHub API and cached in-memory for 5 minutes. Set `GITHUB_TOKEN` to lift the unauthenticated rate limit (60/hr → 5000/hr).
+
+## Privacy & security
+
+- The registry contains **only** skill metadata (`slug`, `repo`, `description`). No skill code is uploaded or stored.
+- Skills are installed directly from their original GitHub repos — what you publish is what users get.
+- All PRs are public, signed, and reviewable.
+- No telemetry. No analytics. No accounts.

--- a/docs/commands/search.md
+++ b/docs/commands/search.md
@@ -1,11 +1,11 @@
 # `rolecraft search`
 
-Search for skills on GitHub or skills.sh (experimental).
+Search for skills on GitHub, skills.sh (experimental), or the rolecraft Registry.
 
 ## Usage
 
 ```bash
-rolecraft search <query> [--interactive] [--skills-sh]
+rolecraft search <query> [--interactive] [--skills-sh] [--registry]
 ```
 
 ## Description
@@ -21,6 +21,12 @@ Use `--interactive` to open an arrow-key navigable TUI. Browse results with `↑
 > ⚠️ **Experimental.** The skills.sh API is undocumented and may change or become unavailable without notice.
 
 Use `--skills-sh` to search the [skills.sh](https://skills.sh) skill directory instead of GitHub. Results include install counts and the exact install command.
+
+### Registry
+
+Use `--registry` to search the [rolecraft Registry](https://github.com/rolecraft-sh/registry) — a community-driven index of published skills. Results include version, author, and the exact install command (using short slugs).
+
+See [`registry.md`](./registry.md) for details.
 
 ## Examples
 
@@ -42,4 +48,7 @@ rolecraft search "code review" --interactive
 
 # Search skills.sh directory (experimental)
 rolecraft search react --skills-sh
+
+# Search the rolecraft Registry
+rolecraft search code-review --registry
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ features:
     details: ~4 KB, no bloat. Only Node.js built-ins.
   - title: MCP + Skills in One Command
     details: Install skills and their MCP servers together. No other CLI tool combines both.
-  - title: 82+ Agents
+  - title: 87+ Agents
     details: opencode, claude-code, cursor, copilot, aider, devin, gemini-cli, and more.
   - title: Security Scoring
     details: Static analysis on install — detects prompt injection, command injection, obfuscated code.
@@ -34,3 +34,5 @@ features:
     details: Lockfile-based re-install, --yes flag, dry-run mode for pipelines.
   - title: Any Source
     details: Local folder, GitHub, GitLab, SSH git URL, npm package.
+  - title: Registry (optional)
+    details: Discover and publish skills via the rolecraft Registry. GitHub-powered, zero-backend, auto-merged PRs.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -137,6 +137,7 @@ rolecraft install owner/repo                         # GitHub shorthand
 rolecraft install https://gitlab.com/org/project     # Git URL
 rolecraft install git@github.com:owner/repo.git      # SSH URL
 rolecraft install npm:package                        # npm package
+rolecraft install my-skill                           # registry slug
 ```
 
 Accepts: `--yes`, `--dry-run`, `--global`, `--project`, `--all`, `--symlink`, `--frozen-lockfile`, `--no-mcp`, agent flags.
@@ -198,7 +199,21 @@ rolecraft setup owner/repo --yes
 rolecraft search code-review                  # GitHub search
 rolecraft search code-review --interactive     # TUI picker
 rolecraft search react --skills-sh             # skills.sh (experimental)
+rolecraft search react --registry              # rolecraft Registry
 ```
+
+### `rolecraft publish <source>`
+
+Publish a skill to the rolecraft Registry:
+
+```bash
+rolecraft publish ./my-skill                          # auto-detect git remote
+rolecraft publish ./my-skill --repo user/my-skill     # explicit repo
+rolecraft publish ./my-skill --dry-run                # preview without PR
+rolecraft publish ./my-skill --yes                    # non-interactive
+```
+
+Requires `GITHUB_TOKEN` environment variable (with `repo` scope). See [`publish.md`](./commands/publish.md) for full details.
 
 ### `rolecraft check`
 

--- a/src/api/check.js
+++ b/src/api/check.js
@@ -11,6 +11,14 @@ export async function apiCheck(cwd = process.cwd()) {
   const entries = Object.entries(allSkills)
   if (entries.length === 0) return { skills: [], updatesAvailable: 0, total: 0 }
 
+  let registryIndex
+  try {
+    const { fetchIndex } = await import('../utils/registry-client.js')
+    registryIndex = await fetchIndex()
+  } catch {
+    registryIndex = null
+  }
+
   const results = []
   let updatesAvailable = 0
 
@@ -19,6 +27,26 @@ export async function apiCheck(cwd = process.cwd()) {
     if (!source) {
       results.push({ slug, status: 'skipped', reason: 'no source info' })
       continue
+    }
+
+    if (registryIndex) {
+      const registrySkill = registryIndex.skills.find((s) => s.slug === slug)
+      if (
+        registrySkill?.latest &&
+        info.version &&
+        registrySkill.latest !== info.version
+      ) {
+        results.push({
+          slug,
+          status: 'update_available',
+          current: info.version,
+          latest: registrySkill.latest,
+          source,
+          fromRegistry: true,
+        })
+        updatesAvailable++
+        continue
+      }
     }
 
     try {

--- a/src/api/registry.js
+++ b/src/api/registry.js
@@ -1,0 +1,32 @@
+import {
+  fetchIndex,
+  searchRegistry,
+  resolveSlug,
+  createPublishPR,
+  checkUpdates,
+  clearCache,
+} from '../utils/registry-client.js'
+
+export {
+  fetchIndex,
+  searchRegistry,
+  resolveSlug,
+  createPublishPR,
+  checkUpdates,
+  clearCache,
+}
+
+export async function apiRegistryInfo(slug) {
+  const index = await fetchIndex()
+  const skill = index.skills.find((s) => s.slug === slug)
+  if (!skill) {
+    const err = new Error(`Skill "${slug}" not found in registry`)
+    throw err
+  }
+  return skill
+}
+
+export async function apiRegistryList() {
+  const index = await fetchIndex()
+  return index.skills
+}

--- a/src/api/registry.test.js
+++ b/src/api/registry.test.js
@@ -1,0 +1,147 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+let api, client
+
+before(async () => {
+  api = await import('./registry.js')
+  client = await import('../utils/registry-client.js')
+})
+
+after(() => {
+  client.setRegistryFetch(globalThis.fetch)
+})
+
+function mockFetch(body) {
+  const encoded = Buffer.from(JSON.stringify(body)).toString('base64')
+  client.setRegistryFetch(() =>
+    Promise.resolve({
+      status: 200,
+      ok: true,
+      json: () => Promise.resolve({ type: 'file', content: encoded }),
+    }),
+  )
+}
+
+const sampleIndex = {
+  updated: '2026-07-23T15:00:00.000Z',
+  skills: [
+    {
+      slug: 'react-rules',
+      name: 'React Best Practices',
+      description: 'React code conventions',
+      repo: 'acme/react-rules',
+      author: 'acme',
+      versions: ['v1.0.0'],
+      latest: 'v1.0.0',
+    },
+    {
+      slug: 'testing-guide',
+      name: 'Testing Guide',
+      description: 'Testing best practices',
+      repo: 'acme/testing-guide',
+      author: 'acme',
+      versions: ['v1.0.0', 'v1.1.0'],
+      latest: 'v1.1.0',
+    },
+  ],
+}
+
+describe('registry API', () => {
+  beforeEach(() => {
+    client.clearCache()
+    client.setRegistryFetch(globalThis.fetch)
+  })
+
+  after(() => client.setRegistryFetch(globalThis.fetch))
+
+  describe('apiRegistryList', () => {
+    it('returns all skills', async () => {
+      mockFetch(sampleIndex)
+
+      const list = await api.apiRegistryList()
+      assert.equal(list.length, 2)
+      assert.ok(list.some((s) => s.slug === 'react-rules'))
+    })
+
+    it('returns empty when registry is empty', async () => {
+      mockFetch({ updated: '2026-07-23T15:00:00.000Z', skills: [] })
+
+      const list = await api.apiRegistryList()
+      assert.equal(list.length, 0)
+    })
+  })
+
+  describe('apiRegistryInfo', () => {
+    it('returns skill details', async () => {
+      mockFetch(sampleIndex)
+
+      const skill = await api.apiRegistryInfo('react-rules')
+      assert.equal(skill.slug, 'react-rules')
+      assert.equal(skill.repo, 'acme/react-rules')
+    })
+
+    it('throws for unknown slug', async () => {
+      mockFetch(sampleIndex)
+
+      await assert.rejects(
+        () => api.apiRegistryInfo('nonexistent'),
+        /not found in registry/,
+      )
+    })
+  })
+
+  describe('searchRegistry', () => {
+    it('searches by slug', async () => {
+      mockFetch(sampleIndex)
+
+      const results = await api.searchRegistry('react')
+      assert.equal(results.length, 1)
+      assert.equal(results[0].slug, 'react-rules')
+    })
+
+    it('is case-insensitive', async () => {
+      mockFetch(sampleIndex)
+
+      const results = await api.searchRegistry('REACT')
+      assert.equal(results.length, 1)
+    })
+
+    it('returns empty for no matches', async () => {
+      mockFetch(sampleIndex)
+
+      const results = await api.searchRegistry('xyz')
+      assert.equal(results.length, 0)
+    })
+  })
+
+  describe('resolveSlug', () => {
+    it('returns full skill entry', async () => {
+      mockFetch(sampleIndex)
+
+      const skill = await api.resolveSlug('testing-guide')
+      assert.equal(skill.latest, 'v1.1.0')
+    })
+  })
+
+  describe('checkUpdates', () => {
+    it('detects outdated skills', async () => {
+      mockFetch(sampleIndex)
+
+      const updates = await api.checkUpdates([
+        { slug: 'testing-guide', name: 'Testing Guide', version: 'v1.0.0' },
+      ])
+      assert.equal(updates.length, 1)
+      assert.equal(updates[0].latest, 'v1.1.0')
+    })
+
+    it('returns empty when current', async () => {
+      mockFetch(sampleIndex)
+
+      const updates = await api.checkUpdates([
+        { slug: 'react-rules', name: 'React', version: 'v1.0.0' },
+      ])
+      assert.equal(updates.length, 0)
+    })
+  })
+})

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -15,7 +15,13 @@ export async function checkCommand() {
     if (s.status === 'skipped') {
       console.log(`   ⏭️  ${s.slug.padEnd(30)} ${s.reason}`)
     } else if (s.status === 'update_available') {
-      console.log(`   🔄 ${s.slug.padEnd(30)} update available`)
+      if (s.fromRegistry) {
+        console.log(
+          `   🔄 ${s.slug.padEnd(30)} ${s.current} → ${s.latest} (registry)`,
+        )
+      } else {
+        console.log(`   🔄 ${s.slug.padEnd(30)} update available`)
+      }
     } else if (s.status === 'up_to_date') {
       console.log(`   ✅ ${s.slug.padEnd(30)} up to date`)
     } else if (s.status === 'error') {

--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -1,0 +1,126 @@
+import { execSync as defaultExecSync } from 'node:child_process'
+import { resolveSource } from '../utils/resolver.js'
+import { createPublishPR } from '../utils/registry-client.js'
+
+let askQuestion = defaultAskQuestion
+let runExecSync = defaultExecSync
+
+async function defaultAskQuestion(query) {
+  const { createInterface } = await import('node:readline')
+  const { stdin, stdout } = await import('node:process')
+  const rl = createInterface({ input: stdin, output: stdout })
+  return new Promise((resolve) => {
+    rl.question(query, (answer) => {
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}
+
+export function setAskQuestion(fn) {
+  askQuestion = fn || defaultAskQuestion
+}
+
+export function setExecSync(fn) {
+  runExecSync = fn || defaultExecSync
+}
+
+function detectGitRemote(skillDir) {
+  try {
+    const output = runExecSync(`git -C "${skillDir}" remote get-url origin`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+    })
+    const url = (output || '').trim()
+    if (!url) return null
+
+    const match = url.match(
+      /(?:github\.com[:/])([\w.-]+)\/([\w.-]+?)(?:\.git)?$/,
+    )
+    if (match) return `${match[1]}/${match[2]}`
+    return null
+  } catch {
+    return null
+  }
+}
+
+export async function publishCommand(source, options = {}) {
+  let skill
+  try {
+    skill = await resolveSource(source)
+  } catch (err) {
+    console.error(`\n❌ Failed to resolve skill: ${err.message}`)
+    return
+  }
+
+  const slug = options.slug || skill.slug
+  const name = options.name || skill.name
+  const description = options.description || skill.description || ''
+
+  let repo = options.repo || ''
+  if (!repo) {
+    repo = detectGitRemote(skill.skillDir || skill.sourcePath || source)
+  }
+
+  if (!repo && !options.dryRun && !options.yes) {
+    const answer = await askQuestion(
+      `\n  GitHub repo not detected. Enter repo (owner/repo): `,
+    )
+    if (!answer) {
+      console.log('  Publish cancelled.')
+      return
+    }
+    repo = answer.trim()
+  }
+
+  if (!repo && !options.dryRun) {
+    console.error('\n❌ No repo specified. Use --repo owner/repo')
+    return
+  }
+
+  if (repo && !/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+    console.error(
+      `\n❌ Invalid repo format. Expected "owner/repo", got: "${repo}"`,
+    )
+    return
+  }
+
+  console.log()
+  console.log(`  Skill:      ${name}`)
+  console.log(`  Slug:       ${slug}`)
+  console.log(`  Repo:       ${repo}`)
+  if (description) console.log(`  Description: ${description}`)
+  console.log()
+
+  if (options.dryRun) {
+    console.log('[dry-run] Would publish:')
+    console.log(`   rolecraft publish ${source}`)
+    console.log(`   → PR to rolecraft-sh/registry adding ${slug}\n`)
+    return
+  }
+
+  const confirm = options.yes
+    ? 'y'
+    : await askQuestion('  Publish this skill to the registry? [y/N] ')
+
+  if (confirm.toLowerCase() !== 'y' && confirm.toLowerCase() !== 'yes') {
+    console.log('  Publish cancelled.')
+    return
+  }
+
+  console.log('  Publishing...')
+
+  try {
+    const result = await createPublishPR({
+      slug,
+      name,
+      repo,
+      description,
+    })
+    console.log(`\n✅ Published! PR #${result.number} created:`)
+    console.log(`   ${result.url}`)
+    console.log('   Auto-merge will handle the rest once checks pass.')
+  } catch (err) {
+    console.error(`\n❌ Failed to publish: ${err.message}`)
+  }
+}

--- a/src/commands/publish.test.js
+++ b/src/commands/publish.test.js
@@ -1,0 +1,170 @@
+import { describe, it, before, after, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let publishModule
+
+before(async () => {
+  publishModule = await import('./publish.js')
+})
+
+after(() => {
+  publishModule.setAskQuestion(undefined)
+  publishModule.setExecSync(undefined)
+})
+
+let testDir
+
+function capture(name) {
+  const orig = console[name]
+  const logs = []
+  console[name] = (...args) => {
+    if (args.length) logs.push(String(args[0]))
+  }
+  return {
+    logs,
+    restore: () => {
+      console[name] = orig
+    },
+  }
+}
+
+function createTestSkill(dir, overrides = {}) {
+  mkdirSync(dir, { recursive: true })
+  const frontmatter = [
+    '---',
+    `name: ${overrides.name || 'Test Skill'}`,
+    `slug: ${overrides.slug || 'test-skill'}`,
+    `description: ${overrides.description || 'A test skill'}`,
+    '---',
+    '## Code Style',
+    'Use tabs',
+    '## Testing',
+    'Write tests',
+  ].join('\n')
+  writeFileSync(join(dir, 'SKILL.md'), frontmatter)
+}
+
+describe('publish command', () => {
+  afterEach(async () => {
+    publishModule.setAskQuestion(undefined)
+    publishModule.setExecSync(undefined)
+    if (testDir) {
+      await rm(testDir, { recursive: true, force: true })
+      testDir = null
+    }
+  })
+
+  it('shows dry-run output', async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'publish-test-'))
+    createTestSkill(testDir)
+
+    const { logs, restore } = capture('log')
+    await publishModule.publishCommand(testDir, {
+      repo: 'user/test-skill',
+      dryRun: true,
+    })
+    restore()
+
+    assert.ok(logs.some((l) => l.includes('[dry-run]')))
+    assert.ok(logs.some((l) => l.includes('test-skill')))
+    assert.ok(logs.some((l) => l.includes('user/test-skill')))
+  })
+
+  it('cancels on user rejection', async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'publish-cancel-'))
+    createTestSkill(testDir)
+
+    publishModule.setAskQuestion(() => Promise.resolve('n'))
+
+    const { logs, restore } = capture('log')
+    await publishModule.publishCommand(testDir, {
+      repo: 'user/test-skill',
+    })
+    restore()
+
+    assert.ok(logs.some((l) => l.includes('cancelled')))
+  })
+
+  it('proceeds with --yes flag', async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'publish-yes-'))
+    createTestSkill(testDir)
+
+    publishModule.setAskQuestion(() => Promise.resolve('n'))
+
+    const { logs, restore } = capture('log')
+    await publishModule.publishCommand(testDir, {
+      repo: 'user/test-skill',
+      yes: true,
+    })
+    restore()
+
+    assert.ok(logs.some((l) => l.includes('Publishing')))
+  })
+
+  it('shows error for invalid source', async () => {
+    const { logs, restore } = capture('error')
+    await publishModule.publishCommand('/nonexistent/path', {
+      dryRun: true,
+    })
+    restore()
+
+    assert.ok(logs.some((l) => l.includes('Failed to resolve')))
+  })
+
+  it('shows error for invalid repo format', async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'publish-repo-'))
+    createTestSkill(testDir)
+
+    const { logs, restore } = capture('error')
+    await publishModule.publishCommand(testDir, {
+      repo: 'invalid-repo-format',
+      dryRun: false,
+      yes: true,
+    })
+    restore()
+
+    assert.ok(logs.some((l) => l.includes('Invalid repo format')))
+  })
+
+  it('detects repo from git remote', async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'publish-git-'))
+    createTestSkill(testDir)
+
+    publishModule.setExecSync(() => 'git@github.com:user/test-skill.git')
+
+    const { logs, restore } = capture('log')
+    await publishModule.publishCommand(testDir, {
+      yes: true,
+      dryRun: true,
+    })
+    restore()
+
+    assert.ok(logs.some((l) => l.includes('user/test-skill')))
+  })
+
+  it('reports publish failure', async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'publish-fail-'))
+    createTestSkill(testDir)
+
+    const origToken = process.env.GITHUB_TOKEN
+    delete process.env.GITHUB_TOKEN
+    delete process.env.GH_TOKEN
+
+    try {
+      const { logs, restore } = capture('error')
+      await publishModule.publishCommand(testDir, {
+        repo: 'user/test-skill',
+        yes: true,
+      })
+      restore()
+
+      assert.ok(logs.some((l) => l.includes('Failed to publish')))
+    } finally {
+      if (origToken) process.env.GITHUB_TOKEN = origToken
+    }
+  })
+})

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -2,8 +2,10 @@ import { stdin as input, stdout as output } from 'node:process'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import { apiSearch } from '../api/search.js'
+import { searchRegistry } from '../utils/registry-client.js'
 
 export { setFetch } from '../api/search.js'
+export { setRegistryFetch } from '../utils/registry-client.js'
 
 const CSI = '\x1b['
 const sgr = (n) => `${CSI}${n}m`
@@ -224,7 +226,53 @@ export function formatSkillsShItem(skill) {
   return `${bold(`${skill.source}/${skill.skillId}`)}\n  ${dim(desc)}  ${yellow(`📦 ${installs}`)}  ${cyan('skills.sh')}`
 }
 
+export function formatRegistryItem(skill) {
+  const desc = skill.description || 'No description'
+  const stars = skill.stars || 0
+  const installs = skill.installs || 0
+  const version = skill.latest || 'v1.0.0'
+  const author = skill.author || ''
+  return `${bold(skill.slug)}  ${yellow(`v${version.replace(/^v/, '')}`)}\n  ${dim(desc)}  ${author ? `@${author}` : ''}  ${dim('📦 ' + installs)}  ${dim(`⭐ ${stars}`)}`
+}
+
 export async function searchCommand(query, options = {}) {
+  if (options.registry) {
+    try {
+      const items = await searchRegistry(query)
+
+      if (items.length === 0) {
+        console.log(`\nNo skills found in registry for "${query}".`)
+        console.log(
+          '  Publish your own skill with: rolecraft publish ./<skill>/',
+        )
+        return
+      }
+
+      console.log(`\n📦 Registry results for "${query}":\n`)
+      for (const skill of items) {
+        const line = formatRegistryItem(skill).split('\n')
+        console.log(`   ${line[0]}`)
+        console.log(`   ├─ ${line[1]}`)
+        console.log(`   └─ rolecraft install ${skill.slug}`)
+        console.log()
+      }
+      console.log(`${items.length} result(s) found.`)
+    } catch (err) {
+      if (err.message?.includes('rate limit')) {
+        console.log(
+          '\n⚠️  GitHub API rate limit reached. Set GITHUB_TOKEN to search the registry.',
+        )
+        return
+      }
+      if (err.message?.includes('Registry not found')) {
+        console.log('\n⚠️  Registry is not yet available. Coming soon.')
+        return
+      }
+      throw err
+    }
+    return
+  }
+
   if (options.skillsSh) {
     try {
       const data = await apiSearch(query, { skillsSh: true })

--- a/src/commands/search.test.js
+++ b/src/commands/search.test.js
@@ -524,4 +524,92 @@ describe('search command', () => {
       )
     })
   })
+
+  describe('registry integration', () => {
+    afterEach(() => {
+      searchModule.setRegistryFetch(globalThis.fetch)
+    })
+
+    function mockRegistryFetch(body) {
+      const encoded = Buffer.from(JSON.stringify(body)).toString('base64')
+      searchModule.setRegistryFetch(() =>
+        Promise.resolve({
+          status: 200,
+          ok: true,
+          json: () => Promise.resolve({ type: 'file', content: encoded }),
+        }),
+      )
+    }
+
+    it('formats a registry item', () => {
+      const result = searchModule.formatRegistryItem({
+        slug: 'react-rules',
+        name: 'React Rules',
+        description: 'React best practices',
+        author: 'acme',
+        latest: 'v1.0.0',
+        installs: 100,
+        stars: 50,
+      })
+      assert.ok(result.includes('react-rules'))
+      assert.ok(result.includes('v1.0.0'))
+      assert.ok(result.includes('@acme'))
+    })
+
+    it('formats registry item with missing fields', () => {
+      const result = searchModule.formatRegistryItem({
+        slug: 'minimal',
+      })
+      assert.ok(result.includes('minimal'))
+      assert.ok(result.includes('No description'))
+    })
+
+    it('shows results from registry', async () => {
+      mockRegistryFetch({
+        updated: '2026-07-23T15:00:00.000Z',
+        skills: [
+          {
+            slug: 'skill-one',
+            name: 'Skill One',
+            description: 'First skill',
+            repo: 'user1/skill-one',
+            author: 'user1',
+            versions: ['v1.0.0'],
+            latest: 'v1.0.0',
+          },
+          {
+            slug: 'skill-two',
+            name: 'Skill Two',
+            description: 'Second skill',
+            repo: 'user2/skill-two',
+            author: 'user2',
+            versions: ['v1.0.0'],
+            latest: 'v1.0.0',
+          },
+        ],
+      })
+
+      const { logs, restore } = capture('log')
+      await searchModule.searchCommand('skill', { registry: true })
+      restore()
+
+      assert.ok(logs.some((l) => l.includes('Registry results')))
+      assert.ok(logs.some((l) => l.includes('skill-one')))
+      assert.ok(logs.some((l) => l.includes('skill-two')))
+      assert.ok(logs.some((l) => l.includes('2 result(s) found')))
+    })
+
+    it('shows no results message when registry empty', async () => {
+      mockRegistryFetch({
+        updated: '2026-07-23T15:00:00.000Z',
+        skills: [],
+      })
+
+      const { logs, restore } = capture('log')
+      await searchModule.searchCommand('nonexistent', { registry: true })
+      restore()
+
+      assert.ok(logs.some((l) => l.includes('No skills found')))
+    })
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
 export {
   apiInstallSkills as install,
   apiResolveSkills as resolveSkills,
-} from './install.js'
-export { apiList as list } from './list.js'
-export { apiRemove as remove } from './remove.js'
-export { apiUpdate as update } from './update.js'
-export { apiCheck as check } from './check.js'
-export { apiVerify as verify } from './verify.js'
-export { apiCi as ci } from './ci.js'
-export { apiDoctor as doctor } from './doctor.js'
-export { apiSearch as search, apiResolve as resolve } from './search.js'
+} from './api/install.js'
+export { apiList as list } from './api/list.js'
+export { apiRemove as remove } from './api/remove.js'
+export { apiUpdate as update } from './api/update.js'
+export { apiCheck as check } from './api/check.js'
+export { apiVerify as verify } from './api/verify.js'
+export { apiCi as ci } from './api/ci.js'
+export { apiDoctor as doctor } from './api/doctor.js'
+export { apiSearch as search, apiResolve as resolve } from './api/search.js'
 export {
   apiMcpInstall as mcpInstall,
   apiMcpList as mcpList,
@@ -17,8 +17,8 @@ export {
   apiMcpRemove as mcpRemove,
   apiMcpCheck as mcpCheck,
   apiMcpSearch as mcpSearch,
-} from './mcp.js'
-export { apiUse as use } from './use.js'
+} from './api/mcp.js'
+export { apiUse as use } from './api/use.js'
 export {
   apiProfileSave as profileSave,
   apiProfileApply as profileApply,
@@ -27,7 +27,16 @@ export {
   apiProfileShow as profileShow,
   apiProfileDelete as profileDelete,
   apiProfileImport as profileImport,
-} from './profile.js'
+} from './api/profile.js'
 export { apiTest as test } from './api/test.js'
 export { apiDiff as diff } from './api/diff.js'
 export { apiCompose as compose } from './api/compose.js'
+export {
+  apiRegistryInfo as registryInfo,
+  apiRegistryList as registryList,
+  searchRegistry,
+  resolveSlug as registryResolve,
+  createPublishPR as registryPublish,
+  checkUpdates as registryCheckUpdates,
+  clearCache as registryClearCache,
+} from './api/registry.js'

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+describe('public API (index.js)', () => {
+  it('exports core install/list/remove/update', async () => {
+    const api = await import('./index.js')
+    assert.equal(typeof api.install, 'function')
+    assert.equal(typeof api.list, 'function')
+    assert.equal(typeof api.remove, 'function')
+    assert.equal(typeof api.update, 'function')
+  })
+
+  it('exports registry functions', async () => {
+    const api = await import('./index.js')
+    assert.equal(typeof api.registryInfo, 'function')
+    assert.equal(typeof api.registryList, 'function')
+    assert.equal(typeof api.searchRegistry, 'function')
+    assert.equal(typeof api.registryResolve, 'function')
+    assert.equal(typeof api.registryPublish, 'function')
+    assert.equal(typeof api.registryCheckUpdates, 'function')
+    assert.equal(typeof api.registryClearCache, 'function')
+  })
+
+  it('exports diff/compose/test', async () => {
+    const api = await import('./index.js')
+    assert.equal(typeof api.diff, 'function')
+    assert.equal(typeof api.compose, 'function')
+    assert.equal(typeof api.test, 'function')
+  })
+
+  it('exports mcp/profile functions', async () => {
+    const api = await import('./index.js')
+    assert.equal(typeof api.mcpInstall, 'function')
+    assert.equal(typeof api.mcpList, 'function')
+    assert.equal(typeof api.mcpUpdate, 'function')
+    assert.equal(typeof api.profileSave, 'function')
+    assert.equal(typeof api.profileApply, 'function')
+  })
+})

--- a/src/utils/registry-client.js
+++ b/src/utils/registry-client.js
@@ -1,0 +1,234 @@
+const REGISTRY_OWNER = 'rolecraft-sh'
+const REGISTRY_REPO = 'registry'
+const REGISTRY_BRANCH = 'main'
+const CACHE_TTL = 5 * 60 * 1000
+
+let runFetch = globalThis.fetch
+let cachedIndex = null
+let cacheTime = 0
+
+export function setRegistryFetch(fn) {
+  runFetch = fn
+}
+
+export function clearCache() {
+  cachedIndex = null
+  cacheTime = 0
+}
+
+function getToken() {
+  return process.env.GITHUB_TOKEN || process.env.GH_TOKEN || ''
+}
+
+function authHeaders(token) {
+  const h = { Accept: 'application/vnd.github.v3+json' }
+  const t = token || getToken()
+  if (t) h.Authorization = `Bearer ${t}`
+  return h
+}
+
+export async function fetchIndex(token) {
+  const now = Date.now()
+  if (cachedIndex && now - cacheTime < CACHE_TTL) return cachedIndex
+
+  const t = token || getToken()
+  const url = `https://api.github.com/repos/${REGISTRY_OWNER}/${REGISTRY_REPO}/contents/index.json?ref=${REGISTRY_BRANCH}`
+
+  const res = await runFetch(url, { headers: authHeaders(t) })
+  if (!res.ok) {
+    if (res.status === 403) {
+      const body = await res.json().catch(() => ({}))
+      if (body.message?.includes('rate limit')) {
+        throw new Error(
+          'GitHub API rate limit reached. Set GITHUB_TOKEN to increase limit.',
+        )
+      }
+      if (body.message?.includes('Not Found')) {
+        throw new Error(
+          `Registry not found: ${REGISTRY_OWNER}/${REGISTRY_REPO}`,
+        )
+      }
+    }
+    throw new Error(`Registry API error: ${res.status} — ${res.statusText}`)
+  }
+
+  const data = await res.json()
+  if (data.type !== 'file' || !data.content) {
+    throw new Error('Registry index.json is not a valid file')
+  }
+
+  const content = Buffer.from(data.content, 'base64').toString('utf-8')
+  const index = JSON.parse(content)
+
+  cachedIndex = index
+  cacheTime = now
+  return index
+}
+
+export async function searchRegistry(query) {
+  const index = await fetchIndex()
+  const q = query.toLowerCase()
+
+  return index.skills.filter((s) => {
+    if (s.slug?.toLowerCase().includes(q)) return true
+    if (s.name?.toLowerCase().includes(q)) return true
+    if (s.description?.toLowerCase().includes(q)) return true
+    return false
+  })
+}
+
+export async function resolveSlug(slug) {
+  const index = await fetchIndex()
+  const skill = index.skills.find((s) => s.slug === slug)
+  if (!skill) {
+    throw new Error(`Skill "${slug}" not found in registry`)
+  }
+  return skill
+}
+
+export async function createPublishPR(
+  { slug, name, repo, description, version },
+  token,
+) {
+  const t = token || getToken()
+  if (!t) {
+    throw new Error(
+      'GITHUB_TOKEN or GH_TOKEN environment variable is required to publish.\n' +
+        '  Create a token at: https://github.com/settings/tokens (scope: repo)\n' +
+        '  Then set: export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx',
+    )
+  }
+
+  const headers = authHeaders(t)
+  const ver = version || 'v1.0.0'
+
+  const userRes = await runFetch('https://api.github.com/user', { headers })
+  if (!userRes.ok)
+    throw new Error('GitHub authentication failed. Check your GITHUB_TOKEN.')
+  const user = await userRes.json()
+  const username = user.login
+
+  const getRes = await runFetch(
+    `https://api.github.com/repos/${REGISTRY_OWNER}/${REGISTRY_REPO}/contents/index.json?ref=${REGISTRY_BRANCH}`,
+    { headers },
+  )
+  if (!getRes.ok) throw new Error('Failed to fetch current registry index')
+  const fileData = await getRes.json()
+  const currentSha = fileData.sha
+  const currentContent = Buffer.from(fileData.content, 'base64').toString(
+    'utf-8',
+  )
+  const index = JSON.parse(currentContent)
+
+  const existing = index.skills.findIndex((s) => s.slug === slug)
+  const entry = {
+    slug,
+    name,
+    description: description || '',
+    repo,
+    author: username,
+    versions: [ver],
+    latest: ver,
+  }
+
+  if (existing >= 0) {
+    const old = index.skills[existing]
+    const allVersions = [...new Set([...old.versions, ver])]
+    entry.versions = allVersions
+    entry.latest = ver
+    index.skills[existing] = { ...old, ...entry }
+  } else {
+    index.skills.push(entry)
+  }
+
+  index.updated = new Date().toISOString()
+  const newContent = `${JSON.stringify(index, null, 2)}\n`
+  const branchName = `publish/${slug}-${ver.replace(/^v/, '')}`
+
+  const forkRes = await runFetch(
+    `https://api.github.com/repos/${REGISTRY_OWNER}/${REGISTRY_REPO}/forks`,
+    { method: 'POST', headers },
+  )
+  if (!forkRes.ok && forkRes.status !== 202) {
+    throw new Error(`Failed to fork registry: ${forkRes.status}`)
+  }
+
+  const branchRes = await runFetch(
+    `https://api.github.com/repos/${username}/${REGISTRY_REPO}/git/refs`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        ref: `refs/heads/${branchName}`,
+        sha: currentSha,
+      }),
+    },
+  )
+  if (!branchRes.ok) {
+    throw new Error(`Failed to create branch: ${branchRes.status}`)
+  }
+
+  const putRes = await runFetch(
+    `https://api.github.com/repos/${username}/${REGISTRY_REPO}/contents/index.json`,
+    {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({
+        message: `publish: ${slug} ${ver}`,
+        content: Buffer.from(newContent).toString('base64'),
+        sha: currentSha,
+        branch: branchName,
+      }),
+    },
+  )
+  if (!putRes.ok) {
+    const errBody = await putRes.text().catch(() => '')
+    throw new Error(
+      `Failed to update index.json: ${putRes.status}${errBody ? ` — ${errBody}` : ''}`,
+    )
+  }
+
+  const prRes = await runFetch(
+    `https://api.github.com/repos/${REGISTRY_OWNER}/${REGISTRY_REPO}/pulls`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        title: `publish: ${name} (${slug})`,
+        body: `Publishes **${name}** (\`${slug}\`) ${ver}\n\nRepo: \`${repo}\`\nAuthor: @${username}`,
+        head: `${username}:${branchName}`,
+        base: REGISTRY_BRANCH,
+      }),
+    },
+  )
+  if (!prRes.ok) {
+    const errBody = await prRes.text().catch(() => '')
+    throw new Error(
+      `Failed to create PR: ${prRes.status}${errBody ? ` — ${errBody}` : ''}`,
+    )
+  }
+
+  const pr = await prRes.json()
+  return { url: pr.html_url, number: pr.number }
+}
+
+export async function checkUpdates(skills) {
+  const index = await fetchIndex()
+  const updates = []
+
+  for (const local of skills) {
+    const registrySkill = index.skills.find((s) => s.slug === local.slug)
+    if (!registrySkill) continue
+
+    if (registrySkill.latest && registrySkill.latest !== local.version) {
+      updates.push({
+        slug: local.slug,
+        name: local.name,
+        current: local.version,
+        latest: registrySkill.latest,
+      })
+    }
+  }
+
+  return updates
+}

--- a/src/utils/registry-client.test.js
+++ b/src/utils/registry-client.test.js
@@ -1,0 +1,339 @@
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+let client
+
+before(async () => {
+  client = await import('./registry-client.js')
+})
+
+after(() => {
+  client.setRegistryFetch(globalThis.fetch)
+})
+
+function mockFetch(status, body) {
+  client.setRegistryFetch(() =>
+    Promise.resolve({
+      status,
+      ok: status >= 200 && status < 300,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+    }),
+  )
+}
+
+function mockSequentialFetch(responses) {
+  let idx = 0
+  client.setRegistryFetch(() => {
+    const resp = responses[idx]
+    if (resp) idx++
+    return Promise.resolve({
+      status: resp?.status || 200,
+      ok: resp?.status ? resp.status >= 200 && resp.status < 300 : true,
+      json: () => Promise.resolve(resp?.body || {}),
+      text: () => Promise.resolve(JSON.stringify(resp?.body || {})),
+    })
+  })
+}
+
+const sampleIndex = {
+  updated: '2026-07-23T15:00:00.000Z',
+  skills: [
+    {
+      slug: 'react-rules',
+      name: 'React Best Practices',
+      description: 'React code conventions',
+      repo: 'acme/react-rules',
+      author: 'acme',
+      versions: ['v1.0.0'],
+      latest: 'v1.0.0',
+      installs: 42,
+      stars: 10,
+    },
+    {
+      slug: 'testing-guide',
+      name: 'Testing Guide',
+      description: 'Testing best practices',
+      repo: 'acme/testing-guide',
+      author: 'acme',
+      versions: ['v1.0.0', 'v1.1.0'],
+      latest: 'v1.1.0',
+    },
+  ],
+}
+
+function base64Encode(obj) {
+  return Buffer.from(JSON.stringify(obj)).toString('base64')
+}
+
+describe('registry-client', () => {
+  beforeEach(() => {
+    client.clearCache()
+    client.setRegistryFetch(globalThis.fetch)
+  })
+
+  after(() => {
+    client.setRegistryFetch(globalThis.fetch)
+  })
+
+  describe('fetchIndex', () => {
+    it('fetches and caches the registry index', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      const result = await client.fetchIndex()
+      assert.equal(result.skills.length, 2)
+      assert.equal(result.skills[0].slug, 'react-rules')
+
+      const cached = await client.fetchIndex()
+      assert.equal(cached.skills.length, 2)
+    })
+
+    it('throws on non-ok response', async () => {
+      mockFetch(404, { message: 'Not Found' })
+
+      await assert.rejects(() => client.fetchIndex(), /Registry API error/)
+    })
+
+    it('throws on rate limit', async () => {
+      mockFetch(403, { message: 'API rate limit exceeded' })
+
+      await assert.rejects(() => client.fetchIndex(), /rate limit/)
+    })
+
+    it('throws on invalid file type', async () => {
+      mockFetch(200, {
+        type: 'symlink',
+        content: base64Encode(sampleIndex),
+      })
+
+      await assert.rejects(() => client.fetchIndex(), /not a valid file/)
+    })
+  })
+
+  describe('searchRegistry', () => {
+    it('searches by slug', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      const results = await client.searchRegistry('react')
+      assert.equal(results.length, 1)
+      assert.equal(results[0].slug, 'react-rules')
+    })
+
+    it('searches by name', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      const results = await client.searchRegistry('testing')
+      assert.equal(results.length, 1)
+      assert.equal(results[0].slug, 'testing-guide')
+    })
+
+    it('searches by description', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      const results = await client.searchRegistry('code conventions')
+      assert.equal(results.length, 1)
+    })
+
+    it('returns empty for no matches', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      const results = await client.searchRegistry('nonexistent')
+      assert.equal(results.length, 0)
+    })
+  })
+
+  describe('resolveSlug', () => {
+    it('resolves an existing slug', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      const result = await client.resolveSlug('react-rules')
+      assert.equal(result.repo, 'acme/react-rules')
+      assert.equal(result.latest, 'v1.0.0')
+    })
+
+    it('throws for unknown slug', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      await assert.rejects(
+        () => client.resolveSlug('unknown'),
+        /not found in registry/,
+      )
+    })
+  })
+
+  describe('createPublishPR', () => {
+    it('throws without token', async () => {
+      const origToken = process.env.GITHUB_TOKEN
+      delete process.env.GITHUB_TOKEN
+      delete process.env.GH_TOKEN
+
+      await assert.rejects(
+        () =>
+          client.createPublishPR({
+            slug: 'my-skill',
+            name: 'My Skill',
+            repo: 'user/my-skill',
+          }),
+        /GITHUB_TOKEN/,
+      )
+
+      if (origToken) process.env.GITHUB_TOKEN = origToken
+    })
+
+    it('creates PR with correct flow', async () => {
+      const origToken = process.env.GITHUB_TOKEN
+      process.env.GITHUB_TOKEN = 'test-token'
+
+      try {
+        const responses = [
+          {
+            // GET /user
+            status: 200,
+            body: { login: 'testuser' },
+          },
+          {
+            // GET index.json
+            status: 200,
+            body: {
+              type: 'file',
+              content: base64Encode(sampleIndex),
+              sha: 'abc123',
+            },
+          },
+          {
+            // POST /forks
+            status: 202,
+            body: {},
+          },
+          {
+            // POST /git/refs (create branch)
+            status: 201,
+            body: { ref: 'refs/heads/publish/my-skill-1.0.0' },
+          },
+          {
+            // PUT /contents/index.json
+            status: 200,
+            body: { content: {} },
+          },
+          {
+            // POST /pulls
+            status: 201,
+            body: {
+              html_url: 'https://github.com/rolecraft-sh/registry/pull/1',
+              number: 1,
+            },
+          },
+        ]
+
+        mockSequentialFetch(responses)
+
+        const result = await client.createPublishPR({
+          slug: 'my-skill',
+          name: 'My Skill',
+          repo: 'user/my-skill',
+          description: 'A test skill',
+          version: 'v1.0.0',
+        })
+
+        assert.equal(result.number, 1)
+        assert.ok(result.url.includes('pull/1'))
+      } finally {
+        if (origToken) process.env.GITHUB_TOKEN = origToken
+        else delete process.env.GITHUB_TOKEN
+      }
+    })
+
+    it('updates existing slug versions', async () => {
+      const origToken = process.env.GITHUB_TOKEN
+      process.env.GITHUB_TOKEN = 'test-token'
+
+      try {
+        const responses = [
+          { status: 200, body: { login: 'testuser' } },
+          {
+            status: 200,
+            body: {
+              type: 'file',
+              content: base64Encode(sampleIndex),
+              sha: 'abc123',
+            },
+          },
+          { status: 202, body: {} },
+          { status: 201, body: {} },
+          { status: 200, body: {} },
+          {
+            status: 201,
+            body: { html_url: 'https://github.com/pull/2', number: 2 },
+          },
+        ]
+
+        mockSequentialFetch(responses)
+
+        const result = await client.createPublishPR({
+          slug: 'testing-guide',
+          name: 'Testing Guide',
+          repo: 'acme/testing-guide',
+          version: 'v2.0.0',
+        })
+
+        assert.equal(result.number, 2)
+      } finally {
+        if (origToken) process.env.GITHUB_TOKEN = origToken
+        else delete process.env.GITHUB_TOKEN
+      }
+    })
+  })
+
+  describe('checkUpdates', () => {
+    it('detects available updates', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      const updates = await client.checkUpdates([
+        { slug: 'testing-guide', name: 'Testing Guide', version: 'v1.0.0' },
+        { slug: 'react-rules', name: 'React Rules', version: 'v1.0.0' },
+      ])
+
+      assert.equal(updates.length, 1)
+      assert.equal(updates[0].slug, 'testing-guide')
+      assert.equal(updates[0].current, 'v1.0.0')
+      assert.equal(updates[0].latest, 'v1.1.0')
+    })
+
+    it('returns empty when all up to date', async () => {
+      mockFetch(200, {
+        type: 'file',
+        content: base64Encode(sampleIndex),
+      })
+
+      const updates = await client.checkUpdates([
+        { slug: 'react-rules', name: 'React Rules', version: 'v1.0.0' },
+      ])
+
+      assert.equal(updates.length, 0)
+    })
+  })
+})

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -531,8 +531,17 @@ async function resolveAll(source) {
   if (isGitUrl(source)) {
     return await resolveGitUrlInternal(source)
   }
+
+  const { resolveSlug } = await import('./registry-client.js')
+  try {
+    const entry = await resolveSlug(source)
+    if (entry?.repo) {
+      return await resolveGitHubInternal(entry.repo)
+    }
+  } catch {}
+
   throw new Error(
-    `Invalid source: "${source}". Use a local path (./, /, ~), GitHub ref (owner/repo), git URL, or npm package (npm:package)`,
+    `Invalid source: "${source}". Use a local path (./, /, ~), GitHub ref (owner/repo), git URL, npm package (npm:package), or a registered skill slug`,
   )
 }
 


### PR DESCRIPTION
Adds community-driven skill registry powered by GitHub:\n\n- `rolecraft search <query> --registry` — search published skills\n- `rolecraft publish <source>` — publish skills to registry (fork + PR via GitHub API)\n- `rolecraft install <slug>` — install by registry slug (auto-resolves to repo)\n- `rolecraft check` — includes registry version checking\n- `src/utils/registry-client.js` — GitHub API wrapper (fetchIndex, searchRegistry, resolveSlug, createPublishPR, checkUpdates)\n- `src/api/registry.js` — programmatic API layer\n- Node.js API exports: registryInfo, registryList, searchRegistry, registryResolve, registryPublish, registryCheckUpdates\n- `rolecraft-sh/registry` repo: seed data, schema.json, GitHub Actions auto-validate + auto-merge\n- 40 new tests, 901 total, lint clean\n\nCloses #registry-mvp