### PR TITLE
fix: security scan bypass in setup/profile/ci + bundle + P1 hardening

### DIFF
--- a/.github/scripts/release-prep.sh
+++ b/.github/scripts/release-prep.sh
@@ -100,9 +100,9 @@ if [ -f package.json ]; then
   else
     node -e "
       const pkg = require('./package.json');
-      pkg.version = '$NEW_VERSION';
+      pkg.version = process.argv[1];
       require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
-    "
+    " "$NEW_VERSION"
   fi
 fi
 

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -574,6 +574,7 @@ const COMMANDS = {
     const opts = {
       dryRun: flags.includes('--dry-run'),
       noMcp: flags.includes('--no-mcp'),
+      yes: flags.includes('--yes') || flags.includes('-y'),
     }
     if (sources.length === 1) {
       return bundleCommand(sources[0], opts)

--- a/src/api/bundle.js
+++ b/src/api/bundle.js
@@ -88,7 +88,7 @@ export async function bundleApi(sources, options = {}) {
 
   const installOpts = {
     scope: { global: true, project: true },
-    yes: true,
+    yes: options.yes || false,
     noMcp: options.noMcp || false,
   }
 

--- a/src/api/ci.js
+++ b/src/api/ci.js
@@ -3,6 +3,7 @@ import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import { readMcpLock } from '../utils/mcp-lock.js'
 import { resolveMcpSource, addMcpServer } from '../utils/mcp.js'
+import { scanSkill, classifyScore } from '../utils/security.js'
 
 export async function apiCi(cwd = process.cwd()) {
   const [globalLock, projectLock, mcpLock] = await Promise.all([
@@ -29,6 +30,19 @@ export async function apiCi(cwd = process.cwd()) {
     }
     try {
       const resolved = await resolveSource(entry.source)
+
+      // Security scan — block dangerous skills even in CI
+      const security = scanSkill(resolved)
+      const level = classifyScore(security.score)
+      if (level === 'danger') {
+        failed.push({
+          slug,
+          source: entry.source,
+          reason: `blocked by security scan (score: ${security.score}/100)`,
+        })
+        continue
+      }
+
       const targets = entry.sourceType === 'local' ? ['project'] : ['agents']
       const results = await installSkill(resolved, targets)
       installed.push({ slug, source: entry.source, results })

--- a/src/api/profile.js
+++ b/src/api/profile.js
@@ -127,6 +127,13 @@ export async function apiProfileDelete(name, options = {}) {
   return { name, deleted: true }
 }
 
+const ALLOWED_PROFILE_HOSTS = [
+  'github.com',
+  'raw.githubusercontent.com',
+  'gist.github.com',
+  'raw.gist.github.com',
+]
+
 export async function apiProfileImport(path) {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')
@@ -142,6 +149,13 @@ export async function apiProfileImport(path) {
   let data
   const isUrl = path.startsWith('http://') || path.startsWith('https://')
   if (isUrl) {
+    const parsedUrl = new URL(path)
+    if (!ALLOWED_PROFILE_HOSTS.includes(parsedUrl.hostname)) {
+      throw new Error(
+        `URL host "${parsedUrl.hostname}" is not allowed for profile imports. ` +
+          `Allowed hosts: ${ALLOWED_PROFILE_HOSTS.join(', ')}`,
+      )
+    }
     const res = await fetch(path)
     if (!res.ok) throw new Error(`Failed to fetch ${path}: ${res.status}`)
     data = parseProfileJSON(await res.text())

--- a/src/api/setup.js
+++ b/src/api/setup.js
@@ -1,5 +1,8 @@
 import { resolveSkills } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
+import { scanSkill } from '../utils/security.js'
+import { classifyScore } from '../utils/security.js'
+import { UserError } from '../utils/errors.js'
 import { detectAgents } from '../commands/setup.js'
 
 export async function setupApi(source, options = {}) {
@@ -69,6 +72,29 @@ export async function setupApi(source, options = {}) {
       sourcePath: skill.sourcePath || source,
       sourceType: skill.sourceType || 'local',
     }
+
+    // Security scan before install
+    const security = scanSkill(resolved)
+    const level = classifyScore(security.score)
+    if ((level === 'danger' || level === 'review') && !options.yes) {
+      const issues = security.issues
+        .filter((i) => i.severity !== 'low')
+        .map(
+          (i) =>
+            `  [${i.severity}] ${i.description}${i.file ? ` (${i.file})` : ''}`,
+        )
+        .join('\n')
+      throw new UserError(
+        `"${resolved.name}" blocked by security scan (score: ${security.score}/100).`,
+        {
+          suggestion:
+            'Review the flagged issues, or use --yes to skip the security check.',
+          detail: issues,
+          code: 'SECURITY_DANGER',
+        },
+      )
+    }
+
     const results = await installSkill(resolved, targets)
     installed.push({ name: resolved.name, slug: resolved.slug, results })
   }

--- a/src/commands/profile.test.js
+++ b/src/commands/profile.test.js
@@ -945,7 +945,9 @@ describe('profile import command', () => {
     }))
 
     const logs = captureLogs()
-    await freshCmd.profileImportCommand('https://example.com/test-profile.json')
+    await freshCmd.profileImportCommand(
+      'https://raw.githubusercontent.com/test/test/main/profile.json',
+    )
 
     assert.ok(logs.some((l) => l.includes('url-profile')))
     fetchMock.mock.restore()

--- a/src/utils/mcp.js
+++ b/src/utils/mcp.js
@@ -282,7 +282,8 @@ export async function resolveMcpSource(source) {
       }
       await readFilesRecursive(cloneDir, cloneDir)
 
-      await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+      // Keep tmpDir on disk — MCP server needs the files at runtime.
+      // The OS cleans /tmp periodically; on error the catch block removes it.
       return {
         command: 'node',
         args: [command],

--- a/src/utils/profile.js
+++ b/src/utils/profile.js
@@ -20,6 +20,7 @@ import { listMcpServers, addMcpServer } from './mcp.js'
 import { readLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
 import { resolveSource } from './resolver.js'
 import { installSkill } from './installer.js'
+import { scanSkill, classifyScore } from './security.js'
 
 const PROFILES_DIR = '.agents/profiles'
 
@@ -484,7 +485,7 @@ export async function applyMcpServers(agentFlag, servers) {
   return results
 }
 
-export async function ensureSkillsInstalled(skills, targetFlags) {
+export async function ensureSkillsInstalled(skills, targetFlags, options = {}) {
   if (!skills || !Array.isArray(skills) || skills.length === 0) return []
 
   const [globalLock, projectLock] = await Promise.all([
@@ -506,6 +507,26 @@ export async function ensureSkillsInstalled(skills, targetFlags) {
 
     try {
       const resolved = await resolveSource(slug)
+
+      // Security scan before install
+      const security = scanSkill(resolved)
+      const level = classifyScore(security.score)
+      if ((level === 'danger' || level === 'review') && !options.yes) {
+        const issues = security.issues
+          .filter((i) => i.severity !== 'low')
+          .map(
+            (i) =>
+              `  [${i.severity}] ${i.description}${i.file ? ` (${i.file})` : ''}`,
+          )
+          .join('\n')
+        results.push({
+          slug,
+          action: 'failed',
+          reason: `security scan blocked (score: ${security.score}/100): ${issues}`,
+        })
+        continue
+      }
+
       const installTargets = targetFlags || ['agents']
       const installResults = await installSkill(resolved, installTargets)
       results.push({
@@ -604,7 +625,11 @@ export async function applyProfileEntry(agentFlag, entry, options = {}) {
 
   if (!options.skipSkills && entry.skills) {
     const targets = options.targets || [agentFlag]
-    const skillResult = await ensureSkillsInstalled(entry.skills, targets)
+    const skillResult = await ensureSkillsInstalled(
+      entry.skills,
+      targets,
+      options,
+    )
     for (const r of skillResult) {
       if (r.action === 'installed') result.skills.applied.push(r.slug)
       else if (r.action === 'failed')

--- a/src/utils/profile.js
+++ b/src/utils/profile.js
@@ -9,12 +9,6 @@ import {
 import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
 
-// Convert through character codes to break CodeQL taint tracking.
-function safeString(s) {
-  let r = ''
-  for (let i = 0; i < s.length; i++) r += String.fromCharCode(s.charCodeAt(i))
-  return r
-}
 import agents from '../agents.js'
 import { listMcpServers, addMcpServer } from './mcp.js'
 import { readLock, getGlobalLockPath, getProjectLockPath } from './lockfile.js'
@@ -204,7 +198,7 @@ export async function writeProfile(data) {
   }
 
   const enriched = {
-    name: safeString(data.name),
+    name: data.name,
     version: data.version ?? PROFILE_SCHEMA_VERSION,
     updatedAt: new Date().toISOString(),
     createdAt: data.createdAt ?? new Date().toISOString(),
@@ -220,7 +214,7 @@ export async function writeProfile(data) {
   ).toString('utf-8')
 
   await ensureProfileDir()
-  await writeFile(profilePath(safeString(data.name)), content, 'utf-8')
+  await writeFile(profilePath(data.name), content, 'utf-8')
   return enriched
 }
 

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -10,14 +10,6 @@ import { computeContentHash } from './lockfile.js'
 import { parseFrontmatter } from './converter.js'
 import { UserError } from './errors.js'
 
-// Convert through character codes to break CodeQL taint tracking.
-// Numeric values are not tracked as tainted, so the returned string is clean.
-function safeString(s) {
-  let r = ''
-  for (let i = 0; i < s.length; i++) r += String.fromCharCode(s.charCodeAt(i))
-  return r
-}
-
 let _runExec = defaultExecSync
 let runHttpsGet = defaultHttpsGet
 
@@ -414,11 +406,11 @@ function parseNpmRef(source) {
 
 function fetchJson(url) {
   const parsed = new URL(url)
-  const hostname = safeString(parsed.hostname)
+  const hostname = parsed.hostname
   if (!hostname.endsWith('.npmjs.org') && hostname !== 'npmjs.org') {
     throw new Error(`Fetch not allowed from ${hostname}`)
   }
-  const cleanUrl = `https://${hostname}${safeString(parsed.pathname)}${safeString(parsed.search)}`
+  const cleanUrl = `https://${hostname}${parsed.pathname}${parsed.search}`
   return new Promise((resolve, reject) => {
     const req = runHttpsGet(
       cleanUrl,
@@ -452,11 +444,11 @@ function fetchJson(url) {
 
 async function downloadFile(url, dest) {
   const parsed = new URL(url)
-  const dlHost = safeString(parsed.hostname)
+  const dlHost = parsed.hostname
   if (dlHost !== 'registry.npmjs.org') {
     throw new Error(`Download not allowed from ${dlHost}`)
   }
-  const dlUrl = `https://${dlHost}${safeString(parsed.pathname)}${safeString(parsed.search)}`
+  const dlUrl = `https://${dlHost}${parsed.pathname}${parsed.search}`
 
   const response = await fetch(dlUrl)
   if (!response.ok) {
@@ -470,7 +462,7 @@ async function downloadFile(url, dest) {
 
 async function resolveNpmInternal(source) {
   const { pkgName, version } = parseNpmRef(source)
-  const encodedName = encodeURIComponent(safeString(pkgName))
+  const encodedName = encodeURIComponent(pkgName)
 
   let metadata
   try {
@@ -510,6 +502,24 @@ async function resolveNpmInternal(source) {
 
   try {
     await downloadFile(tarballUrl, tarballPath)
+
+    // Validate tarball entries before extraction (prevent path traversal)
+    const listResult = runSpawn('tar', ['-tf', tarballPath], {
+      stdio: 'pipe',
+      timeout: 10000,
+    })
+    if (listResult.status === 0) {
+      const entries = listResult.stdout.toString().split('\n').filter(Boolean)
+      const dangerous = entries.some(
+        (e) => e.includes('..') || e.startsWith('/'),
+      )
+      if (dangerous) {
+        throw new Error(
+          `Tarball contains unsafe path entries: ${entries.find((e) => e.includes('..') || e.startsWith('/'))}`,
+        )
+      }
+    }
+
     const tarResult = runSpawn('tar', ['-xzf', tarballPath, '-C', tmpDir], {
       stdio: 'pipe',
       timeout: 30000,


### PR DESCRIPTION
Closes the security-scan bypass paths and applies several P1 hardening fixes.

**Commit 1 — Security scan bypass**:
- `setup` (`api/setup.js`): now runs `scanSkill` before `installSkill`
- `profile apply` (`utils/profile.js` `ensureSkillsInstalled`): runs scan, blocks DANGER/review without `--yes`
- `ci` (`api/ci.js`): blocks DANGER skills even in CI
- `profile import` (`api/profile.js`): URL whitelist (github.com, raw.githubusercontent.com, gist) to prevent SSRF
- `gh:` MCP source (`utils/mcp.js`): no longer deletes the tmpDir the server config points to

**Commit 2 — P1 hardening**:
- Removed the `safeString` CodeQL taint-evasion no-op (identity function) from `resolver.js` and `profile.js`
- `bundle`: no longer hardcodes `yes: true`; added `--yes` flag
- `release-prep.sh`: uses `process.argv[1]` instead of shell interpolation into `node -e`
- npm tarball extraction: validates entries for `../` traversal before extracting

🤖 Generated with [Claude Code](https://claude.com/claude-code)