### PR TITLE
refactor: extract scanner depth and lockfile version constants

### DIFF
--- a/src/utils/lockfile.js
+++ b/src/utils/lockfile.js
@@ -4,6 +4,8 @@ import { createHash } from 'node:crypto'
 import { getAgentByFlag } from '../agents.js'
 import { home } from './paths.js'
 
+const LOCKFILE_VERSION = 3
+
 export function normalizeSlug(slug) {
   return slug.replace(/\//g, '-')
 }
@@ -44,7 +46,7 @@ export async function readLock(lockPath = getGlobalLockPath()) {
     return JSON.parse(raw)
   } catch {
     return {
-      version: 3,
+      version: LOCKFILE_VERSION,
       skills: {},
       dismissed: {},
       lastSelectedAgents: [],

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -10,6 +10,8 @@ import { computeContentHash } from './lockfile.js'
 import { parseFrontmatter } from './converter.js'
 import { UserError } from './errors.js'
 
+const SCAN_MAX_DEPTH = 3
+
 let _runExec = defaultExecSync
 let runHttpsGet = defaultHttpsGet
 
@@ -131,7 +133,7 @@ async function enrichSkill(found) {
   }
 }
 
-async function scanForSkill(dir, maxDepth = 3) {
+async function scanForSkill(dir, maxDepth = SCAN_MAX_DEPTH) {
   const results = []
   const seenDirs = new Set()
 


### PR DESCRIPTION
Replaces the two remaining magic numbers listed in the issue with named constants declared at the top of their files.

- `src/utils/resolver.js` — `SCAN_MAX_DEPTH = 3`, used as the default for `scanForSkill(dir, maxDepth)`
- `src/utils/lockfile.js` — `LOCKFILE_VERSION = 3`, used in the fallback object returned by `readLock()`

I grepped for other occurrences before touching anything: each value appears exactly once outside of tests, so this is a pure rename with no behavioural change. The `WATCH_DEBOUNCE_MS` part of the issue was already done, as the August update notes.

`node --check` passes on both files, and `node --test src/utils/lockfile.test.js src/utils/resolver.test.js` passes 154/154 on both this branch and main — verified during review; the earlier "127 pass / 27 fail" figure was a local-environment artifact (network-dependent tests), not a repo-wide failure.

Closes #95