### PR TITLE
feat: add agents capability manifest command and generated agent docs

### DIFF
--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -18,6 +18,7 @@ import { bundleCommand, bundleCreateCommand } from '../src/commands/bundle.js'
 import { completionsCommand } from '../src/commands/completions.js'
 import { upgradeCommand } from '../src/commands/upgrade.js'
 import { doctorCommand } from '../src/commands/doctor.js'
+import { agentsCommand } from '../src/commands/agents.js'
 import { agentsXmlCommand } from '../src/commands/agents-xml.js'
 import { mcpCommand } from '../src/commands/mcp.js'
 import { watchCommand } from '../src/commands/watch.js'
@@ -72,6 +73,8 @@ Usage:
   rolecraft mcp check               Check for MCP server updates
   rolecraft mcp update <name>       Update an MCP server
   rolecraft mcp remove <name>       Remove an MCP server
+  rolecraft agents                  Show agent capability manifest
+  rolecraft agents --json            Output manifest as JSON
   rolecraft agents-xml              Generate skills XML for AGENTS.md
   rolecraft agents-xml --write      Write skills XML to AGENTS.md
   rolecraft upgrade                 Upgrade rolecraft to the latest version
@@ -434,6 +437,14 @@ export async function main() {
       await new Promise(() => {})
       break
     }
