### PR TITLE
fix: strip YAML quotes, feat: add category to publish flow

### DIFF
--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -61,6 +61,7 @@ export async function publishCommand(source, options = {}) {
   const slug = options.slug || skill.slug
   const name = options.name || skill.name
   const description = options.description || skill.description || ''
+  const category = options.category || skill.category
 
   let repo = options.repo || ''
   if (!repo) {
@@ -94,6 +95,7 @@ export async function publishCommand(source, options = {}) {
   console.log(`  Skill:      ${name}`)
   console.log(`  Slug:       ${slug}`)
   console.log(`  Repo:       ${repo}`)
+  if (category) console.log(`  Category:   ${category}`)
   if (description) console.log(`  Description: ${description}`)
   console.log()
 
@@ -121,6 +123,7 @@ export async function publishCommand(source, options = {}) {
       name,
       repo,
       description,
+      category,
     })
     console.log(`\n✅ Published! PR #${result.number} created:`)
     console.log(`   ${result.url}`)

--- a/src/utils/registry-client.js
+++ b/src/utils/registry-client.js
@@ -90,7 +90,7 @@ export async function resolveSlug(slug) {
 }
 
 export async function createPublishPR(
-  { slug, name, repo, description, version },
+  { slug, name, repo, description, version, category },
   token,
 ) {
   const t = token || getToken()
@@ -141,6 +141,7 @@ export async function createPublishPR(
     versions: [ver],
     latest: ver,
   }
+  if (category) entry.category = category
 
   if (existing >= 0) {
     const old = index.skills[existing]

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -65,7 +65,7 @@ function isLocalPath(source) {
 }
 
 function parseMetadata(content) {
-  let name, slug, owner, description
+  let name, slug, owner, description, category
 
   const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
   if (frontmatterMatch) {
@@ -74,12 +74,14 @@ function parseMetadata(content) {
     const slugMatch = yaml.match(/^slug:\s*(\S+)$/m)
     const ownerMatch = yaml.match(/^owner:\s*(\S+)$/m)
     const descMatch = yaml.match(/^description:\s*(.+)$/m)
+    const catMatch = yaml.match(/^metadata:\n\s+category:\s*(\S+)$/m)
 
     name = nameMatch?.[1]?.trim() || 'unknown'
     slug = slugMatch?.[1] || name
     owner = ownerMatch?.[1] || 'local'
     description =
       descMatch?.[1]?.trim().replace(/^["'](.*)["']$/, '$1') || undefined
+    category = catMatch?.[1] || undefined
   }
 
   if (!slug) {
@@ -92,7 +94,7 @@ function parseMetadata(content) {
     owner = oldOwnerMatch?.[1] || 'local'
   }
 
-  return { name, slug, owner, description }
+  return { name, slug, owner, description, category }
 }
 
 async function readFileContents(skillDir) {

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -78,7 +78,8 @@ function parseMetadata(content) {
     name = nameMatch?.[1]?.trim() || 'unknown'
     slug = slugMatch?.[1] || name
     owner = ownerMatch?.[1] || 'local'
-    description = descMatch?.[1]?.trim() || undefined
+    description =
+      descMatch?.[1]?.trim().replace(/^["'](.*)["']$/, '$1') || undefined
   }
 
   if (!slug) {

--- a/src/utils/resolver.test.js
+++ b/src/utils/resolver.test.js
@@ -345,6 +345,42 @@ Just content
       assert.equal(r.owner, 'local')
       assert.equal(r.description, undefined)
     })
+
+    it('parses metadata.category from YAML frontmatter', async () => {
+      const d = join(tempDir, 'meta6')
+      mkdirSync(d, { recursive: true })
+      writeFileSync(
+        join(d, 'SKILL.md'),
+        `---
+name: cat-skill
+slug: cat-skill
+metadata:
+  category: development
+---
+
+Content
+`,
+      )
+      const r = await resolverModule.resolveSource(d)
+      assert.equal(r.category, 'development')
+    })
+
+    it('returns undefined category when not in frontmatter', async () => {
+      const d = join(tempDir, 'meta7')
+      mkdirSync(d, { recursive: true })
+      writeFileSync(
+        join(d, 'SKILL.md'),
+        `---
+name: no-cat
+slug: no-cat
+---
+
+Content
+`,
+      )
+      const r = await resolverModule.resolveSource(d)
+      assert.equal(r.category, undefined)
+    })
   })
 
   describe('resolveSkills', () => {


### PR DESCRIPTION
**Fixes**\n- YAML quote stripping in resolver (description: \"...\" → description)\n- Multi-line description workaround (SKILL.md)\n\n**Feat**\n- category support in publish flow: resolver parses metadata.category, publish displays + passes it, registry-client includes it in registry entry\n\n**Changes**\n- src/utils/resolver.js: strip YAML quotes, add category parsing\n- src/commands/publish.js: display + pass category to createPublishPR\n- src/utils/registry-client.js: include category in registry entry\n- src/utils/resolver.test.js: tests for category parsing