### PR TITLE
feat: auto-generate benchmark SVG from results data

### DIFF
--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -1,6 +1,6 @@
 # Benchmark Results
 
-> Run `node benchmark/install-speed.js` to reproduce on your machine.
+> Run `npm run benchmark` to reproduce on your machine and regenerate the SVG chart.
 >
 > **Environment:** Node.js v24.18.0, macOS (darwin, arm64)
 > **Fixture (local):** SKILL.md + 1 JS file (2 files, 78 bytes)
@@ -9,34 +9,34 @@
 > **Date:** 2026-07-28
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rolecraft-sh/rolecraft/main/benchmark/comparison.svg" alt="Benchmark comparison chart" width="800">
+  <img src="comparison.svg" alt="Benchmark comparison chart" width="800">
 </p>
 
 ## Local path install
 
-| Tool | avg | min | max | p50 | vs rolecraft |
-|------|-----|-----|-----|-----|-------------|
-| **rolecraft** | **15.34 ms** | **4.33 ms** | **57.00 ms** | **12.83 ms** | **1.00x** |
-| skills (Vercel) | 4622.61 ms | 4036.72 ms | 7761.70 ms | 4303.50 ms | **301.40x** |
-| @agentskill.sh/cli | — | — | — | — | N/A |
+| Tool               | avg          | min         | max          | p50          | vs rolecraft |
+| ------------------ | ------------ | ----------- | ------------ | ------------ | ------------ |
+| **rolecraft**      | **15.34 ms** | **4.33 ms** | **57.00 ms** | **12.83 ms** | **1.00x**    |
+| skills (Vercel)    | 4622.61 ms   | 4036.72 ms  | 7761.70 ms   | 4303.50 ms   | **301.40x**  |
+| @agentskill.sh/cli | —            | —           | —            | —            | N/A          |
 
 > `@agentskill.sh/cli` is marketplace-only and does not support local paths.
 
 ## GitHub install (`rolecraft-sh/skills`)
 
-| Tool | avg | min | max | p50 | vs rolecraft |
-|------|-----|-----|-----|-----|-------------|
-| **rolecraft** | **1366.86 ms** | **1301.34 ms** | **1506.12 ms** | **1357.13 ms** | **1.00x** |
-| skills (Vercel) | 13327.47 ms | 11773.34 ms | 17290.04 ms | 12524.37 ms | **9.75x** |
-| @agentskill.sh/cli | — | — | — | — | **failed** |
+| Tool               | avg            | min            | max            | p50            | vs rolecraft |
+| ------------------ | -------------- | -------------- | -------------- | -------------- | ------------ |
+| **rolecraft**      | **1366.86 ms** | **1301.34 ms** | **1506.12 ms** | **1357.13 ms** | **1.00x**    |
+| skills (Vercel)    | 13327.47 ms    | 11773.34 ms    | 17290.04 ms    | 12524.37 ms    | **9.75x**    |
+| @agentskill.sh/cli | —              | —              | —              | —              | **failed**   |
 
 > `@agentskill.sh/cli` fetches the skill but exits with an error during the agent detection phase. The install does not complete successfully.
 
 ## Key takeaways
 
-| Scenario | rolecraft | Vercel skills | @agentskill.sh/cli |
-|----------|-----------|---------------|-------------------|
-| Local skill install | ✅ **15.34 ms** | ✅ 4623 ms (301x slower) | ❌ not supported |
-| GitHub skill install | ✅ **1.4 s** | ✅ 13.3 s (9.8x slower) | ❌ fails (bug) |
-| Zero dependencies | ✅ **0** | ❌ 1 dep | ❌ 2 deps |
-| Package size | **87.4 kB** | ~465 KB | ~84 KB |
+| Scenario             | rolecraft       | Vercel skills            | @agentskill.sh/cli |
+| -------------------- | --------------- | ------------------------ | ------------------ |
+| Local skill install  | ✅ **15.34 ms** | ✅ 4623 ms (301x slower) | ❌ not supported   |
+| GitHub skill install | ✅ **1.4 s**    | ✅ 13.3 s (9.8x slower)  | ❌ fails (bug)     |
+| Zero dependencies    | ✅ **0**        | ❌ 1 dep                 | ❌ 2 deps          |
+| Package size         | **87.4 kB**     | ~465 KB                  | ~84 KB             |

