### PR TITLE
fix: repair npm README images and tighten package contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/rolecraft_logo.png" alt="RoleCraft" width="200" height="200">
+  <img src="https://raw.githubusercontent.com/rolecraft-sh/rolecraft/main/assets/rolecraft_logo.png" alt="RoleCraft" width="200" height="200">
 </p>
 
 <h1 align="center">RoleCraft</h1>
@@ -45,7 +45,7 @@
 </p>
 
 <p align="center">
-  <img src="assets/rolecraft-demo.gif" alt="RoleCraft demo" width="720">
+  <img src="https://raw.githubusercontent.com/rolecraft-sh/rolecraft/main/assets/rolecraft-demo.gif" alt="RoleCraft demo" width="720">
 </p>
 
 ---
@@ -55,7 +55,7 @@
 </p>
 
 <p align="center">
-  <a href="benchmark/RESULTS.md"><img src="benchmark/comparison.svg" alt="Benchmark: significantly faster than Vercel" width="600"></a>
+  <a href="benchmark/RESULTS.md"><img src="https://raw.githubusercontent.com/rolecraft-sh/rolecraft/main/benchmark/comparison.svg" alt="Benchmark: significantly faster than Vercel" width="600"></a>
   <br>
   <a href="benchmark/RESULTS.md"><b>Full benchmark results →</b></a>
     

--- a/package.json
+++ b/package.json
@@ -18,11 +18,9 @@
     "!src/**/*.test.js",
     "!src/**/*.test.mjs",
     "!src/**/__fixtures__/",
-    "apps.json",
     "scripts/setup-hooks.mjs",
     "README.md",
-    "LICENSE",
-    "CHANGELOG.md"
+    "LICENSE"
   ],
   "preferGlobal": true,
   "keywords": [

--- a/scripts/setup-hooks.mjs
+++ b/scripts/setup-hooks.mjs
@@ -11,8 +11,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const hooksDir = join(__dirname, '..', 'hooks')
 
 if (!existsSync(hooksDir)) {
-  console.error('hooks/ directory not found:', hooksDir)
-  process.exit(1)
+  // Published npm packages ship without hooks/ — skip silently for consumers
+  process.exit(0)
 }
 
 // Make all hooks executable so they actually run


### PR DESCRIPTION
Fixes broken logo and benchmark images on the npm page and trims the published package to code, README, and LICENSE only.