### PR TITLE
refactor: extract home helper to shared utility

### DIFF
--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -17,7 +17,6 @@ import {
   computeFileHashes,
 } from './lockfile.js'
 import { getAgentByFlag } from '../agents.js'
-import { home } from './paths.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -27,11 +26,7 @@ function normalizeSlug(slug) {
  * Get the backup directory path for a skill.
  */
 export function getBackupDir(slug) {
-  return home(
-    '.agents',
-    '.backups',
-    normalizeSlug(slug),
-  )
+  return home('.agents', '.backups', normalizeSlug(slug))
 }
 
 /**
@@ -44,20 +39,11 @@ export async function backupSkill(slug, fileContents) {
 
   await mkdir(backupDir, { recursive: true })
 
-  const timestamp = new Date()
-    .toISOString()
-    .replace(/[:.]/g, '-')
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
 
-  const backupFile = join(
-    backupDir,
-    `${timestamp}.json`,
-  )
+  const backupFile = join(backupDir, `${timestamp}.json`)
 
-  await writeFile(
-    backupFile,
-    JSON.stringify(fileContents, null, 2),
-    'utf-8',
-  )
+  await writeFile(backupFile, JSON.stringify(fileContents, null, 2), 'utf-8')
 
   return timestamp
 }
@@ -98,10 +84,7 @@ export async function restoreSkill(slug) {
     return null
   }
 
-  const raw = await readFile(
-    backups[0].path,
-    'utf-8',
-  )
+  const raw = await readFile(backups[0].path, 'utf-8')
 
   return JSON.parse(raw)
 }
@@ -116,17 +99,10 @@ export async function removeLatestBackup(slug) {
     return
   }
 
-  await rm(
-    backups[0].path,
-    { force: true },
-  ).catch(() => {})
+  await rm(backups[0].path, { force: true }).catch(() => {})
 }
 
-export async function installSkill(
-  resolved,
-  targets,
-  mode = 'copy',
-) {
+export async function installSkill(resolved, targets, mode = 'copy') {
   const slug = resolved.slug
 
   const agentNames = targets.map((target) => {
@@ -144,11 +120,7 @@ export async function installSkill(
     let label
 
     if (target === 'project') {
-      baseDir = join(
-        process.cwd(),
-        '.agents',
-        'skills',
-      )
+      baseDir = join(process.cwd(), '.agents', 'skills')
 
       label = './.agents/skills/'
     } else {
@@ -162,16 +134,10 @@ export async function installSkill(
       label = agent.label
     }
 
-    const slugDir = join(
-      baseDir,
-      normalizeSlug(slug),
-    )
+    const slugDir = join(baseDir, normalizeSlug(slug))
 
     if (mode === 'symlink' && resolved.skillDir) {
-      const relPath = relative(
-        dirname(slugDir),
-        resolved.skillDir,
-      )
+      const relPath = relative(dirname(slugDir), resolved.skillDir)
 
       await rm(slugDir, {
         recursive: true,
@@ -189,30 +155,23 @@ export async function installSkill(
 
         const oldFiles = {}
 
-        const oldEntries = await readdir(
-          slugDir,
-          {
-            withFileTypes: true,
-          },
-        ).catch(() => [])
+        const oldEntries = await readdir(slugDir, {
+          withFileTypes: true,
+        }).catch(() => [])
 
         for (const entry of oldEntries) {
           if (entry.isFile()) {
             try {
-              oldFiles[entry.name] =
-                await readFile(
-                  join(slugDir, entry.name),
-                  'utf-8',
-                )
+              oldFiles[entry.name] = await readFile(
+                join(slugDir, entry.name),
+                'utf-8',
+              )
             } catch {}
           }
         }
 
         if (Object.keys(oldFiles).length > 0) {
-          await backupSkill(
-            slug,
-            oldFiles,
-          ).catch(() => {})
+          await backupSkill(slug, oldFiles).catch(() => {})
         }
       } catch {
         // Directory does not exist yet.
@@ -228,38 +187,20 @@ export async function installSkill(
       })
 
       for (const file of resolved.files) {
-        const destination = join(
-          slugDir,
-          file,
-        )
+        const destination = join(slugDir, file)
 
-        if (
-          Object.hasOwn(
-            resolved.fileContents || {},
-            file,
-          )
-        ) {
-          await writeFile(
-            destination,
-            resolved.fileContents[file],
-          )
+        if (Object.hasOwn(resolved.fileContents || {}, file)) {
+          await writeFile(destination, resolved.fileContents[file])
         } else if (resolved.skillDir) {
-          const source = join(
-            resolved.skillDir,
-            file,
-          )
+          const source = join(resolved.skillDir, file)
 
           try {
             await stat(source)
 
-            await cp(
-              source,
-              destination,
-              {
-                recursive: true,
-                force: true,
-              },
-            )
+            await cp(source, destination, {
+              recursive: true,
+              force: true,
+            })
           } catch {
             // Skip files that do not exist.
           }
@@ -278,9 +219,7 @@ export async function installSkill(
         slug,
         contentSha: resolved.contentSha,
         fileHashes: resolved.fileContents
-          ? computeFileHashes(
-              resolved.fileContents,
-            )
+          ? computeFileHashes(resolved.fileContents)
           : undefined,
         installedAt: new Date().toISOString(),
         agents: agentNames,
@@ -298,18 +237,13 @@ export async function installSkill(
   }
 
   const outcomes = await Promise.allSettled(
-    targets.map((target) =>
-      installToTarget(target),
-    ),
+    targets.map((target) => installToTarget(target)),
   )
 
   const results = []
 
   for (const outcome of outcomes) {
-    if (
-      outcome.status === 'fulfilled' &&
-      outcome.value !== null
-    ) {
+    if (outcome.status === 'fulfilled' && outcome.value !== null) {
       results.push(outcome.value)
     }
   }

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -9,7 +9,6 @@ import {
   readdir,
 } from 'node:fs/promises'
 import { join, relative, dirname } from 'node:path'
-import { homedir } from 'node:os'
 import {
   addSkillToLock,
   getGlobalLockPath,
@@ -17,20 +16,21 @@ import {
   computeFileHashes,
 } from './lockfile.js'
 import { getAgentByFlag } from '../agents.js'
+import { home } from './paths.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
-}
-
-function home(...parts) {
-  return join(homedir(), ...parts)
 }
 
 /**
  * Get the backup directory path for a skill.
  */
 export function getBackupDir(slug) {
-  return home('.agents', '.backups', normalizeSlug(slug))
+  return home(
+    '.agents',
+    '.backups',
+    normalizeSlug(slug),
+  )
 }
 
 /**
@@ -40,10 +40,24 @@ export function getBackupDir(slug) {
  */
 export async function backupSkill(slug, fileContents) {
   const backupDir = getBackupDir(slug)
+
   await mkdir(backupDir, { recursive: true })
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-  const backupFile = join(backupDir, `${timestamp}.json`)
-  await writeFile(backupFile, JSON.stringify(fileContents, null, 2), 'utf-8')
+
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[:.]/g, '-')
+
+  const backupFile = join(
+    backupDir,
+    `${timestamp}.json`,
+  )
+
+  await writeFile(
+    backupFile,
+    JSON.stringify(fileContents, null, 2),
+    'utf-8',
+  )
+
   return timestamp
 }
 