--- a/benchmark/comparison.svg
+++ b/benchmark/comparison.svg
@@ -2,26 +2,36 @@
   <rect width="800" height="820" fill="#ffffff" rx="12"/>
   <rect x="0" y="0" width="800" height="80" fill="#f8fafc" rx="12"/>
   <text x="40" y="34" font-family="system-ui,sans-serif" font-size="20" fill="#1e293b" font-weight="800">⚡ Benchmark Comparison</text>
-  <text x="40" y="60" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">rolecraft vs Vercel skills vs @agentskill.sh/cli · Node.js v22 · 10 iterations</text>
+  <text x="40" y="60" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">rolecraft vs Vercel skills vs @agentskill.sh/cli · Node.js v24.18.0 · 10 iterations</text>
 
   <text x="40" y="110" font-family="system-ui,sans-serif" font-size="16" fill="#1e293b" font-weight="700">📁 Local Path Install — Speed</text>
   <rect x="40" y="125" width="580" height="50" rx="8" fill="#f0fdf4" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="6,3"/>
-  <text x="48" y="147" font-family="system-ui,sans-serif" font-size="14" fill="#15803d" font-weight="700">🏆 rolecraft is 434x faster than Vercel skills</text>
+  <text x="48" y="147" font-family="system-ui,sans-serif" font-size="14" fill="#15803d" font-weight="700">🏆 rolecraft is 301.4x faster than Vercel skills</text>
   <text x="48" y="165" font-family="system-ui,sans-serif" font-size="11" fill="#64748b">@agentskill.sh/cli: not supported for local paths (marketplace-only)</text>
 
-  <rect x="40" y="195" width="1.1430232558139535" height="28" rx="4" fill="#15803d" opacity="0.9"/><text x="48" y="214" font-family="system-ui,sans-serif" font-size="13" fill="#15803d" font-weight="600">rolecraft</text><text x="198" y="214" font-family="system-ui,sans-serif" font-size="12" fill="#64748b">9.83 ms</text>
-  <rect x="40" y="233" width="495.6976744186046" height="28" rx="4" fill="#1d4ed8" opacity="0.9"/><text x="48" y="252" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">Vercel skills</text><text x="527.6976744186046" y="252" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">4,263 ms</text>
+  <text x="40" y="214" font-family="system-ui,sans-serif" font-size="13" fill="#15803d" font-weight="600">rolecraft</text>
+  <rect x="185" y="201" width="4" height="24" rx="3" fill="#15803d" opacity="0.9"/>
+  <text x="197" y="216" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">15.34 ms</text>
+
+  <text x="40" y="248" font-family="system-ui,sans-serif" font-size="13" fill="#1d4ed8" font-weight="600">Vercel skills</text>
+  <rect x="185" y="235" width="513.6233333333333" height="24" rx="3" fill="#1d4ed8" opacity="0.9"/>
+  <text x="706.6233333333333" y="250" font-family="system-ui,sans-serif" font-size="13" fill="#64748b" font-weight="600">4,623 ms</text>
 
   <text x="40" y="290" font-family="system-ui,sans-serif" font-size="16" fill="#1e293b" font-weight="700">🌐 GitHub Repo Install — Speed</text>
