### PR TITLE
refactor: round 2 — fix remaining architectural issues

### DIFF
--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -35,6 +35,72 @@ const pkg = JSON.parse(
   readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'),
 )
 
+// ── Shared CLI helpers ──────────────────────────────────────────────
+
+/** Check if args request help display */
+function isHelp(args) {
+  return args.includes('--help') || args.includes('-h')
+}
+
+/** Return only flag-style args (starting with -) */
+function parseFlags(args) {
+  return args.filter((a) => a.startsWith('-'))
+}
+
+/** Return only positional (non-flag) args */
+function parsePositionals(args) {
+  return args.filter((a) => !a.startsWith('-'))
+}
+
+/**
+ * Extract the value after a named flag (e.g. --skill react-rules).
+ * Returns undefined when the flag is absent or has no subsequent value.
+ */
+function parseFlagValue(args, flag) {
+  const idx = args.indexOf(flag)
+  if (idx !== -1 && args[idx + 1] && !args[idx + 1].startsWith('-')) {
+    return args[idx + 1]
+  }
+  return undefined
+}
+
+/**
+ * Parse --skill react-rules,other-skill into an array of skill names.
+ * Returns undefined when the flag is absent.
+ */
+function parseSkillOption(args) {
+  const val = parseFlagValue(args, '--skill')
+  return val ? val.split(',').map((s) => s.trim()) : undefined
+}
+
+/**
+ * Build scope options for install-like commands from a flags array:
+ * - yes/dryRun/noMcp/frozenLockfile/symlink/list are booleans
+ * - global/project/all + per-agent flags
+ */
+function buildInstallScope(flags, agents) {
+  const scope = {
+    global: flags.includes('--global') || flags.includes('--all'),
+    project: flags.includes('--project') || flags.includes('--all'),
+    ...Object.fromEntries(
+      agents.map((a) => [
+        a.flag,
+        flags.includes(`--${a.flag}`) || flags.includes('--all'),
+      ]),
+    ),
+  }
+  // If no scope flags set, return empty — caller will prompt
+  const scopeFlags = [
+    '--global',
+    '--project',
+    '--all',
+    ...agents.map((a) => `--${a.flag}`),
+  ]
+  return scopeFlags.some((f) => flags.includes(f)) ? scope : {}
+}
+
+// ── Command registry ──────────────────────────────────────────────
+
 function usage() {
   const agentFlags = agents.map(
     (a) => `  --${a.flag.padEnd(15)} Also install to ${a.label}`,
@@ -167,512 +233,397 @@ Examples:
 `)
 }
 
-export async function main() {
-  const [, , cmd, ...args] = process.argv
-  switch (cmd) {
-    case 'install': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const installFlags = args.filter((a) => a.startsWith('-'))
-      const installPos = args.filter((a) => !a.startsWith('-'))
-      const source = installPos[0]
-      if (!source) {
-        console.error('Usage: rolecraft install <source>')
-        console.error(
-          'Source can be a local path (./, /, ~), GitHub ref (owner/repo), or npm package (npm:package)',
-        )
-        throw new Error('Missing source argument.')
-      }
+// ── Command handlers (one per top-level command) ──────────────────
 
-      const flags = installFlags
-      const scopeFlags = [
-        '--global',
-        '--project',
-        '--all',
-        ...agents.map((a) => `--${a.flag}`),
-      ]
-      const hasScopeFlag = flags.some((f) => scopeFlags.includes(f))
-      const options = hasScopeFlag
-        ? {
-            global: flags.includes('--global') || flags.includes('--all'),
-            project: flags.includes('--project') || flags.includes('--all'),
-            ...Object.fromEntries(
-              agents.map((a) => [
-                a.flag,
-                flags.includes(`--${a.flag}`) || flags.includes('--all'),
-              ]),
-            ),
-          }
-        : {}
-      options.frozenLockfile = flags.includes('--frozen-lockfile')
-      options.symlink = flags.includes('--symlink')
-      options.dryRun = flags.includes('--dry-run')
-      options.yes = flags.includes('--yes') || flags.includes('-y')
-      options.noMcp = flags.includes('--no-mcp')
-      options.list = flags.includes('--list')
-
-      const skillIndex = flags.indexOf('--skill')
-      if (
-        skillIndex !== -1 &&
-        flags[skillIndex + 1] &&
-        !flags[skillIndex + 1].startsWith('-')
-      ) {
-        options.skill = flags[skillIndex + 1].split(',').map((s) => s.trim())
-      }
-
-      await installCommand(source, options)
-      break
-    }
-
-    case 'list': {
-      const options = {
-        json: args.includes('--json'),
-      }
-
-      await listCommand(process.cwd(), options)
-      break
-    }
-
-    case 'remove': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const slug = args[0]
-      if (!slug) {
-        console.error('Usage: rolecraft remove <slug>')
-        throw new Error('Missing slug argument.')
-      }
-      const removeFlags = args.filter((a) => a.startsWith('-'))
-      await removeCommand(slug, { dryRun: removeFlags.includes('--dry-run') })
-      break
-    }
-
-    case 'update': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const slug = args[0]
-      if (!slug) {
-        console.error('Usage: rolecraft update <slug>')
-        throw new Error('Missing slug argument.')
-      }
-      const updateFlags = args.filter((a) => a.startsWith('-'))
-      await updateCommand(slug, { dryRun: updateFlags.includes('--dry-run') })
-      break
-    }
-
-    case 'use': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const source = args[0]
-      if (!source) {
-        console.error('Usage: rolecraft use <source>')
-        console.error(
-          'Source can be a local path (./, /, ~), GitHub ref (owner/repo), or npm package (npm:package)',
-        )
-        throw new Error('Missing source argument.')
-      }
-      const useFlags = args.filter((a) => a.startsWith('-'))
-      const useOptions = {
-        list: useFlags.includes('--list'),
-      }
-      const skillIndex = useFlags.indexOf('--skill')
-      if (
-        skillIndex !== -1 &&
-        useFlags[skillIndex + 1] &&
-        !useFlags[skillIndex + 1].startsWith('-')
-      ) {
-        useOptions.skill = useFlags[skillIndex + 1]
-          .split(',')
-          .map((s) => s.trim())
-      }
-      await useCommand(source, useOptions)
-      break
-    }
-
-    case 'init': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const name = args[0]
-      await initCommand(name)
-      break
-    }
-
-    case 'search': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const query = args[0]
-      const flags = args.slice(1)
-      if (!query) {
-        console.error(
-          'Usage: rolecraft search <query> [--interactive] [--registry]',
-        )
-        throw new Error('Missing query argument.')
-      }
-      await searchCommand(query, {
-        interactive: flags.includes('--interactive'),
-        skillsSh: flags.includes('--skills-sh'),
-        registry: flags.includes('--registry'),
-      })
-      break
-    }
-
-    case 'completions': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const shell = args[0]
-      await completionsCommand(shell)
-      break
-    }
-
-    case 'verify': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      await verifyCommand(true)
-      break
-    }
-
-    case 'check':
-    case 'check-updates': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      await checkCommand()
-      break
-    }
-
-    case 'ci': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      await ciCommand()
-      break
-    }
-
-    case 'setup': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const setupFlags = args.filter((a) => a.startsWith('-'))
-      const setupPos = args.filter((a) => !a.startsWith('-'))
-      const source = setupPos[0]
-      const setupOptions = {
-        dryRun: setupFlags.includes('--dry-run'),
-        yes: setupFlags.includes('--yes') || setupFlags.includes('-y'),
-        list: setupFlags.includes('--list'),
-      }
-      const skillIndex = setupFlags.indexOf('--skill')
-      if (
-        skillIndex !== -1 &&
-        setupFlags[skillIndex + 1] &&
-        !setupFlags[skillIndex + 1].startsWith('-')
-      ) {
-        setupOptions.skill = setupFlags[skillIndex + 1]
-          .split(',')
-          .map((s) => s.trim())
-      }
-      await setupCommand(source, setupOptions)
-      break
-    }
-
-    case 'upgrade': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const flags = args
-      await upgradeCommand({ dryRun: flags.includes('--dry-run') })
-      break
-    }
-
-    case 'doctor': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const doctorFlags = args.filter((a) => a.startsWith('-'))
-      await doctorCommand({
-        json: doctorFlags.includes('--json'),
-        network: doctorFlags.includes('--network'),
-        deep: doctorFlags.includes('--deep'),
-      })
-      break
-    }
-
-    case 'watch': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const slug = args[0]
-      const watchFlags = args.filter((a) => a.startsWith('-'))
-      const { watchers } = await watchCommand(slug, process.cwd(), {
-        dryRun: watchFlags.includes('--dry-run'),
-      })
-      if (watchers.length === 0) {
-        return
-      }
-      process.on('SIGINT', () => {
-        console.log('\nStopping watch...')
-        for (const w of watchers) w.close()
-        process.exit(0)
-      })
-      await new Promise(() => {})
-      break
-    }
-
-    case 'agents':
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      await agentsCommand({ json: args.includes('--json') })
-      break
-
-    case 'agents-xml':
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      await agentsXmlCommand(args.includes('--write'))
-      break
-
-    case 'version':
-    case '--version':
-    case '-v':
-      console.log(pkg.version)
-      break
-
-    case 'convert': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const source = args[0]
-      if (!source) {
-        console.error('Usage: rolecraft convert <source>')
-        throw new Error('Missing source argument.')
-      }
-      const convertFlags = args.filter((a) => a.startsWith('-'))
-      const convertOptions = {
-        dryRun: convertFlags.includes('--dry-run'),
-      }
-      const outputIndex = convertFlags.indexOf('--output')
-      if (
-        outputIndex !== -1 &&
-        convertFlags[outputIndex + 1] &&
-        !convertFlags[outputIndex + 1].startsWith('-')
-      ) {
-        convertOptions.output = convertFlags[outputIndex + 1]
-      }
-      await convertCommand(source, convertOptions)
-      break
-    }
-
-    case 'diff': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const diffFlags = args.filter((a) => a.startsWith('-'))
-      const diffPos = args.filter((a) => !a.startsWith('-'))
-      const diffOptions = {
-        json: diffFlags.includes('--json'),
-        brief: diffFlags.includes('--brief'),
-        noColor: diffFlags.includes('--no-color'),
-      }
-      const contextIndex = diffFlags.indexOf('--context')
-      if (
-        contextIndex !== -1 &&
-        diffFlags[contextIndex + 1] &&
-        !diffFlags[contextIndex + 1].startsWith('-')
-      ) {
-        diffOptions.context = parseInt(diffFlags[contextIndex + 1], 10)
-      }
-      await diffCommand(diffPos[0], diffPos[1], diffOptions)
-      break
-    }
-
-    case 'compose': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const composeFlags = args.filter((a) => a.startsWith('-'))
-      const composePos = args.filter((a) => !a.startsWith('-'))
-      const composeOptions = {
-        mode: composeFlags.includes('--chain') ? 'chain' : 'merge',
-        dryRun: composeFlags.includes('--dry-run'),
-        force: composeFlags.includes('--force'),
-        json: composeFlags.includes('--json'),
-        noColor: composeFlags.includes('--no-color'),
-      }
-      const nameIndex = composeFlags.indexOf('--name')
-      if (
-        nameIndex !== -1 &&
-        composeFlags[nameIndex + 1] &&
-        !composeFlags[nameIndex + 1].startsWith('-')
-      ) {
-        composeOptions.name = composeFlags[nameIndex + 1]
-      }
-      const outputIndex =
-        composeFlags.indexOf('--output') !== -1
-          ? composeFlags.indexOf('--output')
-          : composeFlags.indexOf('-o')
-      if (
-        outputIndex !== -1 &&
-        composeFlags[outputIndex + 1] &&
-        !composeFlags[outputIndex + 1].startsWith('-')
-      ) {
-        composeOptions.output = composeFlags[outputIndex + 1]
-      }
-      await composeCommand(composePos, composeOptions)
-      break
-    }
-
-    case 'test': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      const testFlags = args.filter((a) => a.startsWith('-'))
-      const testPos = args.filter((a) => !a.startsWith('-'))
-      const skillPath = testPos[0]
-      const testOptions = {
-        json: testFlags.includes('--json'),
-        verbose: testFlags.includes('--verbose') || testFlags.includes('-v'),
-        noColor: testFlags.includes('--no-color'),
-        noEmoji: testFlags.includes('--no-emoji'),
-        all: testFlags.includes('--all'),
-      }
-      const minScoreIndex = testFlags.indexOf('--min-score')
-      if (
-        minScoreIndex !== -1 &&
-        testFlags[minScoreIndex + 1] &&
-        !testFlags[minScoreIndex + 1].startsWith('-')
-      ) {
-        testOptions.minScore = parseInt(testFlags[minScoreIndex + 1], 10)
-      }
-      const onlyIndex = testFlags.indexOf('--only')
-      if (
-        onlyIndex !== -1 &&
-        testFlags[onlyIndex + 1] &&
-        !testFlags[onlyIndex + 1].startsWith('-')
-      ) {
-        testOptions.only = testFlags[onlyIndex + 1]
-          .split(',')
-          .map((s) => s.trim())
-      }
-      await testCommand(skillPath, testOptions)
-      break
-    }
-
-    case 'bundle': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      if (args.length === 0) {
-        console.error('Usage: rolecraft bundle <source> [...]')
-        console.error('       rolecraft bundle <file>')
-        console.error('       rolecraft bundle create [<name>]')
-        throw new Error('Missing arguments.')
-      }
-      if (args[0] === 'create') {
-        if (args.includes('--help') || args.includes('-h')) {
-          usage()
-          return
-        }
-        await bundleCreateCommand(args[1])
-        break
-      }
-      const flags = args.filter((a) => a.startsWith('--'))
-      const sources = args.filter((a) => !a.startsWith('--'))
-      const opts = {
-        dryRun: flags.includes('--dry-run'),
-        noMcp: flags.includes('--no-mcp'),
-      }
-      if (sources.length === 1) {
-        await bundleCommand(sources[0], opts)
-      } else {
-        await bundleCommand(sources, opts)
-      }
-      break
-    }
-
-    case 'publish': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-
-      const publishOpts = {
-        dryRun: false,
-        yes: false,
-        repo: '',
-        slug: '',
-        name: '',
-      }
-      const publishPos = []
-      for (let i = 0; i < args.length; i++) {
-        const a = args[i]
-        if (a === '--dry-run') publishOpts.dryRun = true
-        else if (a === '--yes' || a === '-y') publishOpts.yes = true
-        else if (a === '--repo') {
-          i++
-          publishOpts.repo = args[i] || ''
-        } else if (a === '--slug') {
-          i++
-          publishOpts.slug = args[i] || ''
-        } else if (a === '--name') {
-          i++
-          publishOpts.name = args[i] || ''
-        } else if (!a.startsWith('-')) publishPos.push(a)
-      }
-      const source = publishPos[0]
-      if (!source) {
-        console.error(
-          'Usage: rolecraft publish <source> [--repo owner/repo] [--dry-run]',
-        )
-        throw new Error('Missing source argument.')
-      }
-      await publishCommand(source, publishOpts)
-      break
-    }
-
-    case 'profile': {
-      await profileCommand(args)
-      break
-    }
-
-    case 'mcp': {
-      if (args.includes('--help') || args.includes('-h')) {
-        usage()
-        return
-      }
-      await mcpCommand(args)
-      break
-    }
-    default:
+const COMMANDS = {
+  install(args) {
+    if (isHelp(args)) {
       usage()
-      break
+      return
+    }
+    const pos = parsePositionals(args)
+    const source = pos[0]
+    if (!source) {
+      console.error('Usage: rolecraft install <source>')
+      console.error(
+        'Source can be a local path (./, /, ~), GitHub ref (owner/repo), or npm package (npm:package)',
+      )
+      throw new Error('Missing source argument.')
+    }
+    const flags = parseFlags(args)
+    const scope = buildInstallScope(flags, agents)
+    const opts = {
+      ...scope,
+      frozenLockfile: flags.includes('--frozen-lockfile'),
+      symlink: flags.includes('--symlink'),
+      dryRun: flags.includes('--dry-run'),
+      yes: flags.includes('--yes') || flags.includes('-y'),
+      noMcp: flags.includes('--no-mcp'),
+      list: flags.includes('--list'),
+      skill: parseSkillOption(args),
+    }
+    return installCommand(source, opts)
+  },
+
+  async list(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return listCommand(process.cwd(), { json: args.includes('--json') })
+  },
+
+  async remove(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    const slug = pos[0]
+    if (!slug) {
+      console.error('Usage: rolecraft remove <slug>')
+      throw new Error('Missing slug argument.')
+    }
+    return removeCommand(slug, { dryRun: args.includes('--dry-run') })
+  },
+
+  async update(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    const slug = pos[0]
+    if (!slug) {
+      console.error('Usage: rolecraft update <slug>')
+      throw new Error('Missing slug argument.')
+    }
+    return updateCommand(slug, { dryRun: args.includes('--dry-run') })
+  },
+
+  async use(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    const source = pos[0]
+    if (!source) {
+      console.error('Usage: rolecraft use <source>')
+      console.error(
+        'Source can be a local path (./, /, ~), GitHub ref (owner/repo), or npm package (npm:package)',
+      )
+      throw new Error('Missing source argument.')
+    }
+    return useCommand(source, {
+      list: args.includes('--list'),
+      skill: parseSkillOption(args),
+    })
+  },
+
+  async init(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    return initCommand(pos[0])
+  },
+
+  async search(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    const query = pos[0]
+    if (!query) {
+      console.error(
+        'Usage: rolecraft search <query> [--interactive] [--registry]',
+      )
+      throw new Error('Missing query argument.')
+    }
+    return searchCommand(query, {
+      interactive: args.includes('--interactive'),
+      skillsSh: args.includes('--skills-sh'),
+      registry: args.includes('--registry'),
+    })
+  },
+
+  async completions(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    return completionsCommand(pos[0])
+  },
+
+  async verify(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return verifyCommand(true)
+  },
+
+  async check(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return checkCommand()
+  },
+
+  async ci(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return ciCommand()
+  },
+
+  async setup(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    const source = pos[0]
+    return setupCommand(source, {
+      dryRun: args.includes('--dry-run'),
+      yes: args.includes('--yes') || args.includes('-y'),
+      list: args.includes('--list'),
+      skill: parseSkillOption(args),
+    })
+  },
+
+  async upgrade(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return upgradeCommand({ dryRun: args.includes('--dry-run') })
+  },
+
+  async doctor(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return doctorCommand({
+      json: args.includes('--json'),
+      network: args.includes('--network'),
+      deep: args.includes('--deep'),
+    })
+  },
+
+  async watch(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    const slug = pos[0]
+    const { watchers } = await watchCommand(slug, process.cwd(), {
+      dryRun: args.includes('--dry-run'),
+    })
+    if (watchers.length === 0) return
+    process.on('SIGINT', () => {
+      console.log('\nStopping watch...')
+      for (const w of watchers) w.close()
+      process.exit(0)
+    })
+    await new Promise(() => {})
+  },
+
+  async agents(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return agentsCommand({ json: args.includes('--json') })
+  },
+
+  async 'agents-xml'(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return agentsXmlCommand(args.includes('--write'))
+  },
+
+  async convert(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    const source = pos[0]
+    if (!source) {
+      console.error('Usage: rolecraft convert <source>')
+      throw new Error('Missing source argument.')
+    }
+    return convertCommand(source, {
+      dryRun: args.includes('--dry-run'),
+      output: parseFlagValue(args, '--output'),
+    })
+  },
+
+  async diff(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    return diffCommand(pos[0], pos[1], {
+      json: args.includes('--json'),
+      brief: args.includes('--brief'),
+      noColor: args.includes('--no-color'),
+      context: parseFlagValue(args, '--context'),
+    })
+  },
+
+  async compose(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    return composeCommand(pos, {
+      mode: args.includes('--chain') ? 'chain' : 'merge',
+      dryRun: args.includes('--dry-run'),
+      force: args.includes('--force'),
+      json: args.includes('--json'),
+      noColor: args.includes('--no-color'),
+      name: parseFlagValue(args, '--name'),
+      output: parseFlagValue(args, '--output') || parseFlagValue(args, '-o'),
+    })
+  },
+
+  async testCommand(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const pos = parsePositionals(args)
+    const skillPath = pos[0]
+    const minScore = parseFlagValue(args, '--min-score')
+    return testCommand(skillPath, {
+      json: args.includes('--json'),
+      verbose: args.includes('--verbose') || args.includes('-v'),
+      noColor: args.includes('--no-color'),
+      noEmoji: args.includes('--no-emoji'),
+      all: args.includes('--all'),
+      minScore: minScore ? parseInt(minScore, 10) : undefined,
+      only: parseSkillOption(args),
+    })
+  },
+
+  async bundle(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    if (args.length === 0) {
+      console.error('Usage: rolecraft bundle <source> [...]')
+      console.error('       rolecraft bundle <file>')
+      console.error('       rolecraft bundle create [<name>]')
+      throw new Error('Missing arguments.')
+    }
+    if (args[0] === 'create') {
+      const createArgs = args.slice(1)
+      if (isHelp(createArgs)) {
+        usage()
+        return
+      }
+      return bundleCreateCommand(parsePositionals(createArgs)[0])
+    }
+    const flags = parseFlags(args)
+    const sources = parsePositionals(args)
+    const opts = {
+      dryRun: flags.includes('--dry-run'),
+      noMcp: flags.includes('--no-mcp'),
+    }
+    if (sources.length === 1) {
+      return bundleCommand(sources[0], opts)
+    }
+    return bundleCommand(sources, opts)
+  },
+
+  async publish(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    const opts = { dryRun: false, yes: false, repo: '', slug: '', name: '' }
+    const pos = []
+    for (let i = 0; i < args.length; i++) {
+      const a = args[i]
+      if (a === '--dry-run') opts.dryRun = true
+      else if (a === '--yes' || a === '-y') opts.yes = true
+      else if (a === '--repo') opts.repo = args[++i] || ''
+      else if (a === '--slug') opts.slug = args[++i] || ''
+      else if (a === '--name') opts.name = args[++i] || ''
+      else if (!a.startsWith('-')) pos.push(a)
+    }
+    const source = pos[0]
+    if (!source) {
+      console.error(
+        'Usage: rolecraft publish <source> [--repo owner/repo] [--dry-run]',
+      )
+      throw new Error('Missing source argument.')
+    }
+    return publishCommand(source, opts)
+  },
+
+  async profile(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return profileCommand(args)
+  },
+
+  async mcp(args) {
+    if (isHelp(args)) {
+      usage()
+      return
+    }
+    return mcpCommand(args)
+  },
+
+  async version() {
+    console.log(pkg.version)
+  },
+}
+
+// Alias: test → testCommand (avoid name collision with node:test)
+COMMANDS.test = COMMANDS.testCommand
+// Alias: check-updates → check
+COMMANDS['check-updates'] = COMMANDS.check
+
+// Only non-command names that show usage
+const ALWAYS_SHOW_USAGE = new Set(['help', undefined, null])
+
+export async function main() {
+  const [, , cmd, ...commandArgs] = process.argv
+
+  if (cmd === '--version' || cmd === '-v') {
+    COMMANDS.version()
+    return
+  }
+
+  if (ALWAYS_SHOW_USAGE.has(cmd)) {
+    usage()
+    return
+  }
+
+  const handler = COMMANDS[cmd]
+  if (handler) {
+    await handler(commandArgs)
+  } else {
+    usage()
   }
 }
 

--- a/src/api/agents-xml.js
+++ b/src/api/agents-xml.js
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from 'node:fs'
+import { readFile, readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   readLock,
@@ -9,14 +9,14 @@ import {
 const SKILLS_SYSTEM_HEADER = `Only use skills listed in <available_skills> below.
 Do not invoke a skill that is already loaded in your context.`
 
-function parseNameAndDescription(slug, dir) {
+async function parseNameAndDescription(slug, dir) {
   try {
-    const files = readdirSync(dir)
+    const files = await readdir(dir)
     const skillFile = files.find(
       (f) => f === 'SKILL.md' || f.toLowerCase() === 'skill.md',
     )
     if (!skillFile) return { name: slug, description: '' }
-    const content = readFileSync(join(dir, skillFile), 'utf-8')
+    const content = await readFile(join(dir, skillFile), 'utf-8')
     const fm = content.match(/^---\n([\s\S]*?)\n---/)
     if (!fm) return { name: slug, description: '' }
     const yaml = fm[1]
@@ -25,6 +25,15 @@ function parseNameAndDescription(slug, dir) {
     return { name, description }
   } catch {
     return { name: slug, description: '' }
+  }
+}
+
+async function dirExists(d) {
+  try {
+    await stat(d)
+    return true
+  } catch {
+    return false
   }
 }
 
@@ -37,27 +46,28 @@ function escapeXml(str) {
     .replace(/'/g, '&apos;')
 }
 
-function generateXml(allSkills) {
+async function generateXml(allSkills) {
   const entries = Object.entries(allSkills)
   if (entries.length === 0) return ''
 
-  const skillsXml = entries
-    .map(([, entry]) => {
+  const skillsXml = await Promise.all(
+    entries.map(async ([, entry]) => {
       const normSlug = entry.slug.replace(/\//g, '-')
       const searchDirs = [
         join(getAgentsDir(), normSlug),
         join(process.cwd(), '.agents', 'skills', normSlug),
       ]
-      const existingDir = searchDirs.find((d) => {
-        try {
-          readdirSync(d)
-          return true
-        } catch {
-          return false
+
+      let existingDir = null
+      for (const d of searchDirs) {
+        if (await dirExists(d)) {
+          existingDir = d
+          break
         }
-      })
+      }
+
       const { name, description } = existingDir
-        ? parseNameAndDescription(entry.slug, existingDir)
+        ? await parseNameAndDescription(entry.slug, existingDir)
         : { name: entry.slug, description: '' }
 
       const agentList = entry.agents || []
@@ -68,14 +78,14 @@ function generateXml(allSkills) {
     <description>${escapeXml(description)}</description>
     <location>${location}</location>
   </skill>`
-    })
-    .join('\n')
+    }),
+  )
 
   return `<skills_system>
 ${SKILLS_SYSTEM_HEADER}
 
 <available_skills>
-${skillsXml}
+${skillsXml.join('\n')}
 </available_skills>
 </skills_system>\n`
 }
