### PR TITLE
fix: warn MCP servers execute arbitrary code for non-github sources

### DIFF
--- a/src/commands/mcp.js
+++ b/src/commands/mcp.js
@@ -42,6 +42,16 @@ function requiresConfirmation(source) {
   return info.type === 'github'
 }
 
+// S-12: npm/local/uvx/etc. sources get a near-max security score (the scanner
+// only flags "published by anyone" as low), so surface the real risk directly.
+function warnMcpArbitraryCode(source, options) {
+  if (options.yes) return
+  const info = classifyMcpSource(source)
+  if (info.type === 'github') return // github gets full confirmation above
+  console.log('\n⚠️  MCP servers execute arbitrary code when started.')
+  console.log('   Only install from sources you trust.')
+}
+
 export async function mcpInstallCommand(source, options) {
   if (requiresConfirmation(source) && !options.yes) {
     console.log(`\n⚠️  Installing MCP server from GitHub repository: ${source}`)
@@ -55,6 +65,8 @@ export async function mcpInstallCommand(source, options) {
       return
     }
   }
+
+  warnMcpArbitraryCode(source, options)
 
   if (options.dryRun) {
     const { resolveMcpSource: mcpResolve } = await import('../utils/mcp.js')
@@ -119,6 +131,8 @@ export async function mcpUpdateCommand(source, options) {
       return
     }
   }
+
+  warnMcpArbitraryCode(source, options)
 
   if (options.dryRun) {
     const { resolveMcpSource: mcpResolve } = await import('../utils/mcp.js')

--- a/src/commands/mcp.test.js
+++ b/src/commands/mcp.test.js
@@ -95,6 +95,40 @@ describe('mcp command', () => {
         assert.ok(logs.some((l) => l.includes('not supported')))
       }),
     )
+
+    it(
+      'warns that MCP servers execute arbitrary code for npm sources',
+      withTempDir(async () => {
+        const { logs, restore } = capture('log')
+        await mcpModule.mcpInstallCommand('npm:@test/warn', {
+          agents: ['agents'],
+          name: 'warn-test',
+        })
+        restore()
+
+        assert.ok(
+          logs.some((l) => l.includes('execute arbitrary code when started')),
+        )
+        assert.ok(logs.some((l) => l.includes('Only install from sources')))
+      }),
+    )
+
+    it(
+      'suppresses arbitrary code warning with yes option',
+      withTempDir(async () => {
+        const { logs, restore } = capture('log')
+        await mcpModule.mcpInstallCommand('npm:@test/warn-yes', {
+          agents: ['agents'],
+          name: 'warn-yes',
+          yes: true,
+        })
+        restore()
+
+        assert.ok(
+          !logs.some((l) => l.includes('execute arbitrary code when started')),
+        )
+      }),
+    )
   })
 
   describe('mcpListCommand', () => {
@@ -181,6 +215,28 @@ describe('mcp command', () => {
         restore()
 
         assert.ok(logs.some((l) => l.includes('not supported')))
+      }),
+    )
+
+    it(
+      'warns that MCP servers execute arbitrary code for npm sources on update',
+      withTempDir(async () => {
+        const addModule = await import('../utils/mcp.js')
+        await addModule.addMcpServer('agents', 'warn-update', {
+          command: 'npx',
+          args: ['-y', '@test/old'],
+        })
+
+        const { logs, restore } = capture('log')
+        await mcpModule.mcpUpdateCommand('npm:@test/new', {
+          agents: ['agents'],
+          name: 'warn-update',
+        })
+        restore()
+
+        assert.ok(
+          logs.some((l) => l.includes('execute arbitrary code when started')),
+        )
       }),
     )
   })


### PR DESCRIPTION
Adds a warning that MCP servers execute arbitrary code when started, displayed for npm/uvx/pipx/go/deno/cargo/local sources during install and update. (S-12)

Co-Authored-By: Claude <noreply@anthropic.com>