-  <rect x="40" y="320" width="190.9090909090909" height="28" rx="4" fill="#15803d" opacity="0.9"/><text x="48" y="339" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">rolecraft</text><text x="222.9090909090909" y="339" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">4.2 s</text>
-  <rect x="40" y="358" width="455.6363636363636" height="28" rx="4" fill="#1d4ed8" opacity="0.9"/><text x="48" y="377" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">Vercel skills</text><text x="487.6363636363636" y="377" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">10.0 s</text>
+  <text x="40" y="336" font-family="system-ui,sans-serif" font-size="13" fill="#15803d" font-weight="600">rolecraft</text>
+  <rect x="185" y="323" width="48.81642857142857" height="24" rx="3" fill="#15803d" opacity="0.9"/>
+  <text x="241.81642857142856" y="338" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">1.37 s</text>
 
-  <text x="40" y="415" font-family="system-ui,sans-serif" font-size="12" fill="#64748b">@agentskill.sh/cli: failed — Error: Unknown agent: antigravity-cli</text>
+  <text x="40" y="370" font-family="system-ui,sans-serif" font-size="13" fill="#1d4ed8" font-weight="600">Vercel skills</text>
+  <rect x="185" y="357" width="475.9810714285714" height="24" rx="3" fill="#1d4ed8" opacity="0.9"/>
+  <text x="668.9810714285713" y="372" font-family="system-ui,sans-serif" font-size="13" fill="#64748b" font-weight="600">13.33 s</text>
+
+  <text x="40" y="415" font-family="system-ui,sans-serif" font-size="12" fill="#64748b">@agentskill.sh/cli: failed — install does not complete successfully</text>
 
   <text x="40" y="450" font-family="system-ui,sans-serif" font-size="16" fill="#1e293b" font-weight="700">📦 Package Size</text>
   <text x="40" y="497" font-family="system-ui,sans-serif" font-size="13" fill="#15803d" font-weight="600">rolecraft</text>
-  <rect x="185" y="484" width="14" height="24" rx="3" fill="#15803d" opacity="0.9"/>
-  <text x="205" y="500" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">~4 KB</text>
+  <rect x="185" y="484" width="52.06808510638298" height="24" rx="3" fill="#15803d" opacity="0.9"/>
+  <text x="245.06808510638297" y="500" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">87.4 kB</text>
 
   <text x="40" y="535" font-family="system-ui,sans-serif" font-size="13" fill="#1d4ed8" font-weight="600">Vercel skills</text>
   <rect x="185" y="522" width="277.02127659574467" height="24" rx="3" fill="#1d4ed8" opacity="0.9"/>
@@ -37,13 +47,13 @@
 
   <text x="40" y="685" font-family="system-ui,sans-serif" font-size="13" fill="#1e293b" font-weight="600">Agent Support</text>
   <rect x="40" y="700" width="200" height="24" rx="4" fill="#15803d"/>
-  <text x="50" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">rolecraft: 82+ agents</text>
+  <text x="50" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">rolecraft: 86+ agents</text>
   <rect x="260" y="700" width="200" height="24" rx="4" fill="#1d4ed8"/>
   <text x="270" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">Vercel skills: 72 agents</text>
   <rect x="480" y="700" width="200" height="24" rx="4" fill="#92400e"/>
   <text x="490" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">@agentskill.sh/cli: 15+</text>
 
   <text x="40" y="755" font-family="system-ui,sans-serif" font-size="13" fill="#1e293b" font-weight="600">Unique Features</text>
-  <text x="40" y="778" font-family="system-ui,sans-serif" font-size="12" fill="#1e293b">✅ MCP server management    ✅ bundle + create    ✅ watch mode (auto-sync)</text>
-  <text x="40" y="798" font-family="system-ui,sans-serif" font-size="12" fill="#1e293b">✅ shell completions        ✅ doctor            ✅ agents-xml</text>
+  <text x="40" y="778" font-family="system-ui,sans-serif" font-size="12" fill="#1e293b">✅ publish to registry   ✅ MCP server mgmt     ✅ bundle + create     ✅ watch (auto-sync)</text>
+  <text x="40" y="798" font-family="system-ui,sans-serif" font-size="12" fill="#1e293b">✅ profile              ✅ compose             ✅ test                ✅ doctor</text>
 </svg>

