### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v2.0.1] - 2026-07-24
+
+### Fixed
+- use upstream commit SHA for branch creation, add error bodies, document gh auth token
+
+### Changed
+- bump version to 2.0.1 (registry publish fix + npm pack hygiene)
+- bump github/codeql-action/analyze from 4.37.1 to 4.37.3 (#178)
+- bump github/codeql-action/init from 4.37.1 to 4.37.3 (#177)
+- release v2.0.0
+
+### Documentation
+- update publish success message to reflect maintainer review
+- add marketplace badge to CI guide
+- add Marketplace badge to CI section, fix agent count, add registry source link
+- complete v2.0.0 docs audit (api diff/compose/test, comparison, CHANGELOG dup fix)
 ## [v2.0.0] - 2026-07-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolecraft",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Install AI agent skills as roles & behaviors directly from any source — zero-dependency CLI for opencode, claude-code, cursor, and more",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This PR updates the changelog and version for `v2.0.1`.

## Changes
- Updated CHANGELOG.md with changes since the previous tag
- Updated package.json version to `v2.0.1`

> Auto-generated by the release-prep workflow.
