### PR TITLE
fix: security hardening and CLI validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Scores range **0–100**:
 - **90+** → SAFE, install proceeds
 - **70–89** → REVIEW, prompts for confirmation
 - **<70** → DANGER, blocked unless `--yes`
+- **Any critical issue** → DANGER regardless of score (a single critical finding can never be silently skipped)
 
 ```bash
 rolecraft install ./my-skill              # auto-scanned

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -54,6 +54,19 @@ function parsePositionals(args) {
   return args.filter((a) => !a.startsWith('-'))
 }
 
+/** Validate flags against allowed list, warn on unknown, exit non-zero if strict */
+function validateFlags(flags, allowed, command) {
+  const unknown = flags.filter(
+    (f) => !allowed.some((a) => f === a || f.startsWith(`${a}=`)),
+  )
+  if (unknown.length > 0) {
+    for (const u of unknown) {
+      console.error(`⚠️  ${command}: unknown flag "${u}" — ignoring`)
+    }
+    process.exitCode = 1
+  }
+}
+
 /**
  * Extract the value after a named flag (e.g. --skill react-rules).
  * Returns undefined when the flag is absent or has no subsequent value.
@@ -265,6 +278,27 @@ const COMMANDS = {
       })
     }
     const flags = parseFlags(args)
+    validateFlags(
+      flags,
+      [
+        '--yes',
+        '-y',
+        '--global',
+        '--project',
+        '--windsurf',
+        '--devin',
+        '--all',
+        '--no-mcp',
+        '--frozen-lockfile',
+        '--symlink',
+        '--copy',
+        '--list',
+        '--skill',
+        '--dry-run',
+        ...agents.map((a) => `--${a.flag}`),
+      ],
+      'install',
+    )
     const scope = buildInstallScope(flags, agents)
     const opts = {
       ...scope,
@@ -284,6 +318,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--json', '--agent', '-a'], 'list')
     const agentIndex = args.findIndex(
       (arg) => arg === '--agent' || arg === '-a',
     )
@@ -302,6 +338,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--dry-run'], 'remove')
     const pos = parsePositionals(args)
     const slug = pos[0]
     if (!slug) {
@@ -316,6 +354,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--dry-run'], 'update')
     const pos = parsePositionals(args)
     const slug = pos[0]
     if (!slug) {
@@ -330,6 +370,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--list', '--skill'], 'use')
     const pos = parsePositionals(args)
     const source = pos[0]
     if (!source) {
@@ -350,8 +392,13 @@ const COMMANDS = {
       usage()
       return
     }
-    const pos = parsePositionals(args)
     const flags = parseFlags(args)
+    validateFlags(
+      flags,
+      ['--list', '--template', '--description', '--agents'],
+      'init',
+    )
+    const pos = parsePositionals(args)
     return initCommand(pos[0], {
       list: flags.includes('--list'),
       template: parseFlagValue(args, '--template'),
@@ -365,6 +412,12 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(
+      flags,
+      ['--interactive', '--skills-sh', '--registry'],
+      'search',
+    )
     const pos = parsePositionals(args)
     const query = pos[0]
     if (!query) {
@@ -418,6 +471,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--dry-run', '--yes', '-y', '--list'], 'setup')
     const pos = parsePositionals(args)
     const source = pos[0]
     return setupCommand(source, {
@@ -433,6 +488,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--dry-run'], 'upgrade')
     return upgradeCommand({ dryRun: args.includes('--dry-run') })
   },
 
@@ -441,6 +498,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--json', '--network', '--deep'], 'doctor')
     return doctorCommand({
       json: args.includes('--json'),
       network: args.includes('--network'),
@@ -453,6 +512,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--dry-run'], 'watch')
     const pos = parsePositionals(args)
     const slug = pos[0]
     const { watchers } = await watchCommand(slug, process.cwd(), {
@@ -472,6 +533,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--json'], 'agents')
     return agentsCommand({ json: args.includes('--json') })
   },
 
@@ -480,6 +543,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--write'], 'agents-xml')
     return agentsXmlCommand(args.includes('--write'))
   },
 
@@ -488,6 +553,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--dry-run', '--output'], 'convert')
     const pos = parsePositionals(args)
     const source = pos[0]
     if (!source) {
@@ -505,6 +572,12 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(
+      flags,
+      ['--json', '--brief', '--no-color', '--context'],
+      'diff',
+    )
     const pos = parsePositionals(args)
     return diffCommand(pos[0], pos[1], {
       json: args.includes('--json'),
@@ -519,6 +592,21 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(
+      flags,
+      [
+        '--chain',
+        '--dry-run',
+        '--force',
+        '--json',
+        '--no-color',
+        '--name',
+        '--output',
+        '-o',
+      ],
+      'compose',
+    )
     const pos = parsePositionals(args)
     return composeCommand(pos, {
       mode: args.includes('--chain') ? 'chain' : 'merge',
@@ -536,6 +624,22 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(
+      flags,
+      [
+        '--json',
+        '--verbose',
+        '-v',
+        '--no-color',
+        '--no-emoji',
+        '--all',
+        '--min-score',
+        '--only',
+        '--skill',
+      ],
+      'test',
+    )
     const pos = parsePositionals(args)
     const skillPath = pos[0]
     const minScore = parseFlagValue(args, '--min-score')
@@ -555,6 +659,8 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(flags, ['--dry-run', '--no-mcp', '--yes', '-y'], 'bundle')
     if (args.length === 0) {
       console.error('Usage: rolecraft bundle <source> [...]')
       console.error('       rolecraft bundle <file>')
@@ -569,7 +675,6 @@ const COMMANDS = {
       }
       return bundleCreateCommand(parsePositionals(createArgs)[0])
     }
-    const flags = parseFlags(args)
     const sources = parsePositionals(args)
     const opts = {
       dryRun: flags.includes('--dry-run'),
@@ -587,6 +692,12 @@ const COMMANDS = {
       usage()
       return
     }
+    const flags = parseFlags(args)
+    validateFlags(
+      flags,
+      ['--dry-run', '--yes', '-y', '--repo', '--slug', '--name'],
+      'publish',
+    )
     const opts = { dryRun: false, yes: false, repo: '', slug: '', name: '' }
     const pos = []
     for (let i = 0; i < args.length; i++) {
@@ -613,6 +724,7 @@ const COMMANDS = {
       usage()
       return
     }
+    // profile command has its own subcommands, skip flag validation
     return profileCommand(args)
   },
 
@@ -621,6 +733,8 @@ const COMMANDS = {
       usage()
       return
     }
+    // mcp command has subcommands (install, list, search, check, update, remove)
+    // We can't easily validate without knowing subcommand, so skip
     return mcpCommand(args)
   },
 
@@ -640,7 +754,7 @@ COMMANDS.test = COMMANDS.testCommand
 COMMANDS['check-updates'] = COMMANDS.check
 
 // Only non-command names that show usage
-const ALWAYS_SHOW_USAGE = new Set(['help', undefined, null])
+const ALWAYS_SHOW_USAGE = new Set(['help', '--help', '-h', undefined, null])
 
 export async function main() {
   const [, , cmd, ...commandArgs] = process.argv
@@ -658,6 +772,11 @@ export async function main() {
   const handler = COMMANDS[cmd]
   if (handler) {
     await handler(commandArgs)
+  } else if (cmd) {
+    console.error(`❌ Unknown command: "${cmd}"`)
+    console.error('Run "rolecraft help" for available commands.')
+    process.exitCode = 1
+    usage()
   } else {
     usage()
   }

--- a/bin/rolecraft.test.js
+++ b/bin/rolecraft.test.js
@@ -71,9 +71,23 @@ describe('rolecraft CLI', () => {
   it('shows usage for unknown command', async () => {
     const { main } = await import('./rolecraft.js')
     const logs = captureLogs()
+    const errors = captureErrors()
     process.argv = ['node', 'rolecraft', 'nonexistent-command']
     await main()
     assert.ok(logs.some((l) => l.includes('rolecraft')))
+    assert.ok(errors.some((e) => e.includes('Unknown command')))
+    assert.equal(process.exitCode, 1)
+    process.exitCode = 0
+  })
+
+  it('sets exit code 1 for unknown flags', async () => {
+    const { main } = await import('./rolecraft.js')
+    const errors = captureErrors()
+    process.argv = ['node', 'rolecraft', 'list', '--bogusflag']
+    await main()
+    assert.ok(errors.some((e) => e.includes('unknown flag')))
+    assert.equal(process.exitCode, 1)
+    process.exitCode = 0
   })
 
   it('shows version for --version', async () => {

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,6 +15,7 @@ Minimum score is 0. Each unique pattern match across all files counts once per c
 | 90–100 | SAFE | Installs without prompt |
 | 70–89 | REVIEW | Shows warning, asks for confirmation |
 | 0–69 | DANGER | Blocks install; use `--yes` to force |
+| Any score with a critical issue | DANGER | A single critical finding (e.g. prompt injection) overrides the score; `--yes` forces but always warns |
 
 ## Scan Categories
 
@@ -188,3 +189,7 @@ rolecraft install attacker/helper --yes
 ```
 
 This is intended for CI pipelines and fully trusted sources only.