--- a/benchmark/install-speed.js
+++ b/benchmark/install-speed.js
@@ -1,9 +1,15 @@
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { execSync } from 'node:child_process'
 import { resolveSource } from '../src/utils/resolver.js'
 import { installSkill } from '../src/utils/installer.js'
+import { getAgentManifest } from '../src/agents.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const DATA_PATH = resolve(ROOT, 'benchmark/results.json')
 
 const ITERATIONS = 10
 const GITHUB_SOURCE = 'rolecraft-sh/skills'
@@ -50,12 +56,15 @@ async function bench(label, fn, baselineAvg) {
   }
   const sorted = [...times].sort((a, b) => a - b)
   const avg = sorted.reduce((a, b) => a + b, 0) / sorted.length
+  const min = sorted[0]
+  const max = sorted[sorted.length - 1]
+  const p50 = sorted[Math.floor(sorted.length * 0.5)]
   const ratio = baselineAvg ? avg / baselineAvg : 1
   console.log(
-    `  ${label.padEnd(25)} avg ${formatMs(avg).padStart(9)}  min ${formatMs(sorted[0]).padStart(9)}  ` +
-      `max ${formatMs(sorted[sorted.length - 1]).padStart(9)}  p50 ${formatMs(sorted[Math.floor(sorted.length * 0.5)]).padStart(9)}  ${ratio.toFixed(2)}x`,
+    `  ${label.padEnd(25)} avg ${formatMs(avg).padStart(9)}  min ${formatMs(min).padStart(9)}  ` +
+      `max ${formatMs(max).padStart(9)}  p50 ${formatMs(p50).padStart(9)}  ${ratio.toFixed(2)}x`,
   )