+
+    case 'agents':
+      if (args.includes('--help') || args.includes('-h')) {
+        usage()
+        return
+      }
+      await agentsCommand({ json: args.includes('--json') })
+      break
 
     case 'agents-xml':
       if (args.includes('--help') || args.includes('-h')) {

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -28,7 +28,7 @@ export default defineConfig({
       ]},
       { text: 'Install', link: '/install' },
       { text: 'Docs', items: [
-        { text: 'Commands', link: '/commands/install' },
+        { text: 'Commands', link: '/commands/agents' },
         { text: 'API', link: '/api' },
         { text: 'Reference', link: '/reference' },
         { text: 'Registry', link: '/commands/registry' },
@@ -55,6 +55,7 @@ export default defineConfig({
         {
           text: 'Commands',
           items: [
+            { text: 'agents', link: '/commands/agents' },
             { text: 'agents-xml', link: '/commands/agents-xml' },
             { text: 'bundle', link: '/commands/bundle' },
             { text: 'convert', link: '/commands/convert' },

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -2,96 +2,106 @@
 
 rolecraft knows where each AI agent looks for skills. When you use a flag like `--claude` or `--cursor`, it installs to the correct directory for that agent.
 
-| Agent       | Directory                                      |
-| ----------- | ---------------------------------------------- |
-| opencode    | `~/.agents/skills/` or `./.agents/skills/`     |
-| claude-code | `~/.claude/skills/` or `./.claude/skills/`     |
-| cursor      | `~/.cursor/skills/` or `./.cursor/skills/`     |
-| windsurf ⚠️ | `~/.windsurf/skills/` or `./.windsurf/skills/` |
-| devin       | `~/.devin/skills/` or `./.devin/skills/`       |
-| codex       | `~/.codex/skills/` or `./.codex/skills/`       |
-| copilot     | `./.github/copilot/skills/` or `~/.copilot/skills/` |
-| aider       | `~/.aider/skills/` or `./.aider/skills/`       |
-| cline       | `~/.cline/skills/` or `./.cline/skills/`       |
-| gemini-cli  | `~/.gemini/skills/`                            |
-| cody        | `~/.cody/skills/`                              |
-| continue    | `~/.continue/skills/`                          |
-| warp        | `~/.warp/skills/`                              |
-| codeium     | `~/.codeium/skills/`                           |
-| fabric      | `~/.fabric/skills/`                            |
-| goose       | `~/.goose/skills/`                             |
-| tabnine     | `~/.tabnine/skills/`                           |
-| supermaven  | `~/.supermaven/skills/`                        |
-| pr-pilot    | `~/.pr-pilot/skills/`                          |
-| loom        | `~/.loom/skills/`                              |
-| roo         | `~/.roo/skills/`                               |
-| trae        | `~/.trae/skills/`                              |
-| hermes      | `~/.hermes/skills/`                            |
-| kiro        | `~/.kiro/skills/`                              |
-| augment     | `~/.augment/skills/`                           |
-| kilo        | `~/.kilo/skills/`                              |
-| openhands   | `~/.openhands/skills/`                         |
-| junie       | `~/.junie/skills/`                             |
-| factory     | `~/.factory/skills/`                             |
-| command-code | `~/.commandcode/skills/`                        |
-| cortex      | `~/.snowflake/cortex/skills/`                   |
-| mistral-vibe | `~/.vibe/skills/`                              |
-| qwen-code   | `~/.qwen/skills/`                               |
-| openclaw    | `~/.openclaw/skills/`                           |
-| codebuddy   | `~/.codebuddy/skills/`                          |
-| mux         | `~/.mux/skills/`                                |
-| pi          | `~/.pi/agent/skills/`                           |
-| autohand-code | `~/.autohand/skills/`                         |
-| rovo        | `~/.rovodev/skills/`                            |
-| firebender  | `~/.firebender/skills/`                         |
-| bob         | `~/.bob/skills/`                                |
-| aider-desk  | `~/.aider-desk/skills/`                         |
-| zap             | `~/.zap/skills/`                                  |
-| codeep          | `~/.codeep/skills/`                               |
-| kimi-code       | `~/.kimi-code/skills/`                            |
-| zcode           | `~/.zcode/skills/`                                |
-| code-arts-doer  | `~/.codeartsdoer/skills/`                         |
-| code-maker      | `~/.codemaker/skills/`                            |
-| code-studio     | `~/.codestudio/skills/`                           |
-| crush           | `~/.crush/skills/`                                |
-| eve             | `./agent/skills/`                                 |
-| forge           | `~/.forge/skills/`                                |
-| inference-sh    | `~/.inferencesh/skills/`                          |
-| jazz            | `~/.jazz/skills/`                                 |
-| iflow           | `~/.iflow/skills/`                                |
-| kilo-code       | `~/.kilocode/skills/`                             |
-| kode            | `~/.kode/skills/`                                 |
-| lingma          | `~/.lingma/skills/`                               |
-| mcp-jam         | `~/.mcpjam/skills/`                               |
-| moxby           | `~/.moxby/skills/`                                |
-| ona             | `~/.ona/skills/`                                  |
-| qoder           | `~/.qoder/skills/`                                |
-| reasonix        | `~/.reasonix/skills/`                             |
-| terra-mind      | `~/.terramind/skills/`                            |
-| tiny-cloud      | `~/.tinycloud/skills/`                            |
-| zencoder        | `~/.zencoder/skills/`                             |
-| amp             | `~/.agents/skills/`                               |
-| antigravity     | `~/.agents/skills/`                               |
-| antigravity-cli | `~/.agents/skills/`                               |
-| deep-agents     | `~/.agents/skills/`                               |
-| dexto           | `~/.agents/skills/`                               |
-| loaf            | `~/.agents/skills/`                               |
-| replit          | `~/.agents/skills/`                               |
-| zed             | `~/.agents/skills/`                               |
-| promptscript    | `./agent/skills/`                                 |
-| astrbot         | `~/.astrbot/data/skills/`                         |
-| qoder-cn        | `~/.qoder-cn/skills/`                             |
-| trae-cn         | `~/.trae-cn/skills/`                              |
-| zenflow         | `~/.zencoder/skills/`                             |
-| neovate         | `~/.neovate/skills/`                              |
-| pochi           | `~/.pochi/skills/`                                |
-| adal            | `~/.adal/skills/`                                 |
-| droid           | `~/.factory/skills/`                              |
-| chatgpt         | `~/.chatgpt/skills/`                              |
-| codearts-agent  | `~/.codeartsdoer/skills/`                         |
-| universal       | `~/.config/agents/skills/`                        |
+| Agent | Directory | Support | MCP |
+| ----- | --------- | ------- | --- |
+| opencode | `~/.agents/skills/ or ./.agents/skills/` | verified | - |
+| claude-code | `~/.claude/skills/ or ./.claude/skills/` | verified | mcpServers |
+| cursor | `~/.cursor/skills/ or ./.cursor/skills/` | verified | mcpServers |
+| windsurf | `~/.windsurf/skills/ or ./.windsurf/skills/` | community | mcpServers |
+| devin | `~/.devin/skills/ or ./.devin/skills/` | experimental | - |
+| codex | `~/.codex/skills/ or ./.codex/skills/` | community | - |
+| copilot | `./.github/copilot/skills/ or ~/.copilot/skills/` | legacy | - |
+| aider | `~/.aider/skills/ or ./.aider/skills/` | experimental | - |
+| cline | `~/.cline/skills/ or ./.cline/skills/` | experimental | - |
+| gemini-cli | `~/.gemini/skills/` | experimental | - |
+| cody | `~/.cody/skills/ or ./.cody/skills/` | experimental | - |
+| continue | `~/.continue/skills/ or ./.continue/skills/` | community | experimental.mcpServers |
+| warp | `~/.warp/skills/` | experimental | - |
+| codeium | `~/.codeium/skills/` | experimental | - |
+| fabric | `~/.fabric/skills/` | experimental | - |
+| goose | `~/.goose/skills/` | experimental | - |
+| tabnine | `~/.tabnine/skills/` | experimental | - |
+| supermaven | `~/.supermaven/skills/` | experimental | - |
+| pr-pilot | `~/.pr-pilot/skills/` | experimental | - |
+| loom | `~/.loom/skills/` | experimental | - |
+| roo | `~/.roo/skills/` | experimental | - |
+| trae | `~/.trae/skills/` | experimental | - |
+| hermes | `~/.hermes/skills/` | experimental | - |
+| kiro | `~/.kiro/skills/` | experimental | - |
+| augment | `~/.augment/skills/` | experimental | - |
+| kilo | `~/.kilo/skills/` | experimental | - |
+| openhands | `~/.openhands/skills/` | experimental | - |
+| junie | `~/.junie/skills/` | experimental | - |
+| factory | `~/.factory/skills/` | experimental | - |
+| command-code | `~/.commandcode/skills/` | experimental | - |
+| cortex | `~/.snowflake/cortex/skills/` | experimental | - |
+| mistral-vibe | `~/.vibe/skills/` | experimental | - |
+| qwen-code | `~/.qwen/skills/` | experimental | - |
+| openclaw | `~/.openclaw/skills/` | experimental | - |
+| codebuddy | `~/.codebuddy/skills/` | experimental | - |
+| mux | `~/.mux/skills/` | experimental | - |
+| pi | `~/.pi/agent/skills/` | experimental | - |
+| autohand-code | `~/.autohand/skills/` | experimental | - |
+| rovo-dev | `~/.rovodev/skills/` | experimental | - |
+| firebender | `~/.firebender/skills/` | experimental | - |
+| ibm-bob | `~/.bob/skills/` | experimental | - |
+| aider-desk | `~/.aider-desk/skills/` | experimental | - |
+| code-arts-doer | `~/.codeartsdoer/skills/` | experimental | - |
+| code-maker | `~/.codemaker/skills/` | experimental | - |
+| code-studio | `~/.codestudio/skills/` | experimental | - |
+| crush | `~/.crush/skills/` | experimental | - |
+| eve | `./agent/skills/` | experimental | - |
+| forge | `~/.forge/skills/` | experimental | - |
+| inference-sh | `~/.inferencesh/skills/` | experimental | - |
+| jazz | `~/.jazz/skills/` | experimental | - |
+| iflow | `~/.iflow/skills/` | experimental | - |
+| kilo-code | `~/.kilocode/skills/` | experimental | - |
+| kode | `~/.kode/skills/` | experimental | - |
+| lingma | `~/.lingma/skills/` | experimental | - |
+| mcp-jam | `~/.mcpjam/skills/` | experimental | - |
+| moxby | `~/.moxby/skills/` | experimental | - |
+| ona | `~/.ona/skills/` | experimental | - |
+| qoder | `~/.qoder/skills/` | experimental | - |
+| reasonix | `~/.reasonix/skills/` | experimental | - |
+| terra-mind | `~/.terramind/skills/` | experimental | - |
+| tiny-cloud | `~/.tinycloud/skills/` | experimental | - |
+| zencoder | `~/.zencoder/skills/` | experimental | - |
+| zap | `~/.zap/skills/` | experimental | - |
+| codeep | `~/.codeep/skills/` | experimental | - |
+| kimi-code | `~/.kimi-code/skills/` | experimental | - |
+| zcode | `~/.zcode/skills/` | experimental | - |
+| astrbot | `~/.astrbot/data/skills/` | experimental | - |
+| qoder-cn | `~/.qoder-cn/skills/` | experimental | - |
+| trae-cn | `~/.trae-cn/skills/` | experimental | - |
+| zenflow | `~/.zencoder/skills/` | experimental | - |
+| neovate | `~/.neovate/skills/` | experimental | - |
+| pochi | `~/.pochi/skills/` | experimental | - |
+| adal | `~/.adal/skills/` | experimental | - |
+| droid | `~/.factory/skills/` | experimental | - |
+| chatgpt | `~/.chatgpt/skills/` | experimental | - |
+| codearts-agent | `~/.codeartsdoer/skills/` | experimental | - |
+| universal | `~/.config/agents/skills/` | experimental | - |
+| amp | `~/.agents/skills/` | experimental | - |
+| antigravity | `~/.agents/skills/` | experimental | - |
+| antigravity-cli | `~/.agents/skills/` | experimental | - |
+| deep-agents | `~/.agents/skills/` | experimental | - |
+| dexto | `~/.agents/skills/` | experimental | - |
+| loaf | `~/.agents/skills/` | experimental | - |
+| replit | `~/.agents/skills/` | experimental | - |
+| zed | `~/.agents/skills/` | experimental | - |
+| promptscript | `./agent/skills/` | experimental | - |
 
-> ⚠️ Windsurf has been rebranded to **Devin Desktop**. The `--windsurf` flag and `~/.windsurf/skills/` path still work for backward compatibility, but new deployments should use `--devin` / `~/.devin/skills/`.
+> **Support levels:** `verified` — actively tested and maintained; `community` — community-contributed, maintained on best-effort; `legacy` — previous generation, no active development; `experimental` — known to exist, not formally tested.
+
+> **MCP support:** 4 agent(s) support MCP server configuration. Format: `mcpServers`, `experimental.mcpServers`
+
+> **Agent count:** 86 total — 3 verified, 3 community, 1 legacy, 79 experimental.
+
+## Notes
+
+- **windsurf:** Rebranded to Devin Desktop; use --devin flag for new deployments
+- **devin:** Desktop agent with limited MCP support
+- **copilot:** MCP support planned but not yet implemented
 
 ## Install to multiple agents
 

--- a/docs/commands/agents.md
+++ b/docs/commands/agents.md
@@ -1,0 +1,103 @@
+# `rolecraft agents`
+
+Display the agent capability manifest — a structured overview of all supported AI coding agents, their skill install directories, support levels, and MCP server configuration support.
+
+## Usage
+
+```bash
+rolecraft agents
+
+# Output as JSON
+rolecraft agents --json
+```
+
+## Description
+
+The `agents` command reads the agent capability manifest — a single source of truth for agent support metadata — and displays it in a human-readable table or machine-readable JSON.
+
+Each agent entry includes:
+
+| Field | Description |
+|-------|-------------|
+| `flag` | CLI flag used with install (e.g. `--claude`, `--cursor`) |
+| `name` | Agent identifier |
+| `skillInstallScope` | Where skills are installed (global path or project path) |
+| `supportLevel` | `verified`, `community`, `legacy`, or `experimental` |
+| `mcpSupport` | Whether MCP servers are supported and in which config format |
+| `instructionFormat` | Skill instruction file format (`skill-md`, `mdc`, `agents-md`, etc.) |
+| `docUrl` | Official documentation URL |
+| `lastVerified` | Last verification date (ISO date) |
+
+## Support levels
+
+| Level | Meaning |
+|-------|---------|
+| `verified` | Actively tested and maintained by the RoleCraft team |
+| `community` | Community-contributed; maintained on best-effort basis |
+| `legacy` | Previous generation agent; no active development |
+| `experimental` | Known to exist; not formally tested |
+
+## Example output
+
+```bash
+$ rolecraft agents
+
+Agent Capability Manifest
+=========================
+
+VERIFIED (3)
+  opencode     ~/.agents/skills/         MCP: -
+  claude-code  ~/.claude/skills/         MCP: mcpServers
+  cursor       ~/.cursor/skills/         MCP: mcpServers
+
+COMMUNITY (3)
+  windsurf     ~/.windsurf/skills/       MCP: mcpServers
+  codex        ~/.codex/skills/          MCP: -
+  continue     ~/.continue/skills/       MCP: experimental.mcpServers
+
+LEGACY (1)
+  copilot      ./.github/copilot/skills/  MCP: -
+
+EXPERIMENTAL (79)
+  aider        ~/.aider/skills/          MCP: -
+  cline        ~/.cline/skills/          MCP: -
+  ...
+```
+
+```bash
+$ rolecraft agents --json
+
+{
+  "version": "1.0",
+  "generated": "2026-07-28",
+  "agentCount": 86,
+  "agents": [
+    {
+      "flag": "claude",
+      "name": "claude-code",
+      "label": "~/.claude/skills/",
+      "skillInstallScope": "global ~/.claude/skills",
+      "supportLevel": "verified",
+      "mcpSupport": {
+        "supported": true,
+        "format": "mcpServers",
+        "configPath": "~/.claude.json"
+      },
+      "instructionFormat": "skill-md",
+      "docUrl": "https://docs.anthropic.com/en/docs/claude-code",
+      "lastVerified": "2026-07-27"
+    }
+  ]
+}
+```
+
+## Node.js API
+
+This command is also available as programmatic functions. See the [Node.js API documentation](../api.md) for detailed usage.
+
+```js
+import { getAgentManifest, validateManifest } from 'rolecraft'
+
+const agents = getAgentManifest()
+const validation = validateManifest()
+```

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "test:coverage": "node --experimental-test-coverage --test --test-coverage-exclude=\"**/*.test.js\" --test-coverage-include=\"src/**\" --test-coverage-include=\"bin/**\"",
     "setup-hooks": "node scripts/setup-hooks.mjs",
     "postinstall": "node scripts/setup-hooks.mjs || true",
+    "generate:agents-docs": "node scripts/generate-agents-docs.js",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/scripts/generate-agents-docs.js
+++ b/scripts/generate-agents-docs.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getAgentManifest, SUPPORT_LEVELS } from '../src/agents/manifest.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const docsPath = join(__dirname, '..', 'docs', 'agents.md')
+
+const DUAL_PATH_AGENTS = new Set([
+  'opencode',
+  'claude-code',
+  'cursor',
+  'windsurf',
+  'devin',
+  'codex',
+  'aider',
+  'cline',
+  'cody',
+  'continue',
+])
+
+const NAME_TO_DIR = {
+  'claude-code': 'claude',
+  opencode: 'agents',
+}
+
+function formatDirLabel(agent) {
+  if (agent.name === 'copilot') {
+    return './.github/copilot/skills/ or ~/.copilot/skills/'
+  }
+  if (DUAL_PATH_AGENTS.has(agent.name)) {
+    const homePath = agent.label
+    const projName = NAME_TO_DIR[agent.name] || agent.name
+    const projPath = `./.${projName}/skills/`
+    return `${homePath} or ${projPath}`
+  }
+  return agent.label
+}
+
+function formatSupportLevel(level) {
+  switch (level) {
+    case SUPPORT_LEVELS.VERIFIED:
+      return 'verified'
+    case SUPPORT_LEVELS.COMMUNITY:
+      return 'community'
+    case SUPPORT_LEVELS.LEGACY:
+      return 'legacy'
+    case SUPPORT_LEVELS.EXPERIMENTAL:
+      return 'experimental'
+    default:
+      return level
+  }
+}
+
+function formatMcp(agent) {
+  if (!agent.mcpSupport.supported) return '-'
+  return agent.mcpSupport.format
+}
+
+/**
+ * Generate docs/agents.md content from manifest data
+ */
+export function generateAgentsDocs() {
+  const manifest = getAgentManifest()
+  const groups = {
+    verified: [],
+    community: [],
+    legacy: [],
+    experimental: [],
+  }
+  for (const agent of manifest) {
+    const level = agent.supportLevel
+    if (groups[level]) groups[level].push(agent)
+  }
+
+  const mcpAgents = manifest.filter((a) => a.mcpSupport.supported)
+
+  const agentCount = manifest.length
+  const verifiedCount = groups.verified.length
+  const communityCount = groups.community.length
+  const legacyCount = groups.legacy.length
+  const experimentalCount = groups.experimental.length
+
+  const header = `# Agent Discovery Paths
+
+rolecraft knows where each AI agent looks for skills. When you use a flag like \`--claude\` or \`--cursor\`, it installs to the correct directory for that agent.
+
+| Agent | Directory | Support | MCP |
+| ----- | --------- | ------- | --- |
+`
+
+  const rows = manifest
+    .map((agent) => {
+      const dir = formatDirLabel(agent)
+      const support = formatSupportLevel(agent.supportLevel)
+      const mcp = formatMcp(agent)
+      return `| ${agent.name} | \`${dir}\` | ${support} | ${mcp} |`
+    })
+    .join('\n')
+
+  const notes = manifest.filter((a) => a.notes)
+  const notesSection =
+    notes.length > 0
+      ? `\n## Notes\n\n${notes.map((a) => `- **${a.name}:** ${a.notes}`).join('\n')}\n`
+      : ''
+
+  const mcpFormats = [...new Set(mcpAgents.map((a) => a.mcpSupport.format))]
+
+  const footer = `
+
+> **Support levels:** \`verified\` — actively tested and maintained; \`community\` — community-contributed, maintained on best-effort; \`legacy\` — previous generation, no active development; \`experimental\` — known to exist, not formally tested.
+
+> **MCP support:** ${mcpAgents.length} agent(s) support MCP server configuration${mcpFormats.length > 0 ? `. Format: \`${mcpFormats.join('`, `')}\`` : '.'}
+
+> **Agent count:** ${agentCount} total — ${verifiedCount} verified, ${communityCount} community, ${legacyCount} legacy, ${experimentalCount} experimental.
+${notesSection}
+## Install to multiple agents
+
+\`\`\`bash
+rolecraft install ./my-skill --cursor --devin --copilot --gemini --cody
+\`\`\`
+`
+
+  return header + rows + footer
+}
+
+function main() {
+  const md = generateAgentsDocs()
+  writeFileSync(docsPath, md, 'utf-8')
+  const sizeKb = (Buffer.byteLength(md, 'utf-8') / 1024).toFixed(1)
+  console.log(
+    `Generated docs/agents.md (${sizeKb} KB, ${getAgentManifest().length} agents)`,
+  )
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/src/agents.js
+++ b/src/agents.js
@@ -564,8 +564,31 @@ for (const a of AGENTS_DATA) {
   }
 }
 
+import {
+  getAgentManifest,
+  getAgentManifestByFlag,
+  getAgentsBySupportLevel,
+  getAgentsWithMcp,
+  validateManifest,
+  SUPPORT_LEVELS,
+  INSTRUCTION_FORMATS,
+  MCP_CONFIG_FORMATS,
+} from './agents/manifest.js'
+
 export function getAgentByFlag(flag) {
   return AGENTS_DATA.find((a) => a.flag === flag)
+}
+
+// Re-export manifest functions
+export {
+  getAgentManifest,
+  getAgentManifestByFlag,
+  getAgentsBySupportLevel,
+  getAgentsWithMcp,
+  validateManifest,
+  SUPPORT_LEVELS,
+  INSTRUCTION_FORMATS,
+  MCP_CONFIG_FORMATS,
 }
 
 export default AGENTS_DATA

--- a/src/agents/manifest.js
+++ b/src/agents/manifest.js
@@ -1,0 +1,356 @@
+/**
+ * Agent Capability Manifest
+ * Single source of truth for agent support levels, MCP configuration,
+ * instruction format, documentation URLs, and verification metadata.
+ */
+
+import agents from '../agents.js'
+
+// Support level definitions
+export const SUPPORT_LEVELS = {
+  VERIFIED: 'verified',
+  COMMUNITY: 'community',
+  LEGACY: 'legacy',
+  EXPERIMENTAL: 'experimental',
+}
+
+// Instruction format types
+export const INSTRUCTION_FORMATS = {
+  SKILL_MD: 'skill-md', // SKILL.md with frontmatter
+  MDC: 'mdc', // VS Code style .mdc files
+  AGENTS_MD: 'agents-md', // AGENTS.md format
+  CUSTOM: 'custom',
+}
+
+// MCP configuration formats
+export const MCP_CONFIG_FORMATS = {
+  STANDARD: 'mcpServers', // Standard mcpServers format
+  CONTINUE: 'experimental.mcpServers', // Continue.dev format
+  COPILOT: 'servers', // GitHub Copilot format
+}
+
+/**
+ * Agent capability manifest data
+ * Each agent has structured metadata including:
+ * - skillInstallScope: where skills are installed
+ * - mcpSupport: MCP configuration support and format
+ * - instructionFormat: skill instruction format support
+ * - supportLevel: verified/community/legacy/experimental
+ * - docUrl: official documentation URL
+ * - lastVerified: last verification date (ISO date string)
+ */
+const MANIFEST_DATA = {
+  opencode: {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.VERIFIED,
+    docUrl: 'https://opencode.ai/docs',
+    lastVerified: '2026-07-20',
+  },
+  'claude-code': {
+    skillInstallScope: 'global ~/.claude/skills',
+    mcpSupport: {
+      supported: true,
+      format: MCP_CONFIG_FORMATS.STANDARD,
+      configPath: '~/.claude.json',
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.VERIFIED,
+    docUrl: 'https://docs.anthropic.com/en/docs/claude-code',
+    lastVerified: '2026-07-27',
+  },
+  cursor: {
+    skillInstallScope: 'global ~/.cursor/skills',
+    mcpSupport: {
+      supported: true,
+      format: MCP_CONFIG_FORMATS.STANDARD,
+      configPath: '~/.cursor/mcp_config.json',
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.VERIFIED,
+    docUrl: 'https://cursor.com/docs',
+    lastVerified: '2026-07-22',
+  },
+  windsurf: {
+    skillInstallScope: 'global ~/.windsurf/skills',
+    mcpSupport: {
+      supported: true,
+      format: MCP_CONFIG_FORMATS.STANDARD,
+      configPath: '~/.windsurf/mcp_config.json',
+    },
+    instructionFormat: INSTRUCTION_FORMATS.MDC,
+    supportLevel: SUPPORT_LEVELS.COMMUNITY,
+    docUrl: 'https://docs.windsurf.com',
+    lastVerified: '2026-07-15',
+    notes: 'Rebranded to Devin Desktop; use --devin flag for new deployments',
+  },
+  devin: {
+    skillInstallScope: 'global ~/.devin/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://devin.ai/docs',
+    lastVerified: '2026-07-10',
+    notes: 'Desktop agent with limited MCP support',
+  },
+  codex: {
+    skillInstallScope: 'global ~/.codex/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.COMMUNITY,
+    docUrl: 'https://openai.github.io/codex/',
+    lastVerified: '2026-07-18',
+  },
+  copilot: {
+    skillInstallScope: 'project ./.github/copilot/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.CUSTOM,
+    supportLevel: SUPPORT_LEVELS.LEGACY,
+    docUrl: 'https://docs.github.com/en/copilot',
+    lastVerified: '2026-06-30',
+    notes: 'MCP support planned but not yet implemented',
+  },
+  continue: {
+    skillInstallScope: 'global ~/.continue/skills',
+    mcpSupport: {
+      supported: true,
+      format: MCP_CONFIG_FORMATS.CONTINUE,
+      configPath: '~/.continue/config.json',
+    },
+    instructionFormat: INSTRUCTION_FORMATS.AGENTS_MD,
+    supportLevel: SUPPORT_LEVELS.COMMUNITY,
+    docUrl: 'https://docs.continue.dev',
+    lastVerified: '2026-07-12',
+  },
+  // Agents sharing .agents/skills directory
+  amp: {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://ampcode.com/docs',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
+  },
+  antigravity: {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://github.com/daniel-e/agents',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
+  },
+  'antigravity-cli': {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://github.com/daniel-e/agents',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
+  },
+  'deep-agents': {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://github.com/daniel-e/deep-agents',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
+  },
+  dexto: {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://dexto.ai',
+    lastVerified: '2026-07-26',
+    aliasFor: 'opencode',
+  },
+  loaf: {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://github.com/loaf-ai/loaf',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
+  },
+  replit: {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://replit.com/docs',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
+  },
+  zed: {
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: false,
+      format: null,
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: 'https://zed.dev/docs',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
+  },
+}
+
+/**
+ * Get full agent manifest with capability data
+ * Merges manifest data with AGENTS_DATA from agents.js
+ */
+export function getAgentManifest() {
+  const manifest = []
+
+  for (const agent of agents) {
+    const name = agent.name
+    const manifestEntry = MANIFEST_DATA[name] || {}
+
+    manifest.push({
+      flag: agent.flag,
+      name: agent.name,
+      label: agent.label,
+      skillInstallScope: manifestEntry.skillInstallScope || 'unknown',
+      mcpSupport: manifestEntry.mcpSupport || {
+        supported: false,
+        format: null,
+      },
+      instructionFormat:
+        manifestEntry.instructionFormat || INSTRUCTION_FORMATS.CUSTOM,
+      supportLevel: manifestEntry.supportLevel || SUPPORT_LEVELS.EXPERIMENTAL,
+      docUrl: manifestEntry.docUrl || null,
+      lastVerified: manifestEntry.lastVerified || null,
+      notes: manifestEntry.notes || null,
+      aliasFor: manifestEntry.aliasFor || null,
+    })
+  }
+
+  return manifest
+}
+
+/**
+ * Get agent by flag with full manifest data
+ */
+export function getAgentManifestByFlag(flag) {
+  for (const agent of agents) {
+    if (agent.flag === flag) {
+      const manifestEntry = MANIFEST_DATA[agent.name] || {}
+      return {
+        flag: agent.flag,
+        name: agent.name,
+        label: agent.label,
+        skillInstallScope: manifestEntry.skillInstallScope || 'unknown',
+        mcpSupport: manifestEntry.mcpSupport || {
+          supported: false,
+          format: null,
+        },
+        instructionFormat:
+          manifestEntry.instructionFormat || INSTRUCTION_FORMATS.CUSTOM,
+        supportLevel: manifestEntry.supportLevel || SUPPORT_LEVELS.EXPERIMENTAL,
+        docUrl: manifestEntry.docUrl || null,
+        lastVerified: manifestEntry.lastVerified || null,
+        notes: manifestEntry.notes || null,
+        aliasFor: manifestEntry.aliasFor || null,
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Get agents grouped by support level
+ */
+export function getAgentsBySupportLevel() {
+  const groups = {
+    [SUPPORT_LEVELS.VERIFIED]: [],
+    [SUPPORT_LEVELS.COMMUNITY]: [],
+    [SUPPORT_LEVELS.LEGACY]: [],
+    [SUPPORT_LEVELS.EXPERIMENTAL]: [],
+  }
+
+  for (const agent of getAgentManifest()) {
+    const level = agent.supportLevel
+    if (groups[level]) {
+      groups[level].push(agent)
+    }
+  }
+
+  return groups
+}
+
+/**
+ * Get agents with MCP support
+ */
+export function getAgentsWithMcp() {
+  return getAgentManifest().filter((agent) => agent.mcpSupport.supported)
+}
+
+/**
+ * Validate manifest has all required fields for a consistent agent count
+ */
+export function validateManifest() {
+  const issues = []
+  const manifest = getAgentManifest()
+
+  for (const agent of manifest) {
+    if (!agent.skillInstallScope) {
+      issues.push({ agent: agent.name, issue: 'missing skillInstallScope' })
+    }
+    if (!agent.supportLevel) {
+      issues.push({ agent: agent.name, issue: 'missing supportLevel' })
+    }
+    if (!agent.lastVerified && agent.supportLevel === SUPPORT_LEVELS.VERIFIED) {
+      issues.push({
+        agent: agent.name,
+        issue: 'missing lastVerified date for verified agent',
+      })
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    agentCount: manifest.length,
+    issues,
+  }
+}
+
+export default getAgentManifest

--- a/src/agents/manifest.test.js
+++ b/src/agents/manifest.test.js
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  getAgentManifest,
+  getAgentManifestByFlag,
+  getAgentsBySupportLevel,
+  getAgentsWithMcp,
+  validateManifest,
+  SUPPORT_LEVELS,
+} from './manifest.js'
+import { generateAgentsDocs } from '../../scripts/generate-agents-docs.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+describe('agent manifest', () => {
+  it('returns all agents with required fields', () => {
+    const manifest = getAgentManifest()
+    assert.ok(manifest.length > 0)
+    for (const agent of manifest) {
+      assert.ok(agent.flag, `missing flag for ${agent.name}`)
+      assert.ok(agent.name, 'missing name')
+      assert.ok(agent.skillInstallScope, `missing scope for ${agent.name}`)
+      assert.ok(agent.supportLevel, `missing support level for ${agent.name}`)
+      assert.ok(agent.label, `missing label for ${agent.name}`)
+    }
+  })
+
+  it('includes opencode as verified', () => {
+    const manifest = getAgentManifest()
+    const opencode = manifest.find((a) => a.name === 'opencode')
+    assert.ok(opencode)
+    assert.equal(opencode.supportLevel, SUPPORT_LEVELS.VERIFIED)
+    assert.equal(opencode.mcpSupport.supported, false)
+  })
+
+  it('includes claude-code as verified with MCP', () => {
+    const manifest = getAgentManifest()
+    const cc = manifest.find((a) => a.name === 'claude-code')
+    assert.ok(cc)
+    assert.equal(cc.supportLevel, SUPPORT_LEVELS.VERIFIED)
+    assert.equal(cc.mcpSupport.supported, true)
+    assert.ok(cc.docUrl)
+  })
+
+  it('flags shared-directory agents with aliasFor', () => {
+    const shared = getAgentManifest().filter((a) => a.aliasFor)
+    assert.ok(shared.length > 0)
+    for (const agent of shared) {
+      assert.equal(agent.skillInstallScope, 'global ~/.agents/skills')
+      assert.equal(agent.supportLevel, SUPPORT_LEVELS.EXPERIMENTAL)
+    }
+  })
+
+  it('getAgentManifestByFlag returns correct agent', () => {
+    const agent = getAgentManifestByFlag('claude')
+    assert.ok(agent)
+    assert.equal(agent.name, 'claude-code')
+    assert.equal(agent.mcpSupport.supported, true)
+  })
+
+  it('getAgentManifestByFlag returns null for unknown flag', () => {
+    assert.equal(getAgentManifestByFlag('nonexistent'), null)
+  })
+
+  it('getAgentsBySupportLevel groups correctly', () => {
+    const groups = getAgentsBySupportLevel()
+    assert.ok(groups[SUPPORT_LEVELS.VERIFIED].length > 0)
+    assert.ok(groups[SUPPORT_LEVELS.COMMUNITY].length >= 0)
+    assert.ok(groups[SUPPORT_LEVELS.EXPERIMENTAL].length > 0)
+
+    const allCount = Object.values(groups).reduce((sum, g) => sum + g.length, 0)
+    assert.equal(allCount, getAgentManifest().length)
+  })
+
+  it('getAgentsWithMcp returns only MCP-enabled agents', () => {
+    const mcpAgents = getAgentsWithMcp()
+    assert.ok(mcpAgents.length > 0)
+    for (const agent of mcpAgents) {
+      assert.equal(agent.mcpSupport.supported, true)
+      assert.ok(agent.mcpSupport.format)
+    }
+  })
+
+  it('validateManifest reports valid for current data', () => {
+    const result = validateManifest()
+    assert.ok(result.valid)
+    assert.equal(result.agentCount, getAgentManifest().length)
+    assert.equal(result.issues.length, 0)
+  })
+
+  it('docs/agents.md matches generated content from manifest', () => {
+    const docsPath = join(__dirname, '..', '..', 'docs', 'agents.md')
+    const current = readFileSync(docsPath, 'utf-8')
+    const generated = generateAgentsDocs()
+    if (current !== generated) {
+      console.error('docs/agents.md is out of sync with manifest.')
+      console.error('Run: node scripts/generate-agents-docs.js')
+      const currentLines = current.split('\n')
+      const generatedLines = generated.split('\n')
+      for (
+        let i = 0;
+        i < Math.max(currentLines.length, generatedLines.length);
+        i++
+      ) {
+        if (currentLines[i] !== generatedLines[i]) {
+          console.error(`Line ${i + 1} differs:`)
+          console.error(`  current:   ${currentLines[i]?.trimEnd()}`)
+          console.error(`  generated: ${generatedLines[i]?.trimEnd()}`)
+          break
+        }
+      }
+    }
+    assert.equal(current, generated)
+  })
+})

--- a/src/commands/agents.js
+++ b/src/commands/agents.js
@@ -1,0 +1,67 @@
+import {
+  getAgentManifest,
+  getAgentsBySupportLevel,
+  getAgentsWithMcp,
+  validateManifest,
+} from '../agents/manifest.js'
+
+export async function agentsCommand(options = {}) {
+  const manifest = getAgentManifest()
+
+  if (options.json) {
+    const output = {
+      version: 1,
+      agentCount: manifest.length,
+      agents: manifest,
+    }
+    console.log(JSON.stringify(output, null, 2))
+    return
+  }
+
+  // Group by support level
+  const byLevel = getAgentsBySupportLevel()
+
+  console.log('\n🔍 Agent Capability Manifest\n')
+  console.log(`Total agents: ${manifest.length}\n`)
+
+  // Display agents by support level
+  for (const [level, agents] of Object.entries(byLevel)) {
+    if (agents.length === 0) continue
+
+    console.log(`\n## ${level.toUpperCase()}\n`)
+    console.log('| Agent | Skill Scope | MCP | Instruction | Docs |')
+    console.log('|-------|-------------|-----|-------------|------|')
+
+    for (const agent of agents) {
+      const mcpStatus = agent.mcpSupport.supported ? '✅' : '❌'
+      const docsLink = agent.docUrl ? `[docs](${agent.docUrl})` : '-'
+      console.log(
+        `| ${agent.name} | ${agent.skillInstallScope} | ${mcpStatus} | ${agent.instructionFormat} | ${docsLink} |`,
+      )
+    }
+  }
+
+  // MCP-enabled agents
+  const mcpAgents = getAgentsWithMcp()
+  if (mcpAgents.length > 0) {
+    console.log('\n## MCP-Supported Agents\n')
+    console.log('These agents have built-in MCP configuration support:')
+    for (const agent of mcpAgents) {
+      console.log(`  • ${agent.name} (${agent.mcpSupport.format})`)
+    }
+  }
+
+  // Validation status
+  const validation = validateManifest()
+  console.log(`\n## Validation\n`)
+  console.log(
+    `Manifest valid: ${validation.valid ? '✅ Yes' : '⚠️ Issues found'}`,
+  )
+  console.log(`Agent count: ${validation.agentCount}`)
+  if (validation.issues.length > 0) {
+    console.log('Issues:')
+    for (const issue of validation.issues) {
+      console.log(`  • ${issue.agent}: ${issue.issue}`)
+    }
+  }
+}

--- a/src/commands/agents.test.js
+++ b/src/commands/agents.test.js
@@ -1,0 +1,46 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+
+let agentsModule
+
+before(async () => {
+  agentsModule = await import('./agents.js')
+})
+
+describe('agents command', () => {
+  it('outputs JSON with --json flag', async () => {
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => logs.push(args.join(' '))
+
+    try {
+      await agentsModule.agentsCommand({ json: true })
+      const output = JSON.parse(logs[0])
+      assert.ok(output.version)
+      assert.ok(output.agentCount > 0)
+      assert.ok(Array.isArray(output.agents))
+      for (const agent of output.agents) {
+        assert.ok(agent.flag)
+        assert.ok(agent.name)
+      }
+    } finally {
+      console.log = origLog
+    }
+  })
+
+  it('outputs formatted table by default', async () => {
+    const logs = []
+    const origLog = console.log
+    console.log = (...args) => logs.push(args.join(' '))
+
+    try {
+      await agentsModule.agentsCommand({})
+      const allText = logs.join('\n')
+      assert.ok(allText.includes('Agent Capability Manifest'))
+      assert.ok(allText.includes('VERIFIED'))
+      assert.ok(allText.includes('EXPERIMENTAL'))
+    } finally {
+      console.log = origLog
+    }
+  })
+})


### PR DESCRIPTION
Adds agents capability manifest command for agent support level visibility and generated agent documentation from the manifest.