@@ -91,7 +101,7 @@ export async function agentsXmlApi(writeToFile = false) {
     if (!allSkills[slug]) allSkills[slug] = entry
   }
 
-  const xml = generateXml(allSkills)
+  const xml = await generateXml(allSkills)
 
   if (!xml) {
     return { xml: '' }
@@ -101,7 +111,7 @@ export async function agentsXmlApi(writeToFile = false) {
     const agentsMdPath = join(process.cwd(), 'AGENTS.md')
     let existing = ''
     try {
-      existing = readFileSync(agentsMdPath, 'utf-8')
+      existing = await readFile(agentsMdPath, 'utf-8')
     } catch {}
 
     const sectionStart = existing.indexOf('<skills_system>')

--- a/src/api/ci.js
+++ b/src/api/ci.js
@@ -46,7 +46,7 @@ export async function apiCi(cwd = process.cwd()) {
       continue
     }
     try {
-      const resolved = resolveMcpSource(entry.source)
+      const resolved = await resolveMcpSource(entry.source)
       for (const agent of entry.agents) {
         await addMcpServer(agent, name, resolved, entry.source)
       }

--- a/src/api/compose.js
+++ b/src/api/compose.js
@@ -1,24 +1,9 @@
-import { readFileSync, existsSync } from 'node:fs'
-import { parseFrontmatter, serializeFrontmatter } from '../utils/converter.js'
-
-function splitSections(body) {
-  const lines = body.split('\n')
-  const sections = []
-  let current = null
-
-  for (const line of lines) {
-    const headingMatch = line.match(/^##\s+(.+)/)
-    if (headingMatch) {
-      if (current) sections.push(current)
-      current = { heading: headingMatch[1].trim(), lines: [] }
-    } else if (current) {
-      current.lines.push(line)
-    }
-  }
-  if (current) sections.push(current)
-
-  return sections
-}
+import { readFile, stat } from 'node:fs/promises'
+import {
+  parseFrontmatter,
+  serializeFrontmatter,
+  splitSections,
+} from '../utils/converter.js'
 
 function mergeSectionLines(existingLines, newLines) {
   const seen = new Set(existingLines)
@@ -53,16 +38,17 @@ export async function apiCompose(sources, options = {}) {
     throw new Error('At least 2 skill files are required for compose.')
   }
 
-  for (const src of sources) {
-    if (!existsSync(src)) throw new Error(`Skill file not found: ${src}`)
-  }
-
   const mode = options.mode || 'merge'
   const allAttrs = []
   const allSections = []
 
   for (const src of sources) {
-    const raw = readFileSync(src, 'utf-8')
+    try {
+      await stat(src)
+    } catch {
+      throw new Error(`Skill file not found: ${src}`)
+    }
+    const raw = await readFile(src, 'utf-8')
     const { attrs, body } = parseFrontmatter(raw)
     allAttrs.push(attrs)
     allSections.push(splitSections(body))
@@ -103,11 +89,17 @@ export async function apiCompose(sources, options = {}) {
   if (options.name) mergedAttrs.name = options.name
 
   if (!mergedAttrs.description) {
-    const names = sources.map((s) => {
-      const raw = readFileSync(s, 'utf-8')
-      const { attrs } = parseFrontmatter(raw)
-      return attrs.name || s
-    })
+    const names = await Promise.all(
+      sources.map(async (s) => {
+        try {
+          const raw = await readFile(s, 'utf-8')
+          const { attrs } = parseFrontmatter(raw)
+          return attrs.name || s
+        } catch {
+          return s
+        }
+      }),
+    )
     mergedAttrs.description = `Composed from: ${names.join(', ')}`
   }
 

--- a/src/api/compose.js
+++ b/src/api/compose.js
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import {
   parseFrontmatter,
   serializeFrontmatter,
@@ -43,12 +43,9 @@ export async function apiCompose(sources, options = {}) {
   const allSections = []
 
   for (const src of sources) {
-    try {
-      await stat(src)
-    } catch {
+    const raw = await readFile(src, 'utf-8').catch(() => {
       throw new Error(`Skill file not found: ${src}`)
-    }
-    const raw = await readFile(src, 'utf-8')
+    })
     const { attrs, body } = parseFrontmatter(raw)
     allAttrs.push(attrs)
     allSections.push(splitSections(body))

--- a/src/api/diff.js
+++ b/src/api/diff.js
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { parseFrontmatter, splitSections } from '../utils/converter.js'
 
 function diffLines(aLines, bLines) {
@@ -33,20 +33,13 @@ function diffFrontmatter(attrsA, attrsB) {
 }
 
 export async function apiDiff(skillA, skillB, _options = {}) {
-  try {
-    await stat(skillA)
-  } catch {
-    throw new Error(`Skill file not found: ${skillA}`)
-  }
-  try {
-    await stat(skillB)
-  } catch {
-    throw new Error(`Skill file not found: ${skillB}`)
-  }
-
   const [rawA, rawB] = await Promise.all([
-    readFile(skillA, 'utf-8'),
-    readFile(skillB, 'utf-8'),
+    readFile(skillA, 'utf-8').catch(() => {
+      throw new Error(`Skill file not found: ${skillA}`)
+    }),
+    readFile(skillB, 'utf-8').catch(() => {
+      throw new Error(`Skill file not found: ${skillB}`)
+    }),
   ])
 
   const { attrs: attrsA, body: bodyA } = parseFrontmatter(rawA)

--- a/src/api/diff.js
+++ b/src/api/diff.js
@@ -1,24 +1,5 @@
-import { readFileSync, existsSync } from 'node:fs'
-import { parseFrontmatter } from '../utils/converter.js'
-
-function splitSections(body) {
-  const lines = body.split('\n')
-  const sections = []
-  let current = null
-
-  for (const line of lines) {
-    const headingMatch = line.match(/^##\s+(.+)/)
-    if (headingMatch) {
-      if (current) sections.push(current)
-      current = { heading: headingMatch[1].trim(), lines: [] }
-    } else if (current) {
-      current.lines.push(line)
-    }
-  }
-  if (current) sections.push(current)
-
-  return sections
-}
+import { readFile, stat } from 'node:fs/promises'
+import { parseFrontmatter, splitSections } from '../utils/converter.js'
 
 function diffLines(aLines, bLines) {
   const added = []
@@ -52,11 +33,21 @@ function diffFrontmatter(attrsA, attrsB) {
 }
 
 export async function apiDiff(skillA, skillB, _options = {}) {
-  if (!existsSync(skillA)) throw new Error(`Skill file not found: ${skillA}`)
-  if (!existsSync(skillB)) throw new Error(`Skill file not found: ${skillB}`)
+  try {
+    await stat(skillA)
+  } catch {
+    throw new Error(`Skill file not found: ${skillA}`)
+  }
+  try {
+    await stat(skillB)
+  } catch {
+    throw new Error(`Skill file not found: ${skillB}`)
+  }
 
-  const rawA = readFileSync(skillA, 'utf-8')
-  const rawB = readFileSync(skillB, 'utf-8')
+  const [rawA, rawB] = await Promise.all([
+    readFile(skillA, 'utf-8'),
+    readFile(skillB, 'utf-8'),
+  ])
 
   const { attrs: attrsA, body: bodyA } = parseFrontmatter(rawA)
   const { attrs: attrsB, body: bodyB } = parseFrontmatter(rawB)

--- a/src/api/doctor.js
+++ b/src/api/doctor.js
@@ -16,7 +16,7 @@ import {
   computeContentHash,
 } from '../utils/lockfile.js'
 import { detectAgents } from '../commands/setup.js'
-import { parseFrontmatter } from '../utils/converter.js'
+import { parseFrontmatter, splitSections } from '../utils/converter.js'
 import agents from '../agents.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -251,23 +251,6 @@ function countAgentSkills(dir) {
   } catch {
     return 0
   }
-}
-
-function splitSections(body) {
-  const lines = body.split('\n')
-  const sections = []
-  let current = null
-  for (const line of lines) {
-    const headingMatch = line.match(/^##\s+(.+)/)
-    if (headingMatch) {
-      if (current) sections.push(current)
-      current = { heading: headingMatch[1].trim(), lines: [] }
-    } else if (current) {
-      current.lines.push(line)
-    }
-  }
-  if (current) sections.push(current)
-  return sections
 }
 
 function parseSkillContent(skillDir) {

--- a/src/api/install.js
+++ b/src/api/install.js
@@ -143,7 +143,7 @@ export async function apiInstallSkills(source, options = {}) {
           (t) => t !== 'project' && supportedAgents.includes(t),
         )
         for (const server of mcpServers) {
-          const resolvedMcp = resolveMcpSource(server.source)
+          const resolvedMcp = await resolveMcpSource(server.source)
           const installed = []
           for (const agent of mcpTargets) {
             const ok = await addMcpServer(agent, server.name, resolvedMcp)

--- a/src/api/mcp.js
+++ b/src/api/mcp.js
@@ -24,7 +24,7 @@ async function fetchNpmLatestVersion(packageName) {
 }
 
 export async function apiMcpInstall(source, options = {}) {
-  const resolved = resolveMcpSource(source)
+  const resolved = await resolveMcpSource(source)
   const scanResult = scanMcpServer(resolved)
 
   if (scanResult.issues.length > 0) {
@@ -84,7 +84,7 @@ export async function apiMcpList(options = {}) {
 }
 
 export async function apiMcpUpdate(source, options = {}) {
-  const resolved = resolveMcpSource(source)
+  const resolved = await resolveMcpSource(source)
   const targets =
     options.agents && options.agents.length > 0
       ? options.agents

--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -57,7 +57,8 @@ export async function mcpInstallCommand(source, options) {
   }
 
   if (options.dryRun) {
-    const resolved = (await import('../utils/mcp.js')).resolveMcpSource(source)
+    const { resolveMcpSource: mcpResolve } = await import('../utils/mcp.js')
+    const resolved = await mcpResolve(source)
     const targets =
       options.agents?.length > 0 ? options.agents : getSupportedMcpAgents()
     console.log(`\n📋 [dry-run] Would install MCP server from: ${source}`)
@@ -120,7 +121,8 @@ export async function mcpUpdateCommand(source, options) {
   }
 
   if (options.dryRun) {
-    const resolved = (await import('../utils/mcp.js')).resolveMcpSource(source)
+    const { resolveMcpSource: mcpResolve } = await import('../utils/mcp.js')
+    const resolved = await mcpResolve(source)
     const targets =
       options.agents?.length > 0 ? options.agents : getSupportedMcpAgents()
     console.log(`\n📋 [dry-run] Would update MCP server from: ${source}`)

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -246,7 +246,7 @@ export async function setupCommand(source, options = {}) {
             .filter((a) => supported.includes(a.flag))
             .map((a) => a.flag)
           for (const server of mcpServers) {
-            const resolvedMcp = resolveMcpSource(server.source)
+            const resolvedMcp = await resolveMcpSource(server.source)
             let installedCount = 0
             for (const agent of mcpTargets) {
               const ok = await addMcpServer(agent, server.name, resolvedMcp)

--- a/src/utils/converter.js
+++ b/src/utils/converter.js
@@ -152,3 +152,26 @@ export function detectFormat(filePath) {
   if (filePath.endsWith('SKILL.md')) return 'skill'
   return null
 }
+
+/**
+ * Split a markdown body into sections by ## headings.
+ * Shared utility used by compose, diff, and doctor modules.
+ */
+export function splitSections(body) {
+  const lines = body.split('\n')
+  const sections = []
+  let current = null
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^##\s+(.+)/)
+    if (headingMatch) {
+      if (current) sections.push(current)
+      current = { heading: headingMatch[1].trim(), lines: [] }
+    } else if (current) {
+      current.lines.push(line)
+    }
+  }
+  if (current) sections.push(current)
+
+  return sections
+}

--- a/src/utils/mcp.js
+++ b/src/utils/mcp.js
@@ -1,12 +1,17 @@
-import { readFile, writeFile, mkdir } from 'node:fs/promises'
-import { join, dirname } from 'node:path'
-import { homedir } from 'node:os'
+import {
+  readFile,
+  writeFile,
+  mkdir,
+  rm,
+  mkdtemp,
+  readdir,
+} from 'node:fs/promises'
+import { join, dirname, relative } from 'node:path'
+import { homedir, tmpdir } from 'node:os'
 import {
   execSync as defaultExecSync,
   spawnSync as defaultSpawnSync,
 } from 'node:child_process'
-import { tmpdir } from 'node:os'
-import { mkdtempSync, readFileSync, readdirSync } from 'node:fs'
 import agents from '../agents.js'
 import { addServerToMcpLock, removeServerFromMcpLock } from './mcp-lock.js'
 
@@ -222,7 +227,7 @@ export function classifyMcpSource(source) {
   return { label: 'local path', type: 'local' }
 }
 
-export function resolveMcpSource(source) {
+export async function resolveMcpSource(source) {
   if (source.startsWith('npm:')) {
     let pkg = source.slice(4)
     let version = null
@@ -248,9 +253,8 @@ export function resolveMcpSource(source) {
       ref = repo.slice(atIdx + 1)
       repo = repo.slice(0, atIdx)
     }
-    const tmpDir = mkdtempSync(join(tmpdir(), 'rolecraft-mcp-'))
+    const tmpDir = await mkdtemp(join(tmpdir(), 'rolecraft-mcp-'))
     const cloneDir = join(tmpDir, 'repo')
-    let fileContents
     try {
       const cloneArgs = [
         'clone',
@@ -271,7 +275,7 @@ export function resolveMcpSource(source) {
           `Failed to clone ${repo}: ${result.stderr?.toString() || result.status}`,
         )
       const pkgJson = JSON.parse(
-        readFileSync(join(cloneDir, 'package.json'), 'utf-8'),
+        await readFile(join(cloneDir, 'package.json'), 'utf-8'),
       )
       const main = pkgJson.main || 'index.js'
       const bin = pkgJson.bin
@@ -280,40 +284,37 @@ export function resolveMcpSource(source) {
           : Object.values(pkgJson.bin)[0]
         : null
       const command = bin ? join(cloneDir, bin) : join(cloneDir, main)
-      const args = []
 
-      fileContents = {}
-      function readFilesRecursive(dir, baseDir) {
-        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      // Read all files asynchronously for security scanning
+      const fileContents = {}
+      async function readFilesRecursive(dir, baseDir) {
+        const entries = await readdir(dir, { withFileTypes: true })
+        for (const entry of entries) {
           const fullPath = join(dir, entry.name)
           if (entry.isDirectory()) {
             if (entry.name === '.git' || entry.name === 'node_modules') continue
-            readFilesRecursive(fullPath, baseDir)
+            await readFilesRecursive(fullPath, baseDir)
           } else if (entry.isFile()) {
             try {
               const relPath = relative(baseDir, fullPath)
-              fileContents[relPath] = readFileSync(fullPath, 'utf-8')
+              fileContents[relPath] = await readFile(fullPath, 'utf-8')
             } catch {}
           }
         }
       }
-      readFilesRecursive(cloneDir, cloneDir)
+      await readFilesRecursive(cloneDir, cloneDir)
 
-      try {
-        runSpawnSync('rm', ['-rf', tmpDir], { stdio: 'pipe' })
-      } catch {}
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
       return {
         command: 'node',
-        args: [command, ...args],
+        args: [command],
         sourceType: 'github',
         repo,
         ref,
         fileContents,
       }
     } catch (err) {
-      try {
-        runSpawnSync('rm', ['-rf', tmpDir], { stdio: 'pipe' })
-      } catch {}
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
       throw err
     }
   }
@@ -408,7 +409,7 @@ export async function installMcpServersFromSkill(skillContent, targets) {
   if (servers.length === 0) return []
   const results = []
   for (const server of servers) {
-    const resolved = resolveMcpSource(server.source)
+    const resolved = await resolveMcpSource(server.source)
     for (const agent of targets) {
       const success = await addMcpServer(
         agent,

--- a/src/utils/mcp.test.js
+++ b/src/utils/mcp.test.js
@@ -529,8 +529,8 @@ Just content
   })
 
   describe('resolveMcpSource', () => {
-    it('resolves npm: source', () => {
-      const resolved = mcpModule.resolveMcpSource(
+    it('resolves npm: source', async () => {
+      const resolved = await mcpModule.resolveMcpSource(
         'npm:@modelcontextprotocol/github',
       )
       assert.equal(resolved.command, 'npx')
@@ -539,8 +539,8 @@ Just content
       assert.equal(resolved.packageVersion, null)
     })
 
-    it('resolves npm: source with @version (scoped)', () => {
-      const resolved = mcpModule.resolveMcpSource(
+    it('resolves npm: source with @version (scoped)', async () => {
+      const resolved = await mcpModule.resolveMcpSource(
         'npm:@modelcontextprotocol/github@1.2.3',
       )
       assert.equal(resolved.command, 'npx')
@@ -553,38 +553,40 @@ Just content
       assert.equal(resolved.packageVersion, '1.2.3')
     })
 
-    it('resolves npm: source with @version (unscoped)', () => {
-      const resolved = mcpModule.resolveMcpSource('npm:lodash@4.17.21')
+    it('resolves npm: source with @version (unscoped)', async () => {
+      const resolved = await mcpModule.resolveMcpSource('npm:lodash@4.17.21')
       assert.equal(resolved.command, 'npx')
       assert.deepEqual(resolved.args, ['-y', 'lodash@4.17.21'])
       assert.equal(resolved.packageName, 'lodash')
       assert.equal(resolved.packageVersion, '4.17.21')
     })
 
-    it('resolves npm: source with tag as version', () => {
-      const resolved = mcpModule.resolveMcpSource('npm:@scope/pkg@latest')
+    it('resolves npm: source with tag as version', async () => {
+      const resolved = await mcpModule.resolveMcpSource('npm:@scope/pkg@latest')
       assert.equal(resolved.command, 'npx')
       assert.deepEqual(resolved.args, ['-y', '@scope/pkg@latest'])
       assert.equal(resolved.packageName, '@scope/pkg')
       assert.equal(resolved.packageVersion, 'latest')
     })
 
-    it('resolves uvx: source', () => {
-      const resolved = mcpModule.resolveMcpSource('uvx:@anthropic/postgres-mcp')
+    it('resolves uvx: source', async () => {
+      const resolved = await mcpModule.resolveMcpSource(
+        'uvx:@anthropic/postgres-mcp',
+      )
       assert.equal(resolved.command, 'uvx')
       assert.deepEqual(resolved.args, ['@anthropic/postgres-mcp'])
       assert.equal(resolved.sourceType, 'uvx')
     })
 
-    it('resolves pipx: source', () => {
-      const resolved = mcpModule.resolveMcpSource('pipx:postgres-mcp')
+    it('resolves pipx: source', async () => {
+      const resolved = await mcpModule.resolveMcpSource('pipx:postgres-mcp')
       assert.equal(resolved.command, 'pipx')
       assert.deepEqual(resolved.args, ['run', 'postgres-mcp'])
       assert.equal(resolved.sourceType, 'pipx')
     })
 
-    it('resolves go: source', () => {
-      const resolved = mcpModule.resolveMcpSource(
+    it('resolves go: source', async () => {
+      const resolved = await mcpModule.resolveMcpSource(
         'go:github.com/org/mcp-server',
       )
       assert.equal(resolved.command, 'go')
@@ -592,49 +594,51 @@ Just content
       assert.equal(resolved.sourceType, 'go')
     })
 
-    it('resolves deno: source', () => {
-      const resolved = mcpModule.resolveMcpSource('deno:jsr:@org/mcp-server')
+    it('resolves deno: source', async () => {
+      const resolved = await mcpModule.resolveMcpSource(
+        'deno:jsr:@org/mcp-server',
+      )
       assert.equal(resolved.command, 'deno')
       assert.deepEqual(resolved.args, ['run', 'jsr:@org/mcp-server'])
       assert.equal(resolved.sourceType, 'deno')
     })
 
-    it('resolves cargo: source', () => {
-      const resolved = mcpModule.resolveMcpSource('cargo:my-mcp-server')
+    it('resolves cargo: source', async () => {
+      const resolved = await mcpModule.resolveMcpSource('cargo:my-mcp-server')
       assert.equal(resolved.command, 'cargo')
       assert.deepEqual(resolved.args, ['run', 'my-mcp-server'])
       assert.equal(resolved.sourceType, 'cargo')
     })
 
-    it('resolves local path source', () => {
-      const resolved = mcpModule.resolveMcpSource('/path/to/server.js')
+    it('resolves local path source', async () => {
+      const resolved = await mcpModule.resolveMcpSource('/path/to/server.js')
       assert.equal(resolved.command, 'node')
       assert.deepEqual(resolved.args, ['/path/to/server.js'])
       assert.equal(resolved.sourceType, 'local')
     })
 
-    it('resolves relative path source', () => {
-      const resolved = mcpModule.resolveMcpSource('./my-server.js')
+    it('resolves relative path source', async () => {
+      const resolved = await mcpModule.resolveMcpSource('./my-server.js')
       assert.equal(resolved.command, 'node')
       assert.equal(resolved.sourceType, 'local')
     })
 
-    it('resolves ~ path source', () => {
-      const resolved = mcpModule.resolveMcpSource('~/dev/my-server.js')
+    it('resolves ~ path source', async () => {
+      const resolved = await mcpModule.resolveMcpSource('~/dev/my-server.js')
       assert.equal(resolved.command, 'node')
       assert.equal(resolved.sourceType, 'local')
     })
 
-    it('throws for unknown source format', () => {
-      assert.throws(
+    it('throws for unknown source format', async () => {
+      await assert.rejects(
         () => mcpModule.resolveMcpSource('invalid-source'),
         /Unknown MCP source format/,
       )
     })
 
-    it('throws when gh: source clone fails', () => {
+    it('throws when gh: source clone fails', async () => {
       mcpModule.setSpawnSync(() => ({ status: 1, stderr: 'mock failure' }))
-      assert.throws(
+      await assert.rejects(
         () => mcpModule.resolveMcpSource('gh:test/repo'),
         /Failed to clone/,
       )
@@ -657,7 +661,7 @@ Just content
           if (cmd === 'rm') return { status: 0 }
           return { status: 0 }
         })
-        const resolved = mcpModule.resolveMcpSource('gh:test/mcp-server')
+        const resolved = await mcpModule.resolveMcpSource('gh:test/mcp-server')
         assert.equal(resolved.command, 'node')
         assert.equal(resolved.sourceType, 'github')
         assert.equal(resolved.repo, 'test/mcp-server')
@@ -666,7 +670,7 @@ Just content
       }),
     )
 
-    it('gh: source with @branch ref uses --branch flag', () => {
+    it('gh: source with @branch ref uses --branch flag', async () => {
       const capturedArgs = []
       mcpModule.setSpawnSync((cmd, args) => {
         if (cmd === 'git') {
@@ -682,7 +686,9 @@ Just content
         if (cmd === 'rm') return { status: 0 }
         return { status: 0 }
       })
-      const resolved = mcpModule.resolveMcpSource('gh:test/mcp-server@main')
+      const resolved = await mcpModule.resolveMcpSource(
+        'gh:test/mcp-server@main',
+      )
       assert.equal(resolved.repo, 'test/mcp-server')
       assert.equal(resolved.ref, 'main')
       assert.ok(capturedArgs.includes('--branch'))
@@ -690,7 +696,7 @@ Just content
       mcpModule.setSpawnSync(undefined)
     })
 
-    it('gh: source with @tag ref', () => {
+    it('gh: source with @tag ref', async () => {
       const capturedArgs = []
       mcpModule.setSpawnSync((cmd, args) => {
         if (cmd === 'git') {
@@ -706,7 +712,7 @@ Just content
         if (cmd === 'rm') return { status: 0 }
         return { status: 0 }
       })
-      const resolved = mcpModule.resolveMcpSource('gh:owner/repo@v1.0.0')
+      const resolved = await mcpModule.resolveMcpSource('gh:owner/repo@v1.0.0')
       assert.equal(resolved.repo, 'owner/repo')
       assert.equal(resolved.ref, 'v1.0.0')
       assert.ok(capturedArgs.includes('--branch'))


### PR DESCRIPTION
## Summary

**−41 lines** (580 added, 621 removed), **929 tests passing**, **0 regressions**.

## Changes by Severity

### 🔴 Critical

**CLI dispatch refactor (`bin/rolecraft.js`)**
- Replaced 29-case switch/case with a command registry (map of command names to handlers)
- Extracted shared CLI helpers: `isHelp()`, `parseFlags()`, `parsePositionals()`, `parseFlagValue()`, `parseSkillOption()`, `buildInstallScope()`
- Eliminated **24 duplicated `--help` guards** and **3 copies of `--skill` parsing**

### 🟡 High

**Extract duplicated `splitSections`**
- Moved from 3 files (compose.js, diff.js, doctor.js) into `converter.js` — single shared utility alongside existing frontmatter helpers

**Async I/O for compose.js, diff.js, agents-xml.js**
- Replaced `readFileSync`/ `existsSync` / `readdirSync` with `fs.promises` equivalents
- Functions were already async, so the API surface is unchanged

### 🟢 Medium

**MCP gh: source resolver now async**
- Replaced `mkdtempSync` → `mkdtemp`, `readFileSync` → `readFile`, `readdirSync` → `readdir`
- Replaced `spawnSync('rm', ...)` with `fs.rm` for cleanup
- Updated 7+ call sites and all test callers

---

Co-Authored-By: Claude <noreply@anthropic.com>