### PR TITLE
chore: release v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v2.3.2] - 2026-08-17
+
+### Fixed
+- repair npm README images and tighten package contents (#222)
+
+### Changed
+- update changelog and version for v2.3.1 (#221)
 ## [v2.3.1] - 2026-08-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rolecraft",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "The package manager for AI agents — install, test, publish, and manage skills & MCP servers across 86+ agents. Zero-dependency CLI for claude-code, cursor, opencode, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This PR updates the changelog and version for `v2.3.2`.

## Changes
- Updated CHANGELOG.md with changes since the previous tag
- Updated package.json version to `v2.3.2`

> Auto-generated by the release-prep workflow.