-  return avg
+  return { avg, min, max, p50, ratio }
 }
 
 function header(label) {
@@ -82,12 +91,12 @@ async function main() {
   // ── local install ──
   header('Local path install')
 
-  const rcLocalAvg = await bench('rolecraft', async () => {
+  const rcLocal = await bench('rolecraft', async () => {
     const resolved = await resolveSource(fixtureDir)
     await installSkill(resolved, ['project'], 'copy')
   })
 
-  await bench(
+  const vercelLocal = await bench(
     'skills (Vercel)',
     async () => {
       execSync(`npx --yes skills add ${fixtureDir} --yes --copy 2>/dev/null`, {
@@ -96,7 +105,7 @@ async function main() {
         cwd: '/tmp',
       })
     },
-    rcLocalAvg,
+    rcLocal.avg,
   )
 
   console.log(
@@ -107,12 +116,12 @@ async function main() {
   // ── GitHub install ──
   header(`GitHub install (${GITHUB_SOURCE})`)
 
-  const rcGhAvg = await bench('rolecraft', async () => {
+  const rcGh = await bench('rolecraft', async () => {
     const resolved = await resolveSource(GITHUB_SOURCE)
     await installSkill(resolved, ['project'], 'copy')
   })
 
-  await bench(
+  const vercelGh = await bench(
     'skills (Vercel)',
     async () => {
       execSync(
@@ -120,7 +129,7 @@ async function main() {
         { stdio: 'pipe', timeout: 60000, cwd: '/tmp' },
       )
     },
-    rcGhAvg,
+    rcGh.avg,
   )
 
   await bench(
@@ -131,10 +140,40 @@ async function main() {
         { stdio: 'pipe', timeout: 120000, cwd: '/tmp' },
       )
     },
-    rcGhAvg,
+    rcGh.avg,
   )
 
   console.log()
+
+  // Write results.json
+  const manifest = getAgentManifest()
+  const agentCount = manifest.length
+
+  const results = {
+    date: new Date().toISOString().slice(0, 10),
+    node: process.version,
+    os: `${process.platform} (${process.arch})`,
+    iterations: ITERATIONS,
+    local: {
+      rolecraft: rcLocal,
+      vercel: vercelLocal,
+      agentskill: null,
+      localRatio: Number.parseFloat(vercelLocal.ratio.toFixed(2)),
+    },
+    github: {
+      rolecraft: rcGh,
+      vercel: vercelGh,
+      agentskill: null,
+      githubRatio: Number.parseFloat(vercelGh.ratio.toFixed(2)),
+    },
+    agents: {
+      rolecraft: agentCount,
+    },
+  }
+
+  writeFileSync(DATA_PATH, `${JSON.stringify(results, null, 2)}\n`)
+  console.log(`  📊 benchmark/results.json written`)
+
   rmSync(fixtureDir, { recursive: true, force: true })
 }
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
     "test:coverage": "node --experimental-test-coverage --test --test-coverage-exclude=\"**/*.test.js\" --test-coverage-include=\"src/**\" --test-coverage-include=\"bin/**\"",
     "setup-hooks": "node scripts/setup-hooks.mjs",
     "postinstall": "node scripts/setup-hooks.mjs || true",
+    "benchmark": "node benchmark/install-speed.js && node scripts/benchmark-visual.js",
+    "benchmark:visual": "node scripts/benchmark-visual.js",
     "generate:agents-docs": "node scripts/generate-agents-docs.js",
     "generate:readme": "node scripts/generate-readme.js",
     "docs:dev": "vitepress dev docs",

--- a/scripts/benchmark-visual.js
+++ b/scripts/benchmark-visual.js
@@ -1,7 +1,11 @@
-import { writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const W = 800
-const H = 820
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const DATA_PATH = resolve(ROOT, 'benchmark/results.json')
+
 const COLORS = {
   rolecraft: '#15803d',
   rolecraftLight: '#22c55e',
@@ -16,10 +20,6 @@ const COLORS = {
   highlight: '#f0fdf4',
 }
 
-function sectionTitle(y, text) {
-  return `<text x="40" y="${y}" font-family="system-ui,sans-serif" font-size="16" fill="${COLORS.text}" font-weight="700">${esc(text)}</text>`
-}
-
 function esc(s) {
   return String(s)
     .replace(/&/g, '&amp;')
@@ -27,59 +27,122 @@ function esc(s) {
     .replace(/>/g, '&gt;')
 }
 
-const MAX_LOCAL = 4300
-const MAX_GITHUB = 11000
+const DEFAULT = {
+  node: 'v24.18.0',
+  os: 'macOS (darwin, arm64)',
+  iterations: 10,
+  date: '2026-07-28',
+  local: {
+    rolecraft: { avg: 15.34, min: 4.33, max: 57.0, p50: 12.83 },
+    vercel: { avg: 4622.61, min: 4036.72, max: 7761.7, p50: 4303.5 },
+    agentskill: null,
+    localRatio: 301.4,
+  },
+  github: {
+    rolecraft: { avg: 1366.86, min: 1301.34, max: 1506.12, p50: 1357.13 },
+    vercel: { avg: 13327.47, min: 11773.34, max: 17290.04, p50: 12524.37 },
+    agentskill: null,
+    githubRatio: 9.75,
+  },
+  packageSize: {
+    rolecraft: '87.4 kB',
+    vercel: '~465 KB',
+    agentskill: '~84 KB',
+  },
+  deps: { rolecraft: 0, vercel: 1, agentskill: 2 },
+  agents: { rolecraft: 86, vercel: 72, agentskill: '15+' },
+}
+
+const data = existsSync(DATA_PATH)
+  ? JSON.parse(readFileSync(DATA_PATH, 'utf-8'))
+  : DEFAULT
+
+const fmt = (n) => Number(n).toLocaleString('en-US')
+
+const BAR_X = 185
+const BAR_W = 500
+const SIZE_BAR_W = 280
+
+const W = 800
+const H = 820
+const MAX_LOCAL = 4500
+const MAX_GITHUB = 14000
 const MAX_SIZE = 470
+
+const barW = (val, max) => Math.max((val / max) * BAR_W, 4)
+
+const lRc = data.local.rolecraft.avg
+const lVc = data.local.vercel.avg
+const gRc = data.github.rolecraft.avg
+const gVc = data.github.vercel.avg
+
+const lRatio = data.local.localRatio || (lVc / lRc).toFixed(1)
+const _gRatio = data.github.githubRatio || (gVc / gRc).toFixed(1)
+
+const ghRcLabel =
+  gRc >= 1000 ? `${(gRc / 1000).toFixed(2)} s` : `${gRc.toFixed(0)} ms`
+const ghVcLabel =
+  gVc >= 1000 ? `${(gVc / 1000).toFixed(2)} s` : `${gVc.toFixed(0)} ms`
 
 const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
   <rect width="${W}" height="${H}" fill="${COLORS.bg}" rx="12"/>
   <rect x="0" y="0" width="${W}" height="80" fill="#f8fafc" rx="12"/>
   <text x="40" y="34" font-family="system-ui,sans-serif" font-size="20" fill="${COLORS.text}" font-weight="800">⚡ Benchmark Comparison</text>
-  <text x="40" y="60" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}">rolecraft vs Vercel skills vs @agentskill.sh/cli · Node.js v22 · 10 iterations</text>
+  <text x="40" y="60" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}">rolecraft vs Vercel skills vs @agentskill.sh/cli · Node.js ${esc(data.node)} · ${data.iterations} iterations</text>
 
-  ${sectionTitle(110, '📁 Local Path Install — Speed')}
+  <text x="40" y="110" font-family="system-ui,sans-serif" font-size="16" fill="${COLORS.text}" font-weight="700">📁 Local Path Install — Speed</text>
   <rect x="40" y="125" width="580" height="50" rx="8" fill="${COLORS.highlight}" stroke="${COLORS.rolecraftLight}" stroke-width="1.5" stroke-dasharray="6,3"/>
-  <text x="48" y="147" font-family="system-ui,sans-serif" font-size="14" fill="${COLORS.rolecraft}" font-weight="700">🏆 rolecraft is 434x faster than Vercel skills</text>
+  <text x="48" y="147" font-family="system-ui,sans-serif" font-size="14" fill="${COLORS.rolecraft}" font-weight="700">🏆 rolecraft is ${lRatio}x faster than Vercel skills</text>
   <text x="48" y="165" font-family="system-ui,sans-serif" font-size="11" fill="${COLORS.muted}">@agentskill.sh/cli: not supported for local paths (marketplace-only)</text>
 
-  <rect x="40" y="195" width="${(9.83 / MAX_LOCAL) * 500}" height="28" rx="4" fill="${COLORS.rolecraft}" opacity="0.9"/><text x="48" y="214" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.rolecraft}" font-weight="600">rolecraft</text><text x="198" y="214" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.muted}">9.83 ms</text>
-  <rect x="40" y="233" width="${(4263 / MAX_LOCAL) * 500}" height="28" rx="4" fill="${COLORS.vercel}" opacity="0.9"/><text x="48" y="252" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">Vercel skills</text><text x="${40 + (4263 / MAX_LOCAL) * 500 - 8}" y="252" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">4,263 ms</text>
+  <text x="40" y="214" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.rolecraft}" font-weight="600">rolecraft</text>
+  <rect x="${BAR_X}" y="201" width="${barW(lRc, MAX_LOCAL)}" height="24" rx="3" fill="${COLORS.rolecraft}" opacity="0.9"/>
+  <text x="${BAR_X + barW(lRc, MAX_LOCAL) + 8}" y="216" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}">${fmt(lRc)} ms</text>
 
-  ${sectionTitle(290, '🌐 GitHub Repo Install — Speed')}
-  <rect x="40" y="320" width="${(4200 / MAX_GITHUB) * 500}" height="28" rx="4" fill="${COLORS.rolecraft}" opacity="0.9"/><text x="48" y="339" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">rolecraft</text><text x="${40 + (4200 / MAX_GITHUB) * 500 - 8}" y="339" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">4.2 s</text>
-  <rect x="40" y="358" width="${(10024 / MAX_GITHUB) * 500}" height="28" rx="4" fill="${COLORS.vercel}" opacity="0.9"/><text x="48" y="377" font-family="system-ui,sans-serif" font-size="13" fill="#fff" font-weight="600">Vercel skills</text><text x="${40 + (10024 / MAX_GITHUB) * 500 - 8}" y="377" font-family="system-ui,sans-serif" font-size="13" fill="#fff" text-anchor="end">10.0 s</text>
+  <text x="40" y="248" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.vercel}" font-weight="600">Vercel skills</text>
+  <rect x="${BAR_X}" y="235" width="${barW(lVc, MAX_LOCAL)}" height="24" rx="3" fill="${COLORS.vercel}" opacity="0.9"/>
+  <text x="${BAR_X + barW(lVc, MAX_LOCAL) + 8}" y="250" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}" font-weight="600">${fmt(lVc.toFixed(0))} ms</text>
 
-  <text x="40" y="415" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.muted}">@agentskill.sh/cli: failed — Error: Unknown agent: antigravity-cli</text>
+  <text x="40" y="290" font-family="system-ui,sans-serif" font-size="16" fill="${COLORS.text}" font-weight="700">🌐 GitHub Repo Install — Speed</text>
+  <text x="40" y="336" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.rolecraft}" font-weight="600">rolecraft</text>
+  <rect x="${BAR_X}" y="323" width="${barW(gRc, MAX_GITHUB)}" height="24" rx="3" fill="${COLORS.rolecraft}" opacity="0.9"/>
+  <text x="${BAR_X + barW(gRc, MAX_GITHUB) + 8}" y="338" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}">${ghRcLabel}</text>
 
-  ${sectionTitle(450, '📦 Package Size')}
+  <text x="40" y="370" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.vercel}" font-weight="600">Vercel skills</text>
+  <rect x="${BAR_X}" y="357" width="${barW(gVc, MAX_GITHUB)}" height="24" rx="3" fill="${COLORS.vercel}" opacity="0.9"/>
+  <text x="${BAR_X + barW(gVc, MAX_GITHUB) + 8}" y="372" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}" font-weight="600">${ghVcLabel}</text>
+
+  <text x="40" y="415" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.muted}">@agentskill.sh/cli: failed — install does not complete successfully</text>
+
+  <text x="40" y="450" font-family="system-ui,sans-serif" font-size="16" fill="${COLORS.text}" font-weight="700">📦 Package Size</text>
   <text x="40" y="497" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.rolecraft}" font-weight="600">rolecraft</text>
