### PR TITLE
feat: add GitHub Release creation to publish workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -35,4 +35,47 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Extract version from package.json
+        id: version
+        run: |
+          VERSION=$(node -e "console.log(require('./package.json').version)")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
+          # Extract the changelog section for this version
+          awk -v tag="$TAG" '
+            /^## \[/ { in_section = ($0 ~ "\\[" tag "\\]") }
+            in_section { print }
+          ' CHANGELOG.md > /tmp/changelog.md
+          # Check if we got content
+          if [ ! -s /tmp/changelog.md ]; then
+            echo "No changelog found for version $VERSION"
+            echo "changelog=No changelog available" >> $GITHUB_OUTPUT
+          else
+            echo "changelog<<EOF" >> $GITHUB_OUTPUT
+            cat /tmp/changelog.md >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        if: steps.changelog.outputs.changelog != 'No changelog available'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
+
+          # Check if release already exists
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping creation"
+          else
+            echo "Creating GitHub Release for $TAG"
+            gh release create "$TAG" \
+              --title "Release $TAG" \
+              --notes-file /tmp/changelog.md \
+              --latest=false
+          fi


### PR DESCRIPTION
This PR adds automated GitHub Release creation to the release-publish workflow.

## Changes
- Modified  to:
  1. Extract version from package.json after npm publish
  2. Parse the relevant changelog section for that version
  3. Create a GitHub Release with the changelog as release notes
  4. Skip if release already exists (idempotent)

## How it works
When a release PR (from  workflow) is merged:
1. This workflow publishes to npm
2. Then extracts the version and changelog
3. Creates a GitHub Release with 

## Historical releases
All existing tags (v0.1.0 → v2.3.2) have already been manually created as GitHub Releases with their changelog content via .

## Future releases
Going forward, every npm release will automatically create a matching GitHub Release with the changelog.