@@ -52,19 +66,23 @@ export async function backupSkill(slug, fileContents) {
  */
 export async function listBackups(slug) {
   const backupDir = getBackupDir(slug)
+
   let entries
+
   try {
     entries = await readdir(backupDir)
   } catch {
     return []
   }
+
   const backups = entries
-    .filter((e) => e.endsWith('.json'))
+    .filter((entry) => entry.endsWith('.json'))
     .sort()
     .reverse()
-  return backups.map((b) => ({
-    timestamp: b.replace('.json', ''),
-    path: join(backupDir, b),
+
+  return backups.map((backup) => ({
+    timestamp: backup.replace('.json', ''),
+    path: join(backupDir, backup),
   }))
 }
 
@@ -74,8 +92,16 @@ export async function listBackups(slug) {
  */
 export async function restoreSkill(slug) {
   const backups = await listBackups(slug)
-  if (backups.length === 0) return null
-  const raw = await readFile(backups[0].path, 'utf-8')
+
+  if (backups.length === 0) {
+    return null
+  }
+
+  const raw = await readFile(
+    backups[0].path,
+    'utf-8',
+  )
+
   return JSON.parse(raw)
 }
 
@@ -84,16 +110,28 @@ export async function restoreSkill(slug) {
  */
 export async function removeLatestBackup(slug) {
   const backups = await listBackups(slug)
-  if (backups.length === 0) return
-  await rm(backups[0].path, { force: true }).catch(() => {})
+
+  if (backups.length === 0) {
+    return
+  }
+
+  await rm(
+    backups[0].path,
+    { force: true },
+  ).catch(() => {})
 }
 
-export async function installSkill(resolved, targets, mode = 'copy') {
+export async function installSkill(
+  resolved,
+  targets,
+  mode = 'copy',
+) {
   const slug = resolved.slug
 
-  const agentNames = targets.map((t) => {
-    const agent = getAgentByFlag(t)
-    return agent ? agent.name : t
+  const agentNames = targets.map((target) => {
+    const agent = getAgentByFlag(target)
+
+    return agent ? agent.name : target
   })
 
   /**
@@ -105,59 +143,124 @@ export async function installSkill(resolved, targets, mode = 'copy') {
     let label
 
     if (target === 'project') {
-      baseDir = join(process.cwd(), '.agents', 'skills')
+      baseDir = join(
+        process.cwd(),
+        '.agents',
+        'skills',
+      )
+
       label = './.agents/skills/'
     } else {
       const agent = getAgentByFlag(target)
-      if (!agent) return null
+
+      if (!agent) {
+        return null
+      }
+
       baseDir = agent.getDir()
       label = agent.label
     }
 
-    const slugDir = join(baseDir, normalizeSlug(slug))
+    const slugDir = join(
+      baseDir,
+      normalizeSlug(slug),
+    )
 
     if (mode === 'symlink' && resolved.skillDir) {
-      const relPath = relative(dirname(slugDir), resolved.skillDir)
-      await rm(slugDir, { recursive: true, force: true })
-      await mkdir(dirname(slugDir), { recursive: true })
+      const relPath = relative(
+        dirname(slugDir),
+        resolved.skillDir,
+      )
+
+      await rm(slugDir, {
+        recursive: true,
+        force: true,
+      })
+
+      await mkdir(dirname(slugDir), {
+        recursive: true,
+      })
+
       await symlink(relPath, slugDir)
     } else {
-      // Back up existing files before overwriting (for rollback support)
       try {
         await stat(slugDir)
+
         const oldFiles = {}
-        const oldEntries = await readdir(slugDir, {
-          withFileTypes: true,
-        }).catch(() => [])
+
+        const oldEntries = await readdir(
+          slugDir,
+          {
+            withFileTypes: true,
+          },
+        ).catch(() => [])
+
         for (const entry of oldEntries) {
           if (entry.isFile()) {
             try {
-              oldFiles[entry.name] = await readFile(
-                join(slugDir, entry.name),
-                'utf-8',
-              )
+              oldFiles[entry.name] =
+                await readFile(
+                  join(slugDir, entry.name),
+                  'utf-8',
+                )
             } catch {}
           }
         }
+
         if (Object.keys(oldFiles).length > 0) {
-          await backupSkill(slug, oldFiles).catch(() => {})
+          await backupSkill(
+            slug,
+            oldFiles,
+          ).catch(() => {})
         }
       } catch {
-        // directory doesn't exist yet — nothing to back up
+        // Directory does not exist yet.
       }
-      await rm(slugDir, { recursive: true, force: true })
-      await mkdir(slugDir, { recursive: true })
+
+      await rm(slugDir, {
+        recursive: true,
+        force: true,
+      })
+
+      await mkdir(slugDir, {
+        recursive: true,
+      })
+
       for (const file of resolved.files) {
-        const dst = join(slugDir, file)
-        if (Object.hasOwn(resolved.fileContents || {}, file)) {
-          await writeFile(dst, resolved.fileContents[file])
+        const destination = join(
+          slugDir,
+          file,
+        )
+
+        if (
+          Object.hasOwn(
+            resolved.fileContents || {},
+            file,
+          )
+        ) {
+          await writeFile(
+            destination,
+            resolved.fileContents[file],
+          )
         } else if (resolved.skillDir) {
-          const src = join(resolved.skillDir, file)
+          const source = join(
+            resolved.skillDir,
+            file,
+          )
+
           try {
-            await stat(src)
-            await cp(src, dst, { recursive: true, force: true })
+            await stat(source)
+
+            await cp(
+              source,
+              destination,
+              {
+                recursive: true,
+                force: true,
+              },
+            )
           } catch {
-            // skip files that don't exist
+            // Skip files that do not exist.
           }
         }
       }
@@ -174,7 +277,9 @@ export async function installSkill(resolved, targets, mode = 'copy') {
         slug,
         contentSha: resolved.contentSha,
         fileHashes: resolved.fileContents
-          ? computeFileHashes(resolved.fileContents)
+          ? computeFileHashes(
+              resolved.fileContents,
+            )
           : undefined,
         installedAt: new Date().toISOString(),
         agents: agentNames,
@@ -184,22 +289,28 @@ export async function installSkill(resolved, targets, mode = 'copy') {
       lockPath,
     )
 
-    return { target, path: slugDir, label }
+    return {
+      target,
+      path: slugDir,
+      label,
+    }
   }
 
-  // Run all target installations in parallel with error isolation
   const outcomes = await Promise.allSettled(
-    targets.map((t) => installToTarget(t)),
+    targets.map((target) =>
+      installToTarget(target),
+    ),
   )
 
   const results = []
+
   for (const outcome of outcomes) {
-    if (outcome.status === 'fulfilled' && outcome.value !== null) {
+    if (
+      outcome.status === 'fulfilled' &&
+      outcome.value !== null
+    ) {
       results.push(outcome.value)
     }
-    // Rejected targets are silently skipped — one agent failure
-    // shouldn't prevent skill installation to other agents.
-    // (installToTarget only throws on lockfile write failures.)
   }
 
   return results

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -8,6 +8,7 @@ import {
   rm,
   readdir,
 } from 'node:fs/promises'
+import { home } from './paths.js'
 import { join, relative, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import {
@@ -22,9 +23,6 @@ function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
 }
 
-function home(...parts) {
-  return join(homedir(), ...parts)
-}
 
 /**
  * Get the backup directory path for a skill.

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -3,10 +3,9 @@ import { join, dirname } from 'node:path'
 import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
 import { getAgentByFlag } from '../agents.js'
+import { home } from './paths.js'
 
-function home(...parts) {
-  return join(homedir(), ...parts)
-}
+
 
 export function getGlobalLockPath() {
   return home('.agents', '.skill-lock.json')

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -1,12 +1,8 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { createHash } from 'node:crypto'
-import { homedir } from 'node:os'
 import { getAgentByFlag } from '../agents.js'
-
-function home(...parts) {
-  return join(homedir(), ...parts)
-}
+import { home } from './paths.js'
 
 export function getGlobalLockPath() {
   return home('.agents', '.skill-lock.json')
@@ -22,7 +18,11 @@ export function getAgentsDir() {
  */
 export function getDirForAgent(flag) {
   const agent = getAgentByFlag(flag)
-  if (agent) return agent.getDir()
+
+  if (agent) {
+    return agent.getDir()
+  }
+
   return home('.agents', 'skills')
 }
 
@@ -39,13 +39,26 @@ export async function readLock(lockPath = getGlobalLockPath()) {
     const raw = await readFile(lockPath, 'utf-8')
     return JSON.parse(raw)
   } catch {
-    return { version: 3, skills: {}, dismissed: {}, lastSelectedAgents: [] }
+    return {
+      version: 3,
+      skills: {},
+      dismissed: {},
+      lastSelectedAgents: [],
+    }
   }
 }
 
-export async function writeLock(data, lockPath = getGlobalLockPath()) {
+export async function writeLock(
+  data,
+  lockPath = getGlobalLockPath(),
+) {
   await ensureParentDir(lockPath)
-  await writeFile(lockPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8')
+
+  await writeFile(
+    lockPath,
+    `${JSON.stringify(data, null, 2)}\n`,
+    'utf-8',
+  )
 }
 
 /**
@@ -60,10 +73,18 @@ const MAX_HISTORY = 5
  */
 function pushHistory(lock, slug, newEntry) {
   const existing = lock.skills[slug]
-  if (!existing?.contentSha) return // nothing to save
-  if (existing.contentSha === newEntry.contentSha) return // no change
 
-  if (!lock.skills[slug].history) lock.skills[slug].history = []
+  if (!existing?.contentSha) {
+    return
+  }
+
+  if (existing.contentSha === newEntry.contentSha) {
+    return
+  }
+
+  if (!lock.skills[slug].history) {
+    lock.skills[slug].history = []
+  }
 
   lock.skills[slug].history.push({
     contentSha: existing.contentSha,
@@ -73,9 +94,9 @@ function pushHistory(lock, slug, newEntry) {
     sourceType: existing.sourceType,
   })
 
-  // Keep only the most recent MAX_HISTORY entries
   if (lock.skills[slug].history.length > MAX_HISTORY) {
-    lock.skills[slug].history = lock.skills[slug].history.slice(-MAX_HISTORY)
+    lock.skills[slug].history =
+      lock.skills[slug].history.slice(-MAX_HISTORY)
   }
 }
 
@@ -86,13 +107,13 @@ export async function addSkillToLock(
 ) {
   const lock = await readLock(lockPath)
   const existing = lock.skills[slug]
+
   const mergedAgents = existing?.agents
     ? [...new Set([...existing.agents, ...(entry.agents || [])])]
     : entry.agents || []
 
   pushHistory(lock, slug, entry)
 
-  // Capture history before overwriting the entry (pushHistory modifies it in-place)
   const history = lock.skills[slug]?.history || []
 
   lock.skills[slug] = {
@@ -101,7 +122,9 @@ export async function addSkillToLock(
     installedAt: new Date().toISOString(),
     history,
   }
+
   await writeLock(lock, lockPath)
+
   return lock
 }
 
@@ -109,10 +132,17 @@ export async function addSkillToLock(
  * Get the rollback history for a specific skill.
  * Returns an array of historical entries (newest first).
  */
-export async function getSkillHistory(slug, lockPath = getGlobalLockPath()) {
+export async function getSkillHistory(
+  slug,
+  lockPath = getGlobalLockPath(),
+) {
   const lock = await readLock(lockPath)
   const entry = lock.skills[slug]
-  if (!entry?.history || entry.history.length === 0) return []
+
+  if (!entry?.history || entry.history.length === 0) {
+    return []
+  }
+
   return [...entry.history].reverse()
 }
 
@@ -121,19 +151,27 @@ export async function getSkillHistory(slug, lockPath = getGlobalLockPath()) {
  * Removes the most recent history entry and restores its metadata.
  * Returns the restored entry data, or null if no history exists.
  */
-export async function popHistory(slug, lockPath = getGlobalLockPath()) {
+export async function popHistory(
+  slug,
+  lockPath = getGlobalLockPath(),
+) {
   const lock = await readLock(lockPath)
   const entry = lock.skills[slug]
-  if (!entry?.history || entry.history.length === 0) return null
+
+  if (!entry?.history || entry.history.length === 0) {
+    return null
+  }
 
   const prev = entry.history.pop()
-  // Restore the previous version's metadata into the current entry
+
   lock.skills[slug].contentSha = prev.contentSha
   lock.skills[slug].fileHashes = prev.fileHashes
   lock.skills[slug].installedAt = prev.installedAt
   lock.skills[slug].source = prev.source
   lock.skills[slug].sourceType = prev.sourceType
+
   await writeLock(lock, lockPath)
+
   return prev
 }
 
@@ -142,25 +180,34 @@ export async function removeSkillFromLock(
   lockPath = getGlobalLockPath(),
 ) {
   const lock = await readLock(lockPath)
+
   delete lock.skills[slug]
+
   await writeLock(lock, lockPath)
+
   return lock
 }
 
 export function computeContentHash(fileContents) {
   const hash = createHash('sha256')
   const sortedNames = Object.keys(fileContents).sort()
+
   for (const name of sortedNames) {
     hash.update(`${name}\0`)
     hash.update(fileContents[name])
   }
+
   return hash.digest('hex')
 }
 
 export function computeFileHashes(fileContents) {
   const hashes = {}
+
   for (const [name, content] of Object.entries(fileContents)) {
-    hashes[name] = createHash('sha256').update(content).digest('hex')
+    hashes[name] = createHash('sha256')
+      .update(content)
+      .digest('hex')
   }
+
   return hashes
 }

--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -4,8 +4,6 @@ import { createHash } from 'node:crypto'
 import { getAgentByFlag } from '../agents.js'
 import { home } from './paths.js'
 
-
-
 export function getGlobalLockPath() {
   return home('.agents', '.skill-lock.json')
 }
@@ -50,17 +48,10 @@ export async function readLock(lockPath = getGlobalLockPath()) {
   }
 }
 
-export async function writeLock(
-  data,
-  lockPath = getGlobalLockPath(),
-) {
+export async function writeLock(data, lockPath = getGlobalLockPath()) {
   await ensureParentDir(lockPath)
 
-  await writeFile(
-    lockPath,
-    `${JSON.stringify(data, null, 2)}\n`,
-    'utf-8',
-  )
+  await writeFile(lockPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8')
 }
 
 /**
@@ -97,8 +88,7 @@ function pushHistory(lock, slug, newEntry) {
   })
 
   if (lock.skills[slug].history.length > MAX_HISTORY) {
-    lock.skills[slug].history =
-      lock.skills[slug].history.slice(-MAX_HISTORY)
+    lock.skills[slug].history = lock.skills[slug].history.slice(-MAX_HISTORY)
   }
 }
 
@@ -134,10 +124,7 @@ export async function addSkillToLock(
  * Get the rollback history for a specific skill.
  * Returns an array of historical entries (newest first).
  */
-export async function getSkillHistory(
-  slug,
-  lockPath = getGlobalLockPath(),
-) {
+export async function getSkillHistory(slug, lockPath = getGlobalLockPath()) {
   const lock = await readLock(lockPath)
   const entry = lock.skills[slug]
 
@@ -153,10 +140,7 @@ export async function getSkillHistory(
  * Removes the most recent history entry and restores its metadata.
  * Returns the restored entry data, or null if no history exists.
  */
-export async function popHistory(
-  slug,
-  lockPath = getGlobalLockPath(),
-) {
+export async function popHistory(slug, lockPath = getGlobalLockPath()) {
   const lock = await readLock(lockPath)
   const entry = lock.skills[slug]
 
@@ -206,9 +190,7 @@ export function computeFileHashes(fileContents) {
   const hashes = {}
 
   for (const [name, content] of Object.entries(fileContents)) {
-    hashes[name] = createHash('sha256')
-      .update(content)
-      .digest('hex')
+    hashes[name] = createHash('sha256').update(content).digest('hex')
   }
 
   return hashes

--- a/src/utils/mcp-lock.js
+++ b/src/utils/mcp-lock.js
@@ -1,10 +1,9 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { homedir } from 'node:os'
+import { home } from './paths.js'
 
-function home(...parts) {
-  return join(homedir(), ...parts)
-}
+
 
 export function getMcpLockPath() {
   return home('.agents', '.mcp-lock.json')

--- a/src/utils/mcp-lock.js
+++ b/src/utils/mcp-lock.js
@@ -1,32 +1,18 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { join, dirname } from 'node:path'
-import { homedir } from 'node:os'
+import { dirname } from 'node:path'
 import { home } from './paths.js'
 
-
-
 export function getMcpLockPath() {
-  return home(
-    '.agents',
-    '.mcp-lock.json',
-  )
+  return home('.agents', '.mcp-lock.json')
 }
 
 async function ensureParentDir(filePath) {
-  await mkdir(
-    dirname(filePath),
-    { recursive: true },
-  )
+  await mkdir(dirname(filePath), { recursive: true })
 }
 
-export async function readMcpLock(
-  lockPath = getMcpLockPath(),
-) {
+export async function readMcpLock(lockPath = getMcpLockPath()) {
   try {
-    const raw = await readFile(
-      lockPath,
-      'utf-8',
-    )
+    const raw = await readFile(lockPath, 'utf-8')
 
     return JSON.parse(raw)
   } catch {
@@ -37,17 +23,10 @@ export async function readMcpLock(
   }
 }
 
-export async function writeMcpLock(
-  data,
-  lockPath = getMcpLockPath(),
-) {
+export async function writeMcpLock(data, lockPath = getMcpLockPath()) {
   await ensureParentDir(lockPath)
 
-  await writeFile(
-    lockPath,
-    `${JSON.stringify(data, null, 2)}\n`,
-    'utf-8',
-  )
+  await writeFile(lockPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8')
 }
 
 export async function addServerToMcpLock(
@@ -59,12 +38,7 @@ export async function addServerToMcpLock(
   const existing = lock.servers[serverName]
 
   const mergedAgents = existing?.agents
-    ? [
-        ...new Set([
-          ...existing.agents,
-          ...(entry.agents || []),
-        ]),
-      ]
+    ? [...new Set([...existing.agents, ...(entry.agents || [])])]
     : entry.agents || []
 
   lock.servers[serverName] = {
@@ -88,18 +62,14 @@ export async function removeServerFromMcpLock(
     return lock
   }
 
-  const remaining =
-    (
-      lock.servers[serverName].agents || []
-    ).filter(
-      (agent) => agent !== agentToRemove,
-    )
+  const remaining = (lock.servers[serverName].agents || []).filter(
+    (agent) => agent !== agentToRemove,
+  )
 
   if (remaining.length === 0) {
     delete lock.servers[serverName]
   } else {
-    lock.servers[serverName].agents =
-      remaining
+    lock.servers[serverName].agents = remaining
   }
 
   await writeMcpLock(lock, lockPath)

--- a/src/utils/mcp-lock.js
+++ b/src/utils/mcp-lock.js
@@ -1,31 +1,54 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { join, dirname } from 'node:path'
-import { homedir } from 'node:os'
-
-function home(...parts) {
-  return join(homedir(), ...parts)
-}
+import {
+  mkdir,
+  readFile,
+  writeFile,
+} from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { home } from './paths.js'
 
 export function getMcpLockPath() {
-  return home('.agents', '.mcp-lock.json')
+  return home(
+    '.agents',
+    '.mcp-lock.json',
+  )
 }
 
 async function ensureParentDir(filePath) {
-  await mkdir(dirname(filePath), { recursive: true })
+  await mkdir(
+    dirname(filePath),
+    { recursive: true },
+  )
 }
 
-export async function readMcpLock(lockPath = getMcpLockPath()) {
+export async function readMcpLock(
+  lockPath = getMcpLockPath(),
+) {
   try {
-    const raw = await readFile(lockPath, 'utf-8')
+    const raw = await readFile(
+      lockPath,
+      'utf-8',
+    )
+
     return JSON.parse(raw)
   } catch {
-    return { version: 1, servers: {} }
+    return {
+      version: 1,
+      servers: {},
+    }
   }
 }
 
-export async function writeMcpLock(data, lockPath = getMcpLockPath()) {
+export async function writeMcpLock(
+  data,
+  lockPath = getMcpLockPath(),
+) {
   await ensureParentDir(lockPath)
-  await writeFile(lockPath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8')
+
+  await writeFile(
+    lockPath,
+    `${JSON.stringify(data, null, 2)}\n`,
+    'utf-8',
+  )
 }
 
 export async function addServerToMcpLock(
@@ -35,11 +58,23 @@ export async function addServerToMcpLock(
 ) {
   const lock = await readMcpLock(lockPath)
   const existing = lock.servers[serverName]
+
   const mergedAgents = existing?.agents
-    ? [...new Set([...existing.agents, ...(entry.agents || [])])]
+    ? [
+        ...new Set([
+          ...existing.agents,
+          ...(entry.agents || []),
+        ]),
+      ]
     : entry.agents || []
-  lock.servers[serverName] = { ...entry, agents: mergedAgents }
+
+  lock.servers[serverName] = {
+    ...entry,
+    agents: mergedAgents,
+  }
+
   await writeMcpLock(lock, lockPath)
+
   return lock
 }
 
@@ -49,15 +84,26 @@ export async function removeServerFromMcpLock(
   lockPath = getMcpLockPath(),
 ) {
   const lock = await readMcpLock(lockPath)
-  if (!lock.servers[serverName]) return lock
-  const remaining = (lock.servers[serverName].agents || []).filter(
-    (a) => a !== agentToRemove,
-  )
+
+  if (!lock.servers[serverName]) {
+    return lock
+  }
+
+  const remaining =
+    (
+      lock.servers[serverName].agents || []
+    ).filter(
+      (agent) => agent !== agentToRemove,
+    )
+
   if (remaining.length === 0) {
     delete lock.servers[serverName]
   } else {
-    lock.servers[serverName].agents = remaining
+    lock.servers[serverName].agents =
+      remaining
   }
+
   await writeMcpLock(lock, lockPath)
+
   return lock
 }

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,6 +1,6 @@
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 
 export function home(...parts) {
-  return join(homedir(), ...parts);
+  return join(homedir(), ...parts)
 }

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,0 +1,6 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function home(...parts) {
+  return join(homedir(), ...parts);
+}

--- a/src/utils/templates/src/utils/paths.js
+++ b/src/utils/templates/src/utils/paths.js
@@ -1,0 +1,6 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export function home(...parts) {
+  return join(homedir(), ...parts)
+}

--- a/src/utils/templates/src/utils/paths.js
+++ b/src/utils/templates/src/utils/paths.js
@@ -1,6 +1,0 @@
-import { homedir } from 'node:os'
-import { join } from 'node:path'
-
-export function home(...parts) {
-  return join(homedir(), ...parts)
-}


### PR DESCRIPTION
- Created a shared paths utility for the home() helper.
- Removed duplicate home() implementations from lockfile, installer, and MCP lock modules.
- Updated the affected modules to import the shared helper.
- Reduced code duplication and improved maintainability.

## Description

<!-- Describe the changes in this PR -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [ ] Tests pass locally (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] No new dependencies added
- [ ] Docs updated if needed

## Related issue

<!-- Link to related issue if applicable -->