-  <rect x="185" y="484" width="14" height="24" rx="3" fill="${COLORS.rolecraft}" opacity="0.9"/>
-  <text x="205" y="500" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}">~4 KB</text>
+  <rect x="${BAR_X}" y="484" width="${Math.max((parseFloat(data.packageSize.rolecraft) / MAX_SIZE) * SIZE_BAR_W, 14)}" height="24" rx="3" fill="${COLORS.rolecraft}" opacity="0.9"/>
+  <text x="${BAR_X + Math.max((parseFloat(data.packageSize.rolecraft) / MAX_SIZE) * SIZE_BAR_W, 14) + 8}" y="500" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}">${esc(data.packageSize.rolecraft)}</text>
 
   <text x="40" y="535" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.vercel}" font-weight="600">Vercel skills</text>
-  <rect x="185" y="522" width="${(465 / MAX_SIZE) * 280}" height="24" rx="3" fill="${COLORS.vercel}" opacity="0.9"/>
-  <text x="${185 + (465 / MAX_SIZE) * 280 + 8}" y="538" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}" font-weight="600">~465 KB</text>
+  <rect x="${BAR_X}" y="522" width="${(parseFloat(data.packageSize.vercel.replace(/[~]/g, '')) / MAX_SIZE) * SIZE_BAR_W}" height="24" rx="3" fill="${COLORS.vercel}" opacity="0.9"/>
+  <text x="${BAR_X + (parseFloat(data.packageSize.vercel.replace(/[~]/g, '')) / MAX_SIZE) * SIZE_BAR_W + 8}" y="538" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}" font-weight="600">${esc(data.packageSize.vercel)}</text>
 
   <text x="40" y="573" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.agentskill}" font-weight="600">@agentskill.sh/cli</text>
