### PR TITLE
feat(spinner): colorize succeed and fail markers

### DIFF
--- a/src/utils/spinner.js
+++ b/src/utils/spinner.js
@@ -1,4 +1,5 @@
 import { stdout } from 'node:process'
+import { theme } from './tui.js'
 
 const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 const INTERVAL = 80
@@ -44,11 +45,11 @@ export function createSpinner(text) {
     },
     succeed(msg) {
       if (id) clearInterval(id)
-      stdout.write(`\r${msg || '✓'} ${text}\n`)
+      stdout.write(`\r${theme.green(msg || '✓')} ${text}\n`)
     },
     fail(msg) {
       if (id) clearInterval(id)
-      stdout.write(`\r${msg || '✗'} ${text}\n`)
+      stdout.write(`\r${theme.red(msg || '✗')} ${text}\n`)
     },
   }
 }
@@ -99,11 +100,11 @@ export function createProgressBar(text) {
     succeed(msg) {
       if (id) clearInterval(id)
       render(100)
-      stdout.write(` ${msg || '✓'}\n`)
+      stdout.write(` ${theme.green(msg || '✓')}\n`)
     },
     fail(msg) {
       if (id) clearInterval(id)
-      stdout.write(`\r${msg || '✗'} ${text}\n`)
+      stdout.write(`\r${theme.red(msg || '✗')} ${text}\n`)
     },
   }
 }

--- a/src/utils/spinner.test.js
+++ b/src/utils/spinner.test.js
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import { stdout } from 'node:process'
 import { createSpinner, createProgressBar } from './spinner.js'
 
@@ -169,5 +170,42 @@ describe('createProgressBar', () => {
       assert.ok(out.includes('✗'))
       assert.ok(out.includes('download'))
     })
+  })
+})
+
+describe('marker colors', () => {
+  const spinnerUrl = new URL('./spinner.js', import.meta.url).href
+
+  function runWithEnv(env) {
+    const script = `
+      process.stdout.isTTY = true
+      import(${JSON.stringify(spinnerUrl)}).then(
+        ({ createSpinner, createProgressBar }) => {
+          createSpinner('install').succeed()
+          createSpinner('install').fail()
+          createProgressBar('download').succeed()
+          createProgressBar('download').fail()
+        },
+      )
+    `
+    return spawnSync(process.execPath, ['--input-type=module', '-'], {
+      input: script,
+      env: { ...process.env, NO_COLOR: '', ...env },
+      encoding: 'utf-8',
+    })
+  }
+
+  it('emits green check and red cross under FORCE_COLOR', () => {
+    const result = runWithEnv({ FORCE_COLOR: '1' })
+    assert.equal(result.status, 0, result.stderr)
+    assert.ok(result.stdout.includes('\x1b[32m✓\x1b[0m'))
+    assert.ok(result.stdout.includes('\x1b[31m✗\x1b[0m'))
+  })
+
+  it('stays bare when NO_COLOR overrides FORCE_COLOR', () => {
+    const result = runWithEnv({ FORCE_COLOR: '1', NO_COLOR: '1' })
+    assert.equal(result.status, 0, result.stderr)
+    assert.ok(result.stdout.includes('✓'))
+    assert.ok(!result.stdout.includes('\x1b[32m'))
   })
 })


### PR DESCRIPTION
Colors the `✓` / `✗` markers green and red in both `createSpinner` and `createProgressBar`, using the existing `theme` helper from `src/utils/tui.js` as the issue suggests.

Four call sites, matching the locations listed in the issue:

- `createSpinner`: `succeed()` and `fail()`
- `createProgressBar`: `succeed()` and `fail()`

Because it goes through `theme`, the env-var and TTY handling comes for free. I verified the three cases actually behave:

| Environment | `theme.green('✓')` |
|---|---|
| non-TTY, no env | `✓` (bare) |
| `FORCE_COLOR=1` | `\x1b[32m✓\x1b[0m` |
| `NO_COLOR=1` | `✓` (bare — `NO_COLOR` wins over `FORCE_COLOR`) |

The non-TTY early-return branches of both factories were left alone: they use `console.log`/`console.error` without a marker, so there is nothing to color there.

`node --test src/utils/spinner.test.js` → 16/16 pass.

Closes #110