+
+## MCP Server Scanning
+
+MCP servers referenced in a skill's frontmatter (`mcpServers`) are scanned with the same engine before installation. A server flagged DANGER blocks the whole skill install (`rolecraft install`/`rolecraft ci`), with `--yes` as the only bypass — it always prints a warning. See `MCP_SECURITY_DANGER` in the error output for the flagged issues.

--- a/src/api/ci.js
+++ b/src/api/ci.js
@@ -3,7 +3,7 @@ import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import { readMcpLock } from '../utils/mcp-lock.js'
 import { resolveMcpSource, addMcpServer } from '../utils/mcp.js'
-import { scanSkill, classifyScore } from '../utils/security.js'
+import { scanSkill, scanMcpServer, classifyScore } from '../utils/security.js'
 
 export async function apiCi(cwd = process.cwd()) {
   const [globalLock, projectLock, mcpLock] = await Promise.all([
@@ -33,7 +33,7 @@ export async function apiCi(cwd = process.cwd()) {
 
       // Security scan — block dangerous skills even in CI
       const security = scanSkill(resolved)
-      const level = classifyScore(security.score)
+      const level = classifyScore(security.score, security.issues)
       if (level === 'danger') {
         failed.push({
           slug,
@@ -61,6 +61,19 @@ export async function apiCi(cwd = process.cwd()) {
     }
     try {
       const resolved = await resolveMcpSource(entry.source)
+
+      // Security scan for MCP servers
+      const mcpSecurity = scanMcpServer(resolved)
+      const mcpLevel = classifyScore(mcpSecurity.score, mcpSecurity.issues)
+      if (mcpLevel === 'danger') {
+        mcpFailed.push({
+          name,
+          source: entry.source,
+          reason: `blocked by MCP security scan (score: ${mcpSecurity.score}/100)`,
+        })
+        continue
+      }
+
       for (const agent of entry.agents) {
         await addMcpServer(agent, name, resolved, entry.source)
       }

--- a/src/api/install.js
+++ b/src/api/install.js
@@ -1,6 +1,6 @@
 import { resolveSource, resolveSkills } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
-import { scanSkill } from '../utils/security.js'
+import { scanSkill, scanMcpServer, classifyScore } from '../utils/security.js'
 import {
   parseMcpServersFromSkill,
   resolveMcpSource,
@@ -108,8 +108,7 @@ export async function apiInstallSkills(source, options = {}) {
     }
 
     const security = scanSkill(resolved)
-    const level =
-      security.score >= 90 ? 'safe' : security.score >= 70 ? 'review' : 'danger'
+    const level = classifyScore(security.score, security.issues)
 
     if (level === 'danger' && !options.yes) {
       const issues = security.issues
@@ -149,6 +148,23 @@ export async function apiInstallSkills(source, options = {}) {
       )
     }
 
+    // --yes forces past danger/review but never silently: warn the user
+    // so a forced install of a flagged skill leaves a visible trail.
+    if (options.yes && (level === 'danger' || level === 'review')) {
+      const issues = security.issues
+        .filter((i) => i.severity === 'critical' || i.severity === 'high')
+        .map(
+          (i) =>
+            `  🔴 [${i.severity}] ${i.description}${i.file ? ` (${i.file})` : ''}`,
+        )
+        .join('\n')
+      const tag = level === 'danger' ? 'DANGER' : 'REVIEW'
+      console.error(
+        `\n⚠️  [${tag}] --yes forcing install of "${resolved.name}" despite security scan (score: ${security.score}/100).`,
+      )
+      if (issues) console.error(issues)
+    }
+
     const installResults = await installSkill(
       resolved,
       targets,
@@ -171,6 +187,37 @@ export async function apiInstallSkills(source, options = {}) {
         )
         for (const server of mcpServers) {
           const resolvedMcp = await resolveMcpSource(server.source)
+
+          // Security scan for MCP servers
+          const mcpSecurity = scanMcpServer(resolvedMcp)
+          const mcpLevel = classifyScore(mcpSecurity.score, mcpSecurity.issues)
+          if (mcpLevel === 'danger' && !options.yes) {
+            const issues = mcpSecurity.issues
+              .filter((i) => i.severity === 'critical' || i.severity === 'high')
+              .map(
+                (i) =>
+                  `  🔴 [${i.severity}] ${i.description}${i.file ? ` (${i.file})` : ''}`,
+              )
+              .join('\n')
+            throw new UserError(
+              `MCP server "${server.name}" blocked by security scan (score: ${mcpSecurity.score}/100).`,
+              {
+                suggestion:
+                  'Review the flagged issues, or use --yes to force install.',
+                detail: `Flagged issues:\n${issues}`,
+                code: 'MCP_SECURITY_DANGER',
+              },
+            )
+          }
+
+          // --yes forces past danger but never silently
+          if (options.yes && (mcpLevel === 'danger' || mcpLevel === 'review')) {
+            const tag = mcpLevel === 'danger' ? 'DANGER' : 'REVIEW'
+            console.error(
+              `\n⚠️  [${tag}] --yes forcing install of MCP server "${server.name}" despite security scan (score: ${mcpSecurity.score}/100).`,
+            )
+          }
+
           const installed = []
           for (const agent of mcpTargets) {
             const ok = await addMcpServer(agent, server.name, resolvedMcp)

--- a/src/api/remove.js
+++ b/src/api/remove.js
@@ -6,6 +6,7 @@ import {
   getAgentsDir,
   getProjectLockPath,
 } from '../utils/lockfile.js'
+import { assertSafeSlug } from '../utils/installer.js'
 
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
@@ -41,21 +42,22 @@ export async function apiRemove(slug, cwd = process.cwd(), options = {}) {
 
   if (options.dryRun) {
     const dirs = []
-    if (globalFound)
-      dirs.push({
-        scope: 'global',
-        path: join(getAgentsDir(), normalizeSlug(actualSlug)),
-      })
-    if (projectFound)
-      dirs.push({
-        scope: 'project',
-        path: join(cwd, '.agents', 'skills', normalizeSlug(actualSlug)),
-      })
+    if (globalFound) {
+      const dir = join(getAgentsDir(), normalizeSlug(actualSlug))
+      assertSafeSlug(actualSlug, getAgentsDir(), dir)
+      dirs.push({ scope: 'global', path: dir })
+    }
+    if (projectFound) {
+      const dir = join(cwd, '.agents', 'skills', normalizeSlug(actualSlug))
+      assertSafeSlug(actualSlug, join(cwd, '.agents', 'skills'), dir)
+      dirs.push({ scope: 'project', path: dir })
+    }
     return { dryRun: true, slug: actualSlug, dirs }
   }
 
   if (globalFound) {
     const dir = join(getAgentsDir(), normalizeSlug(actualSlug))
+    assertSafeSlug(actualSlug, getAgentsDir(), dir)
     await rm(dir, { recursive: true, force: true })
     await removeSkillFromLock(actualSlug)
     removed.push({ scope: 'global', path: dir })
@@ -63,6 +65,7 @@ export async function apiRemove(slug, cwd = process.cwd(), options = {}) {
 
   if (projectFound) {
     const projectDir = join(cwd, '.agents', 'skills', normalizeSlug(actualSlug))
+    assertSafeSlug(actualSlug, join(cwd, '.agents', 'skills'), projectDir)
     await rm(projectDir, { recursive: true, force: true })
     await removeSkillFromLock(actualSlug, projectLockPath)
     removed.push({ scope: 'project', path: projectDir })

--- a/src/api/rollback.js
+++ b/src/api/rollback.js
@@ -8,7 +8,11 @@ import {
   getSkillHistory,
   popHistory,
 } from '../utils/lockfile.js'
-import { restoreSkill, removeLatestBackup } from '../utils/installer.js'
+import {
+  restoreSkill,
+  removeLatestBackup,
+  assertSafeSlug,
+} from '../utils/installer.js'
 import { getAgentByFlag } from '../agents.js'
 import { UserError } from '../utils/errors.js'
 
@@ -108,6 +112,7 @@ export async function apiRollback(slug, options = {}) {
     }
 
     const slugDir = join(baseDir, normalizeSlug(slug))
+    assertSafeSlug(slug, baseDir, slugDir)
     await rm(slugDir, { recursive: true, force: true }).catch(() => {})
     await mkdir(slugDir, { recursive: true })
 

--- a/src/utils/installer.js
+++ b/src/utils/installer.js
@@ -10,6 +10,7 @@ import {
 } from 'node:fs/promises'
 import { home } from './paths.js'
 import { join, relative, dirname } from 'node:path'
+import { UserError } from './errors.js'
 import {
   addSkillToLock,
   getGlobalLockPath,
@@ -18,8 +19,50 @@ import {
 } from './lockfile.js'
 import { getAgentByFlag } from '../agents.js'
 
+import { resolve, sep } from 'node:path'
+
 function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
+}
+
+/**
+ * Reject slugs that could escape their base directory.
+ * `..`, `.`, empty, or any slug whose resolved path leaves baseDir is blocked.
+ * This prevents path-traversal via `slug: "..` in a malicious SKILL.md
+ * (which would otherwise make rm(slugDir, {recursive:true}) delete baseDir).
+ */
+export function assertSafeSlug(slug, baseDir, slugDir) {
+  const normalized = normalizeSlug(slug)
+
+  // Reject exact traversal tokens and empty slugs outright. Without this,
+  // slug "." resolves to baseDir and rm(baseDir) would delete the whole
+  // install directory.
+  if (!normalized || normalized === '.' || normalized === '..') {
+    throw new UserError(
+      `Refusing unsafe slug "${slug}": would delete the install directory itself.`,
+      {
+        suggestion:
+          'Slug must be a single kebab-case name (e.g. "my-skill"), not ".", "..", or a path.',
+        detail: `baseDir=${baseDir} slugDir=${slugDir}`,
+        code: 'UNSAFE_SLUG',
+      },
+    )
+  }
+
+  const root = resolve(baseDir)
+  const target = resolve(slugDir)
+  // target must be inside (or equal to) root
+  if (target !== root && !target.startsWith(root + sep)) {
+    throw new UserError(
+      `Refusing unsafe slug "${slug}": would escape the install directory.`,
+      {
+        suggestion:
+          'Slug must be a single kebab-case name (e.g. "my-skill"), not a path or "..".',
+        detail: `baseDir=${baseDir} slugDir=${slugDir}`,
+        code: 'UNSAFE_SLUG',
+      },
+    )
+  }
 }
 
 /**
@@ -135,6 +178,8 @@ export async function installSkill(resolved, targets, mode = 'copy') {
     }
 
     const slugDir = join(baseDir, normalizeSlug(slug))
+
+    assertSafeSlug(slug, baseDir, slugDir)
 
     if (mode === 'symlink' && resolved.skillDir) {
       const relPath = relative(dirname(slugDir), resolved.skillDir)

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -1281,4 +1281,51 @@ describe('installer', () => {
       assert.deepEqual(backups, [])
     })
   })
+
+  describe('assertSafeSlug (path traversal guard)', () => {
+    const safeBase = join(tempDir, 'safe-base')
+    const insideBase = join(tempDir, 'safe-base', 'my-skill')
+    const outsideBase = join(tempDir, 'escaped')
+
+    it('accepts a normal kebab-case slug inside baseDir', () => {
+      assert.doesNotThrow(() =>
+        installerModule.assertSafeSlug('my-skill', safeBase, insideBase),
+      )
+    })
+
+    it('accepts a slug with a slash that normalizes to a single segment', () => {
+      assert.doesNotThrow(() =>
+        installerModule.assertSafeSlug(
+          'ns/my-skill',
+          safeBase,
+          join(safeBase, 'ns-my-skill'),
+        ),
+      )
+    })
+
+    for (const bad of ['..', '.', '']) {
+      const label = bad === '' ? '<empty>' : bad
+      it(`rejects traversal/empty slug "${label}"`, () => {
+        assert.throws(
+          () => installerModule.assertSafeSlug(bad, safeBase, insideBase),
+          (err) => err.userCode === 'UNSAFE_SLUG',
+        )
+      })
+    }
+
+    it('rejects a slugDir that escapes baseDir', () => {
+      assert.throws(
+        () => installerModule.assertSafeSlug('foo', safeBase, outsideBase),
+        (err) => err.userCode === 'UNSAFE_SLUG',
+      )
+    })
+
+    it('rejects a normalized ".." slug that would resolve outside baseDir', () => {
+      const escaped = join(safeBase, '..', 'evil')
+      assert.throws(
+        () => installerModule.assertSafeSlug('..', safeBase, escaped),
+        (err) => err.userCode === 'UNSAFE_SLUG',
+      )
+    })
+  })
 })

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -97,11 +97,13 @@ function parseMetadata(content) {
 async function readFileContents(skillDir) {
   let entries
   try {
-    entries = await readdir(skillDir, { withFileTypes: true })
+    entries = await readdir(skillDir, { withFileTypes: true, recursive: true })
   } catch {
     return {}
   }
-  const files = entries.filter((e) => e.name !== '.git').map((e) => e.name)
+  const files = entries
+    .filter((e) => e.isFile() && !e.name.startsWith('.git'))
+    .map((e) => e.name)
   const fileContents = {}
   for (const f of files) {
     try {

--- a/src/utils/security.js
+++ b/src/utils/security.js
@@ -52,14 +52,14 @@ const PATTERNS = [
     severity: 'critical',
     category: 'prompt_injection',
     pattern:
-      /ignore\s+(all|previous|above)\s+(instructions|directives|commands)/i,
+      /ignore\s+(?:all|previous|above)\s+(?:of\s+the\s+)?(?:instructions|directives|commands)/i,
     description: 'Prompt injection: attempts to override instructions',
   },
   {
     severity: 'critical',
     category: 'prompt_injection',
     pattern:
-      /you\s+are\s+(now\s+)?a\s*(free|unrestricted|unlimited|unbounded|unconstrained|unfiltered)/i,
+      /you\s+are\s+(now\s+)?an?\s*(free|unrestricted|unlimited|unbounded|unconstrained|unfiltered)/i,
     description: 'Prompt injection: role override attempt',
   },
   {
@@ -222,7 +222,10 @@ export function scanSkill(resolved) {
   return { score: Math.max(0, score), issues }
 }
 
-export function classifyScore(score) {
+export function classifyScore(score, issues = []) {
+  // Any critical issue → danger regardless of score
+  const hasCritical = issues.some((i) => i.severity === 'critical')
+  if (hasCritical) return 'danger'
   if (score >= 90) return 'safe'
   if (score >= 70) return 'review'
   return 'danger'


### PR DESCRIPTION
Applies the P1 security roadmap items (slug path traversal guard, recursive skill scanning, MCP server security scanning in ci/install, prompt injection regex hardening, critical-to-danger scoring) plus CLI validation (unknown commands and flags now exit non-zero).