-  <rect x="185" y="560" width="${Math.max((84 / MAX_SIZE) * 280, 14)}" height="24" rx="3" fill="${COLORS.agentskill}" opacity="0.9"/>
-  <text x="${185 + Math.max((84 / MAX_SIZE) * 280, 14) + 8}" y="576" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}" font-weight="600">~84 KB</text>
+  <rect x="${BAR_X}" y="560" width="${Math.max((parseFloat(data.packageSize.agentskill.replace(/[~]/g, '')) / MAX_SIZE) * SIZE_BAR_W, 14)}" height="24" rx="3" fill="${COLORS.agentskill}" opacity="0.9"/>
+  <text x="${BAR_X + Math.max((parseFloat(data.packageSize.agentskill.replace(/[~]/g, '')) / MAX_SIZE) * SIZE_BAR_W, 14) + 8}" y="576" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.muted}" font-weight="600">${esc(data.packageSize.agentskill)}</text>
 
-  <text x="40" y="620" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.muted}">Dependencies: rolecraft 0 · Vercel 1 · @agentskill.sh/cli 2</text>
+  <text x="40" y="620" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.muted}">Dependencies: rolecraft ${data.deps.rolecraft} · Vercel ${data.deps.vercel} · @agentskill.sh/cli ${data.deps.agentskill}</text>
 
   <line x1="40" y1="660" x2="760" y2="660" stroke="${COLORS.border}" stroke-width="1"/>
 
   <text x="40" y="685" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.text}" font-weight="600">Agent Support</text>
   <rect x="40" y="700" width="200" height="24" rx="4" fill="${COLORS.rolecraft}"/>
-  <text x="50" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">rolecraft: 82+ agents</text>
+  <text x="50" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">rolecraft: ${data.agents.rolecraft}+ agents</text>
   <rect x="260" y="700" width="200" height="24" rx="4" fill="${COLORS.vercel}"/>
-  <text x="270" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">Vercel skills: 72 agents</text>
+  <text x="270" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">Vercel skills: ${data.agents.vercel} agents</text>
   <rect x="480" y="700" width="200" height="24" rx="4" fill="${COLORS.agentskill}"/>
-  <text x="490" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">@agentskill.sh/cli: 15+</text>
+  <text x="490" y="716" font-family="system-ui,sans-serif" font-size="12" fill="#fff" font-weight="600">@agentskill.sh/cli: ${esc(String(data.agents.agentskill))}</text>
 
   <text x="40" y="755" font-family="system-ui,sans-serif" font-size="13" fill="${COLORS.text}" font-weight="600">Unique Features</text>
-  <text x="40" y="778" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.text}">✅ MCP server management    ✅ bundle + create    ✅ watch mode (auto-sync)</text>
-  <text x="40" y="798" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.text}">✅ shell completions        ✅ doctor            ✅ agents-xml</text>
+  <text x="40" y="778" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.text}">✅ publish to registry   ✅ MCP server mgmt     ✅ bundle + create     ✅ watch (auto-sync)</text>
+  <text x="40" y="798" font-family="system-ui,sans-serif" font-size="12" fill="${COLORS.text}">✅ profile              ✅ compose             ✅ test                ✅ doctor</text>
 </svg>`
 
-writeFileSync('benchmark/comparison.svg', svg)
+writeFileSync(resolve(ROOT, 'benchmark/comparison.svg'), svg)
 console.log('✅ benchmark/comparison.svg created')


### PR DESCRIPTION
Makes comparison.svg data-driven: install-speed.js writes results.json, benchmark-visual.js reads it to generate the SVG. Adds `npm run benchmark` script that runs both steps.