### PR TITLE
docs: fix audit issues across docs, README, and CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ---
 
 <p align="center">
-  <b>⚡ Zero dependencies</b> · <b>📦 107.3 kB</b> · <b>🤖 26 verified agents</b> · <b>🔌 Skills + MCP</b> · <b>🔒 Security scoring</b> · <b>📝 Skill testing</b> · <b>🔧 Init templates</b> · <b>🌐 Offline-first</b>
+  <b>⚡ Zero dependencies</b> · <b>📦 432.8 kB</b> · <b>🤖 26 verified agents</b> · <b>🔌 Skills + MCP</b> · <b>🔒 Security scoring</b> · <b>📝 Skill testing</b> · <b>🔧 Init templates</b> · <b>🌐 Offline-first</b>
 </p>
 
 <p align="center">
@@ -98,7 +98,7 @@ rolecraft convert ./my-skill
 rolecraft convert --help
 ```
 
-**Requirements:** Node.js >= 20 · 107.3 kB · zero dependencies · 86 agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
+**Requirements:** Node.js >= 20 · 432.8 kB · zero dependencies · 86 agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
 
 > **Why zero dependencies?** Every dependency is a supply-chain risk. rolecraft uses only Node.js built-ins (`fs`, `path`, `crypto`, `https`) — no `node_modules` surprises.
 
@@ -151,7 +151,7 @@ No other CLI combines both. npx skills has no MCP support. ags has a separate MC
 
 ## Features
 
-- **Zero dependencies** — 107.3 kB, only Node.js built-ins
+- **Zero dependencies** — 432.8 kB, only Node.js built-ins
 - **MCP + Skills in one command** — install skills and their MCP servers together
 - **Any source** — local folder, GitHub/GitLab/SSH URL, npm package
 - **86 agents** — opencode, claude-code, cursor, copilot, aider, and more
@@ -253,6 +253,7 @@ All API functions return plain objects (no side-effects). Available exports:
 | ------------------------------------------ | --------------------------------------------------------------------------- | ------------------------------------ |
 | `rolecraft init [<name>]`                  | Scaffold a new `SKILL.md` (`--template`, `--list`)                          | [docs](docs/commands/init.md)        |
 | `rolecraft install <source>`               | Install a skill with security scan (local path, GitHub/GitLab/SSH URL, npm) | [docs](docs/commands/install.md)     |
+| `rolecraft publish <source>`               | Publish a skill to the rolecraft Registry                                   | [docs](docs/commands/publish.md)     |
 | `rolecraft bundle <sources>`               | Install multiple skills from inline sources or file                         | [docs](docs/commands/bundle.md)      |
 | `rolecraft bundle create`                  | Create a new bundle file                                                    | [docs](docs/commands/bundle.md)      |
 | `rolecraft search <query>`                 | Search for skills on GitHub (TUI with `--interactive`)                      | [docs](docs/commands/search.md)      |
@@ -262,13 +263,17 @@ All API functions return plain objects (no side-effects). Available exports:
 | `rolecraft setup [<source>]`               | Detect agents, optionally install a skill to all                            | [docs](docs/commands/setup.md)       |
 | `rolecraft list`                           | Show all installed skills (filter with `--agent`)                           | [docs](docs/commands/list.md)        |
 | `rolecraft doctor`                         | Run system health check                                                     | [docs](docs/commands/doctor.md)      |
+| `rolecraft agents`                         | Show agent capability manifest                                              | [docs](docs/commands/agents.md)      |
 | `rolecraft agents-xml [--write]`           | Generate skills XML for AGENTS.md                                           | [docs](docs/commands/agents-xml.md)  |
 | `rolecraft mcp install/remove/list/search` | Install, remove, list, or search MCP servers for AI agents                  | [docs](docs/commands/mcp.md)         |
+| `rolecraft mcp check/update`               | Check for MCP server updates or update a server                             | [docs](docs/commands/mcp.md)         |
 | `rolecraft profile save/apply/list`        | Save, apply, and share multi-agent configuration profiles                   | [docs](docs/commands/profile.md)     |
 | `rolecraft verify`                         | Check installed skill integrity via content hash                            | [docs](docs/commands/verify.md)      |
 | `rolecraft watch [<slug>]`                 | Watch skills for changes and auto-sync                                      | [docs](docs/commands/watch.md)       |
 | `rolecraft ci`                             | Re-install all skills from lockfile (CI mode)                               | [docs](docs/commands/ci.md)          |
 | `rolecraft convert <source>`               | Convert between SKILL.md and .mdc formats                                   | [docs](docs/commands/convert.md)     |
+| `rolecraft diff <a> <b>`                   | Compare two skills section-by-section                                       | [docs](docs/commands/diff.md)        |
+| `rolecraft compose <a> <b> [...]`          | Compose multiple skills into one                                            | [docs](docs/commands/compose.md)     |
 | `rolecraft upgrade`                        | Upgrade rolecraft to the latest version                                     | [docs](docs/commands/upgrade.md)     |
 | `rolecraft test <skill-path>`              | Test a skill quality with built-in assertions                               | [docs](docs/commands/test.md)        |
 | `rolecraft remove <slug>`                  | Uninstall a skill                                                           | [docs](docs/commands/remove.md)      |
@@ -289,7 +294,7 @@ All API functions return plain objects (no side-effects). Available exports:
 | GitLab / SSH git URL                 | ✅               | ✅              | ❌                  |
 | npm package source                   | ✅               | ✅              | ❌                  |
 | **MCP server management**            | ✅               | ❌              | ❌                  |
-| Agent targets                        | **87**           | 72              | 15+                 |
+| Agent targets                        | **86**           | 72              | 15+                 |
 | **Registry / marketplace**           | ✅               | ✅ (skills.sh)  | ⚠️ (registry only)  |
 | Bundle install + create              | ✅               | ❌              | ✅ (skillset only)  |
 | Interactive TUI search + install     | ✅               | ✅              | ❌                  |
@@ -306,7 +311,7 @@ All API functions return plain objects (no side-effects). Available exports:
 | AGENTS.md XML generation             | ✅               | ❌              | ❌                  |
 | Self-upgrade command                 | ✅               | ❌              | ❌                  |
 | **Publish to registry**              | ✅               | ❌              | ❌                  |
-| File size                            | 107.3 kB          | ~465 KB         | ~84 KB              |
+| File size                            | 432.8 kB          | ~465 KB         | ~84 KB              |
 
 [See full table →](docs/comparison.md)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -85,7 +85,7 @@ npx rolecraft convert ./my-skill
 
 ## Supported agents (86 total · 26 verified)
 
-`opencode`, `claude-code`, `cursor`, `windsurf`, `devin`, `codex`, `copilot`, `aider`, `cline`, `gemini-cli`, `cody`, `continue`, `warp`, `codeium`, `fabric`, `goose`, `tabnine`, `supermaven`, `pr-pilot`, `loom`, `roo`, `trae`, `hermes`, `kiro`, `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, `cortex`, `mistral-vibe`, `qwen-code`, `openclaw`, `codebuddy`, `mux`, `pi`, `autohand-code`, `rovo`, `firebender`, `bob`, `aider-desk`, and 25+ more.
+`opencode`, `claude-code`, `cursor`, `windsurf`, `devin`, `codex`, `copilot`, `aider`, `cline`, `gemini-cli`, `cody`, `continue`, `warp`, `codeium`, `fabric`, `goose`, `tabnine`, `supermaven`, `pr-pilot`, `loom`, `roo`, `trae`, `hermes`, `kiro`, `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, `cortex`, `mistral-vibe`, `qwen-code`, `openclaw`, `codebuddy`, `mux`, `pi`, `autohand-code`, `rovo-dev`, `firebender`, `ibm-bob`, `aider-desk`, and 44 more.
 
 ## Examples
 

--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -39,4 +39,4 @@
 | Local skill install  | ✅ **10.23 ms**   | ✅ 3894 ms (381x slower)  | ❌ not supported   |
 | GitHub skill install | ✅ **1.6 s**      | ✅ 10.9 s (6.9x slower)   | ❌ fails (bug)     |
 | Zero dependencies    | ✅ **0**          | ❌ 1 dep                  | ❌ 2 deps          |
-| Package size         | **107.3 kB**      | ~465 KB                   | ~84 KB             |
+| Package size         | **432.8 kB**      | ~465 KB                   | ~84 KB             |

--- a/benchmark/comparison.svg
+++ b/benchmark/comparison.svg
@@ -31,7 +31,7 @@
   <text x="40" y="450" font-family="system-ui,sans-serif" font-size="16" fill="#1e293b" font-weight="700">📦 Package Size</text>
   <text x="40" y="497" font-family="system-ui,sans-serif" font-size="13" fill="#15803d" font-weight="600">rolecraft</text>
   <rect x="185" y="484" width="63.92340425531915" height="24" rx="3" fill="#15803d" opacity="0.9"/>
-  <text x="256.92340425531916" y="500" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">107.3 kB</text>
+  <text x="256.92340425531916" y="500" font-family="system-ui,sans-serif" font-size="13" fill="#64748b">432.8 kB</text>
 
   <text x="40" y="535" font-family="system-ui,sans-serif" font-size="13" fill="#1d4ed8" font-weight="600">Vercel skills</text>
   <rect x="185" y="522" width="277.02127659574467" height="24" rx="3" fill="#1d4ed8" opacity="0.9"/>

--- a/bin/rolecraft.js
+++ b/bin/rolecraft.js
@@ -210,7 +210,7 @@ Options for search:
 
 Options for init:
   --list              List available templates
-  --template <name>   Scaffold from a named template (basic, standard, mcp, rules, empty)
+  --template <name>   Scaffold from a named template (basic, code-review, git-workflow, testing, security, react)
 
 Options for setup:
   --list         List available skills from a source without installing
@@ -220,8 +220,6 @@ Options for install:
   --yes, -y      Non-interactive: accept all defaults and skip prompts
   --global       Install to ~/.agents/skills/
   --project      Install to ./.agents/skills/ (default)
-  --windsurf     Also install to ~/.windsurf/skills/
-  --devin        Also install to ~/.devin/skills/
 ${agentFlags.join('\n')}
   --all              Install to all locations
   --no-mcp           Skip MCP server installation from skill
@@ -472,7 +470,11 @@ const COMMANDS = {
       return
     }
     const flags = parseFlags(args)
-    validateFlags(flags, ['--dry-run', '--yes', '-y', '--list'], 'setup')
+    validateFlags(
+      flags,
+      ['--dry-run', '--yes', '-y', '--list', '--skill'],
+      'setup',
+    )
     const pos = parsePositionals(args)
     const source = pos[0]
     return setupCommand(source, {

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -4,13 +4,13 @@ rolecraft knows where each AI agent looks for skills. When you use a flag like `
 
 | Agent | Directory | Support | MCP |
 | ----- | --------- | ------- | --- |
-| opencode | `~/.agents/skills/ or ./.agents/skills/` | verified | - |
+| opencode | `~/.agents/skills/ or ./.agents/skills/` | verified | mcpServers |
 | claude-code | `~/.claude/skills/ or ./.claude/skills/` | verified | mcpServers |
 | cursor | `~/.cursor/skills/ or ./.cursor/skills/` | verified | mcpServers |
 | windsurf | `~/.codeium/windsurf/skills/ or ./.windsurf/skills/` | verified | mcpServers |
-| devin | `./.devin/skills/` | verified | - |
+| devin | `./.devin/skills/` | verified | mcpServers |
 | codex | `~/.agents/skills/ or ./.agents/skills/` | verified | - |
-| copilot | `./.github/skills/ or ~/.copilot/skills/` | verified | - |
+| copilot | `./.github/skills/ or ~/.copilot/skills/` | verified | servers |
 | aider | `~/.aider/skills/ or ./.aider/skills/` | experimental | - |
 | cline | `~/.cline/skills/ or ./.cline/skills/` | verified | - |
 | gemini-cli | `~/.gemini/skills/` | verified | - |
@@ -93,7 +93,7 @@ rolecraft knows where each AI agent looks for skills. When you use a flag like `
 
 > **Support levels:** `verified` — actively tested and maintained; `community` — community-contributed, maintained on best-effort; `legacy` — previous generation, no active development; `experimental` — known to exist, not formally tested.
 
-> **MCP support:** 4 agent(s) support MCP server configuration. Format: `mcpServers`, `experimental.mcpServers`
+> **MCP support:** 7 agent(s) support MCP server configuration. Format: `mcpServers`, `servers`, `experimental.mcpServers`
 
 > **Agent count:** 86 total — 26 verified, 0 community, 0 legacy, 60 experimental.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,7 @@ Install a skill with security scan.
 |--------|------|---------|-------------|
 | `global` | `boolean` | `false` | Install to `~/.agents/skills/` |
 | `project` | `boolean` | `true` | Install to `./.agents/skills/` |
+| `scope` | `object` | `{ project: true }` | Target scope object (`{ project, global, [agentFlag]: true, ... }`); overrides `global`/`project` |
 | `yes` | `boolean` | `false` | Bypass security prompts |
 | `dryRun` | `boolean` | `false` | Preview only |
 | `symlink` | `boolean` | `false` | Symlink instead of copy |
@@ -90,7 +91,7 @@ Returns `{ slug, source, updated: boolean }`.
 
 Check installed skills for available updates.
 
-Returns `{ updates: [{ slug, hasUpdate }], current: [...] }`.
+Returns `{ skills: [{ slug, status: 'update_available'|'up_to_date'|'error', current?, latest?, source?, fromRegistry?, oldHash?, newHash?, hash?, reason? }], updatesAvailable: number, total: number }`.
 
 ### `verify(options?)`
 
@@ -102,11 +103,7 @@ Returns `{ verified: [...], failed: [...] }`.
 
 Re-install all skills and MCP servers from lockfile.
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `yes` | `boolean` | `false` | Non-interactive mode |
-| `dryRun` | `boolean` | `false` | Preview only |
-| `frozenLockfile` | `boolean` | `false` | Fail if lockfile changes |
+Takes no options. Non-interactive by design — installs everything from the lockfile.
 
 Returns `{ installed: [{ slug, name, scope }], failed: [{ slug, reason }], skillCount, mcpCount, total, allPassed, mcpInstalled: [{ name, agents }], mcpFailed: [{ name, reason }] }`.
 
@@ -202,13 +199,13 @@ Install an MCP server.
 | `yes` | `boolean` | `false` | Skip confirmation and security blocks |
 | `dryRun` | `boolean` | `false` | Preview without making changes |
 
-Returns `{ server: { name, command, args }, agent, configPath }`.
+Returns `{ name, source, resolved: { command, args }, results: [{ agent, name, success }], scanResult }`.
 
 ### `mcpList(options?)`
 
 List all installed MCP servers.
 
-Returns `{ servers: [{ name, command, args, agent }] }`.
+Returns `{ servers: [{ agent, name, command, args }], total: number }`.
 
 ### `mcpUpdate(name, options?)`
 
@@ -220,7 +217,7 @@ Update an MCP server.
 | `yes` | `boolean` | `false` | Skip confirmation |
 | `dryRun` | `boolean` | `false` | Preview without making changes |
 
-Returns `{ server: { name, command, args } }`.
+Returns `{ name, source, resolved: { command, args }, results: [{ agent, name, success }] }`.
 
 ### `mcpRemove(name, options?)`
 
@@ -230,13 +227,13 @@ Remove an MCP server.
 |--------|------|---------|-------------|
 | `dryRun` | `boolean` | `false` | Preview only |
 
-Returns `{ removed: true }`.
+Returns `{ name, results: [{ agent, name, success }] }`.
 
 ### `mcpCheck(options?)`
 
 Check MCP server health.
 
-Returns `{ servers: [{ name, currentVersion, latestVersion, hasUpdate }], updatesAvailable: number }`.
+Returns `{ servers: [{ agent, name, currentVersion, latestVersion, hasUpdate }], updatesAvailable: number, total: number }`.
 
 ### `mcpSearch(query, options?)`
 
@@ -247,11 +244,11 @@ Search for MCP servers on npm or GitHub.
 | `npm` | `boolean` | `false` | Search npm registry instead of GitHub |
 | `interactive` | `boolean` | `false` | Enable TUI picker |
 
-Returns `{ results: [{ name, description, source, stars }] }`.
+Returns `{ results: [{ name, description, source, stars }], source: 'npm'|'github', total: number }`.
 
 ### `profileSave(name, options?)`
 
-Save current agent configuration as a profile. Returns `{ agents: number }`.
+Save current agent configuration as a profile. Returns `{ name, agents: number, profile: { name, description, agents } }`.
 
 ### `profileApply(name, options?)`
 

--- a/docs/commands/agents.md
+++ b/docs/commands/agents.md
@@ -42,53 +42,40 @@ Each agent entry includes:
 ```bash
 $ rolecraft agents
 
-Agent Capability Manifest
-=========================
+🔍 Agent Capability Manifest
 
-VERIFIED (26)
-  opencode     ~/.agents/skills/         MCP: -
-  claude-code  ~/.claude/skills/         MCP: mcpServers
-  cursor       ~/.cursor/skills/         MCP: mcpServers
-  windsurf     ~/.codeium/windsurf/skills/  MCP: mcpServers
-  devin        ./.devin/skills/          MCP: -
-  codex        ~/.agents/skills/         MCP: -
-  copilot      ./.github/skills/         MCP: -
-  cline        ~/.cline/skills/          MCP: -
-  continue     ~/.continue/skills/       MCP: experimental.mcpServers
-  gemini-cli   ~/.gemini/skills/         MCP: -
-  qwen-code    ~/.qwen/skills/           MCP: -
-  roo          ~/.roo/skills/            MCP: -
-  trae         ~/.trae/skills/           MCP: -
-  junie        ~/.junie/skills/          MCP: -
-  kiro         ~/.kiro/skills/           MCP: -
-  lingma       ~/.lingma/skills/         MCP: -
-  forge        ./.forge/skills/          MCP: -
-  jazz         ~/.jazz/skills/           MCP: -
-  chatgpt      ~/.agents/skills/         MCP: -
-  amp          ~/.config/agents/skills/  MCP: -
-  replit       ./.agents/skills/         MCP: -
-  zed          ~/.agents/skills/         MCP: -
-  warp         ~/.agents/skills/         MCP: -
-  goose        ~/.agents/skills/         MCP: -
-  tabnine      ~/.tabnine/agent/skills/  MCP: -
-  openhands    ~/.agents/skills/         MCP: -
+Total agents: 86
 
-COMMUNITY (0)
+## VERIFIED
 
-LEGACY (0)
+| Agent | Skill Scope | MCP | Instruction | Docs |
+|-------|-------------|-----|-------------|------|
+| opencode | ~/.agents/skills/ | ❌ | skill-md | [docs](https://opencode.ai) |
+| claude-code | ~/.claude/skills/ | ✅ | skill-md | [docs](https://docs.anthropic.com/en/docs/claude-code) |
+| cursor | ~/.cursor/skills/ | ✅ | skill-md | [docs](https://cursor.com) |
+| windsurf | ~/.codeium/windsurf/skills/ | ✅ | skill-md | [docs](https://docs.windsurf.com) |
+| devin | ./.devin/skills/ | ❌ | skill-md | [docs](https://devin.ai) |
+| ... | ... | ... | ... | ... |
 
-EXPERIMENTAL (60)
-  aider        ~/.aider/skills/          MCP: -
-  cody         ~/.cody/skills/           MCP: -
-  ...
+## MCP-Supported Agents
+
+These agents have built-in MCP configuration support:
+  • claude-code (mcpServers)
+  • cursor (mcpServers)
+  • windsurf (mcpServers)
+  • continue (experimental.mcpServers)
+
+## Validation
+
+Manifest valid: ✅ Yes
+Agent count: 86
 ```
 
 ```bash
 $ rolecraft agents --json
 
 {
-  "version": "1.0",
-  "generated": "2026-07-28",
+  "version": 1,
   "agentCount": 86,
   "agents": [
     {
@@ -96,15 +83,17 @@ $ rolecraft agents --json
       "name": "claude-code",
       "label": "~/.claude/skills/",
       "skillInstallScope": "global ~/.claude/skills",
-      "supportLevel": "verified",
       "mcpSupport": {
         "supported": true,
         "format": "mcpServers",
         "configPath": "~/.claude.json"
       },
       "instructionFormat": "skill-md",
+      "supportLevel": "verified",
       "docUrl": "https://docs.anthropic.com/en/docs/claude-code",
-      "lastVerified": "2026-07-27"
+      "lastVerified": "2026-07-27",
+      "notes": null,
+      "aliasFor": null
     }
   ]
 }
@@ -112,11 +101,4 @@ $ rolecraft agents --json
 
 ## Node.js API
 
-This command is also available as programmatic functions. See the [Node.js API documentation](../api.md) for detailed usage.
-
-```js
-import { getAgentManifest, validateManifest } from 'rolecraft'
-
-const agents = getAgentManifest()
-const validation = validateManifest()
-```
+This command is not available as a package-level API function. The manifest is internal to the CLI — see the [Node.js API documentation](../api.md) for the functions that are exported from `rolecraft`.

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -47,7 +47,7 @@ $ rolecraft doctor
    ✅ Node.js version                        v22.0.0
    ✅ Git availability                       detected
    ✅ npm availability                       detected
-   ✅ rolecraft version                      v1.6.0
+   ✅ rolecraft version                      v2.3.2
    ✅ Node.js location                       /usr/local/bin/node
    ✅ Platform                               darwin 24.0.0
    ✅ Home directory                         /home/user
@@ -78,7 +78,7 @@ $ rolecraft doctor --json
     "Skill integrity": { "status": "warn", "detail": "3 checked, 1 missing director(ies)" },
     "MCP servers": { "status": "warn", "detail": "none configured" }
   },
-  "summary": { "passed": 12, "warnings": 3, "errors": 0 }
+  "summary": { "total": 15, "passed": 12, "warnings": 3, "errors": 0 }
 }
 ```
 
@@ -103,7 +103,7 @@ $ rolecraft doctor --deep
 
 🔍 Skill Conflict Analysis
 
-   ⚠️ "react-rules" ve "frontend-rules" arasında çelişki:
+   ⚠️ Conflict between "react-rules" and "frontend-rules":
        - Code Style: "use tabs" vs "use spaces"
        - Naming: "camelCase" vs "snake_case"
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -5,12 +5,12 @@ Scaffold a new `SKILL.md` for your agent skill.
 ## Usage
 
 ```bash
-rolecraft init                               # create ./SKILL.md (default: my-skill)
+rolecraft init                               # create ./my-skill/SKILL.md (default: my-skill)
 rolecraft init my-custom-tool                # create ./my-custom-tool/SKILL.md
 rolecraft init namespace/skill               # create ./namespace-skill/SKILL.md
 rolecraft init --list                        # list available templates
 rolecraft init my-skill --template basic     # scaffold from a template
-rolecraft init my-skill --template mcp       # scaffold with MCP server setup
+rolecraft init my-skill --template react     # scaffold with React best practices
 ```
 
 ## Description
@@ -30,13 +30,14 @@ Use `--list` to see all available templates. Use `--template <name>` to scaffold
 
 | Template | Description |
 |----------|-------------|
-| `basic` | Minimal frontmatter with name, slug, owner, and description. No body sections. |
-| `standard` | Full scaffold with frontmatter and structured sections (description, when to use, examples, links). Recommended for most skills. **(default)** |
-| `mcp` | Pre-configured with MCP server declarations in frontmatter. Ideal for skills that integrate with external tools. |
-| `rules` | Rule-based skill with instruction-style body. Suitable for Claude Code `.mdc`-style agent rules. |
-| `empty` | Just the frontmatter — no body content. Useful when you want full control over the structure. |
+| `basic` | General-purpose skill template for AI agent instructions |
+| `code-review` | Code review guidelines and best practices for AI agents |
+| `git-workflow` | Git workflow conventions and branch strategy for AI agents |
+| `testing` | Testing guidelines and best practices for AI agents |
+| `security` | Security guidelines and dangerous pattern detection for AI agents |
+| `react` | React best practices and component patterns for AI agents |
 
-The `standard` template is used when no `--template` flag is provided.
+When no `--template` flag is provided, a minimal frontmatter scaffold is created (backward-compatible with older versions).
 
 ## Examples
 
@@ -44,17 +45,18 @@ The `standard` template is used when no `--template` flag is provided.
 ```bash
 rolecraft init --list
 # Available templates:
-#   basic      Minimal frontmatter only
-#   standard   Full scaffold with structured sections (default)
-#   mcp        Pre-configured with MCP server declarations
-#   rules      Rule-based skill for agent instructions
-#   empty      Just the frontmatter
+#   basic                General-purpose skill template for AI agent instructions
+#   code-review          Code review guidelines and best practices for AI agents
+#   git-workflow         Git workflow conventions and branch strategy for AI agents
+#   testing              Testing guidelines and best practices for AI agents
+#   security             Security guidelines and dangerous pattern detection for AI agents
+#   react                React best practices and component patterns for AI agents
 ```
 
 ### Scaffold with default template
 ```bash
 rolecraft init
-# Creates ./SKILL.md
+# Creates ./my-skill/SKILL.md
 
 rolecraft init code-reviewer
 # Creates ./code-reviewer/SKILL.md
@@ -68,14 +70,11 @@ rolecraft init myorg/ts-helper
 rolecraft init my-tool --template basic
 # Creates ./my-tool/SKILL.md with minimal frontmatter
 
-rolecraft init db-agent --template mcp
-# Creates ./db-agent/SKILL.md pre-configured with MCP server setup
+rolecraft init review-bot --template code-review
+# Creates ./review-bot/SKILL.md pre-filled with code review guidelines
 
-rolecraft init my-rules --template rules
-# Creates ./my-rules/SKILL.md as a rule-based skill
-
-rolecraft init scratch --template empty
-# Creates ./scratch/SKILL.md with frontmatter only
+rolecraft init my-rules --template git-workflow
+# Creates ./my-rules/SKILL.md as a git workflow skill
 ```
 
 ## Node.js API

--- a/docs/commands/install.md
+++ b/docs/commands/install.md
@@ -77,10 +77,14 @@ interactively to select which skills to install.
 | `--project`     | `./.agents/skills/` (default)      |
 | `--global`      | `~/.agents/skills/`                |
 | `--all`         | all known agent directories        |
+| `--agents`      | `~/.agents/skills/` (opencode)     |
 | `--claude`      | `~/.claude/skills/`                |
 | `--cursor`      | `~/.cursor/skills/`                |
+| `--windsurf`    | `~/.codeium/windsurf/skills/`      |
 | `--devin`       | `./.devin/skills/`                 |
-| *(and 25+ more — see [docs/agents.md](../agents.md))* | |
+| `--codex`       | `~/.agents/skills/`                |
+| `--copilot`     | `./.github/skills/`                |
+| *(79 more agent flags — see [docs/agents.md](../agents.md))* | |
 
 ## Mode flags
 
@@ -90,6 +94,8 @@ interactively to select which skills to install.
 | `--copy`              | Force copy (default)                       |
 | `--dry-run`           | Preview without copying files              |
 | `--frozen-lockfile`   | Fail if skill is already installed         |
+| `--yes`, `-y`         | Non-interactive: accept all defaults and skip prompts |
+| `--no-mcp`            | Skip MCP server installation from skill    |
 
 ## Examples
 

--- a/docs/commands/rollback.md
+++ b/docs/commands/rollback.md
@@ -22,7 +22,6 @@ rolecraft rollback <slug> [options]
 |--------|-------------|
 | `--list` | Show available rollback versions without restoring |
 | `--dry-run` | Preview which files would be restored |
-| `--yes`, `-y` | Skip confirmation prompt. Overrides `--dry-run` when both are set |
 | `--help`, `-h` | Show help |
 
 ## Examples

--- a/docs/commands/test.md
+++ b/docs/commands/test.md
@@ -70,7 +70,7 @@ $ rolecraft test ./my-skill/SKILL.md
   ✅ Example commands present
   ❌ No agent targets specified
 
-Score: 73/100 -> B (Good)
+Score: 73/100 -> C (Adequate)
 
 Suggestions:
   -> Add "slug" field to frontmatter
@@ -87,7 +87,7 @@ Testing all installed skills...
   ✅ react-rules       92/100  A
   ✅ testing-guide     88/100  B
   ❌ legacy-rules      34/100  D  -> needs review
-  ✅ my-skill          73/100  B
+  ✅ my-skill          73/100  C
 
 📋 Summary: 3/4 passed, 1 failed
 ```
@@ -108,7 +108,7 @@ $ rolecraft test ./skill.SKILL.md --only name-defined,slug-defined
 import { test } from 'rolecraft'
 
 const result = await test('./my-skill/SKILL.md')
-// { skill: 'my-skill', score: 73, grade: 'B', label: 'Good',
+// { skill: 'my-skill', score: 73, grade: 'C', label: 'Adequate',
 //   assertions: [{ name: 'name-defined', pass: true, weight: 10 }, ...],
 //   suggestions: ['Add "slug" field to frontmatter'] }
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -7,7 +7,7 @@
 | | rolecraft | skills (Vercel) | @agentskill.sh/cli |
 |---|---|---|---|
 | **Runtime** | Zero-dep Node ESM | 1 dep (Node) | 2 deps (TypeScript) |
-| **File size** | 107.3 kB | ~465 KB | ~84 KB |
+| **File size** | 432.8 kB | ~465 KB | ~84 KB |
 | **Agent targets** | **86** | 72 | 15+ |
 | **Skill marketplace** | rolecraft registry | skills.sh (90K+) | agentskill.sh (100K+) |
 | **Publish your own** | ✅ | ❌ | ❌ |

--- a/docs/guides/ci.md
+++ b/docs/guides/ci.md
@@ -21,7 +21,7 @@ jobs:
           node-version: 20
       - uses: rolecraft-sh/rolecraft-action@v1
         with:
-          command: ci --yes
+          command: ci
 ```
 
 ## Examples
@@ -31,7 +31,7 @@ jobs:
 ```yaml
 - uses: rolecraft-sh/rolecraft-action@v1
   with:
-    command: ci --yes
+    command: ci
 ```
 
 ### Verify skill integrity

--- a/docs/guides/onboarding.md
+++ b/docs/guides/onboarding.md
@@ -155,7 +155,7 @@ rolecraft setup your-org/ci-rules --yes              # install
 Lockfile-based deterministic re-install:
 
 ```bash
-rolecraft ci --yes
+rolecraft ci
 ```
 
 ---

--- a/docs/guides/use-cases.md
+++ b/docs/guides/use-cases.md
@@ -43,7 +43,7 @@ rules: |
 
 ```bash
 # CI pipeline
-rolecraft ci --yes
+rolecraft ci
 ```
 
 The lockfile (`~/.agents/.skill-lock.json`) pins exact sources and content hashes. Same install every time.
@@ -51,13 +51,13 @@ The lockfile (`~/.agents/.skill-lock.json`) pins exact sources and content hashe
 ```yaml
 # GitHub Actions workflow
 - run: npm install -g rolecraft
-- run: rolecraft ci --yes
+- run: rolecraft ci
 ```
 
 Use `--dry-run` to preview changes before applying:
 
 ```bash
-rolecraft ci --yes --dry-run
+rolecraft ci
 ```
 
 **Who it's for:** DevOps engineers, platform teams, CI/CD maintainers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
   - title: One-Command Onboarding
     details: "rolecraft setup <source> detects all AI agents and installs skills + MCP servers to every one of them."
   - title: Zero Dependencies
-    details: 107.3 kB, no bloat. Only Node.js built-ins.
+    details: 432.8 kB, no bloat. Only Node.js built-ins.
   - title: MCP + Skills in One Command
     details: Install skills and their MCP servers together. No other CLI tool combines both.
   - title: Rollback
@@ -31,7 +31,7 @@ features:
   - title: Security Scoring
     details: Static analysis on install — detects prompt injection, command injection, obfuscated code.
   - title: CI-Ready
-    details: Lockfile-based re-install, --yes flag, dry-run mode for pipelines.
+    details: Lockfile-based re-install for pipelines.
   - title: Init Templates
     details: "rolecraft init --template scaffolds production-ready skills from pre-built templates. Start fast, ship faster."
   - title: Parallel Install

--- a/docs/migration-from-skills.md
+++ b/docs/migration-from-skills.md
@@ -7,7 +7,7 @@ If you're using [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) a
 | Reason | rolecraft | Vercel skills |
 |---|---|---|
 | Dependencies | **0** (zero-dep) | 1 (`supports-color`) |
-| Package size | **107.3 kB** | ~465 KB |
+| Package size | **432.8 kB** | ~465 KB |
 | Agent targets | **86** | 72 |
 | Telemetry | **None** | Anonymous telemetry |
 | Offline installs | **Fully supported** | Requires network |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -21,6 +21,7 @@ Complete reference for all rolecraft commands, flags, and options.
 | `rollback <slug>` | Restore a skill to previous version (from backup history) |
 | `setup [source]` | Detect agents and optionally install a skill |
 | `search <query>` | Search GitHub for skills (`--skills-sh` for skills.sh) |
+| `publish <source>` | Publish a skill to the registry (requires `GITHUB_TOKEN`) |
 | `check` | Check for available updates |
 | `ci` | Re-install all skills from lockfile (CI mode) |
 | `verify` | Check installed skill integrity via content hash |
@@ -28,7 +29,7 @@ Complete reference for all rolecraft commands, flags, and options.
 | `watch [slug]` | Watch skills for changes and auto-sync |
 | `convert <source>` | Convert between SKILL.md and .mdc formats |
 | `profile save/apply/list` | Save, apply, and manage multi-agent profiles |
-| `mcp install/list/remove` | Install, list, and remove MCP servers |
+| `mcp install/list/remove/update/check/search` | Install, list, remove, update, check, and search MCP servers |
 | `agents-xml [--write]` | Generate skills XML for AGENTS.md |
 | `completions bash\|zsh\|fish` | Generate shell completion scripts |
 | `test <skill-path>` | Test a skill quality with built-in assertions |
@@ -46,7 +47,7 @@ These flags work across multiple commands:
 
 | Flag | Affects | Description |
 |------|---------|-------------|
-| `--yes` / `-y` | install, setup, bundle, ci, mcp, profile, publish | Non-interactive: accept all defaults, bypass security prompts |
+| `--yes` / `-y` | install, setup, bundle, mcp, profile, publish | Non-interactive: accept all defaults, bypass security prompts |
 | `--dry-run` | install, setup, bundle, remove, update, profile, mcp, upgrade, watch, convert | Preview without making changes |
 | `--global` | install, use, setup | Install to `~/.agents/skills/` (user-wide) |
 | `--project` | install, use, setup | Install to `./.agents/skills/` (repo-scoped, default) |
@@ -85,8 +86,8 @@ Pass any of these to `install`, `setup`, or `profile` to target specific agents:
 | `--warp` | warp | `~/.agents/skills/` |
 | `--codeium` | codeium | `~/.codeium/skills/` |
 | `--fabric` | fabric | `~/.fabric/skills/` |
-| `--goose` | goose | `~/.goose/skills/` |
-| `--tabnine` | tabnine | `~/.tabnine/skills/` |
+| `--goose` | goose | `~/.agents/skills/` |
+| `--tabnine` | tabnine | `~/.tabnine/agent/skills/` |
 | `--supermaven` | supermaven | `~/.supermaven/skills/` |
 | `--pr-pilot` | pr-pilot | `~/.pr-pilot/skills/` |
 | `--loom` | loom | `~/.loom/skills/` |
@@ -96,7 +97,7 @@ Pass any of these to `install`, `setup`, or `profile` to target specific agents:
 | `--kiro` | kiro | `~/.kiro/skills/` |
 | `--augment` | augment | `~/.augment/skills/` |
 | `--kilo` | kilo | `~/.kilo/skills/` |
-| `--openhands` | openhands | `~/.openhands/skills/` |
+| `--openhands` | openhands | `~/.agents/skills/` |
 | `--junie` | junie | `~/.junie/skills/` |
 | `--factory` | factory | `~/.factory/skills/` |
 | `--command-code` | command-code | `~/.commandcode/skills/` |
@@ -119,21 +120,21 @@ Pass any of these to `install`, `setup`, or `profile` to target specific agents:
 | `--astrbot` | astrbot | `~/.astrbot/data/skills/` |
 | `--qoder-cn` | qoder-cn | `~/.qoder-cn/skills/` |
 | `--trae-cn` | trae-cn | `~/.trae-cn/skills/` |
-| `--zenflow` | zenflow | `~/.zencoder/skills/` |
+| `--zenflow` | zenflow | `~/.zenflow/skills/` |
 | `--neovate` | neovate | `~/.neovate/skills/` |
 | `--pochi` | pochi | `~/.pochi/skills/` |
 | `--adal` | adal | `~/.adal/skills/` |
-| `--droid` | droid | `~/.factory/skills/` |
+| `--droid` | droid | `~/.droid/skills/` |
 | `--chatgpt` | chatgpt | `~/.agents/skills/` |
 | `--codearts-agent` | codearts-agent | `~/.codeartsdoer/skills/` |
 | `--universal` | universal | `~/.config/agents/skills/` |
-| `--amp` | amp | `~/.agents/skills/` |
+| `--amp` | amp | `~/.config/agents/skills/` |
 | `--antigravity` | antigravity | `~/.agents/skills/` |
 | `--antigravity-cli` | antigravity-cli | `~/.agents/skills/` |
 | `--deepagents` | deep-agents | `~/.agents/skills/` |
 | `--dexto` | dexto | `~/.agents/skills/` |
 | `--loaf` | loaf | `~/.agents/skills/` |
-| `--replit` | replit | `~/.agents/skills/` |
+| `--replit` | replit | `./.agents/skills/` |
 | `--zed` | zed | `~/.agents/skills/` |
 | `--promptscript` | promptscript | `./agent/skills/` |
 | `--code-arts-doer` | code-arts-doer | `~/.codeartsdoer/skills/` |
@@ -175,9 +176,9 @@ Scaffold a new skill:
 
 ```bash
 rolecraft init my-skill                # creates ./my-skill/SKILL.md
-rolecraft init                         # creates ./SKILL.md
+rolecraft init                         # creates ./my-skill/SKILL.md (default: my-skill)
 rolecraft init --list                  # list available templates
-rolecraft init my-skill --template mcp # scaffold from a specific template
+rolecraft init my-skill --template basic # scaffold from a specific template
 ```
 
 **Options:**
@@ -185,7 +186,7 @@ rolecraft init my-skill --template mcp # scaffold from a specific template
 | Option | Description |
 |--------|-------------|
 | `--list` | List available templates with descriptions |
-| `--template <name>` | Scaffold from a named template (`basic`, `standard`, `mcp`, `rules`, `empty`) |
+| `--template <name>` | Scaffold from a named template (`basic`, `code-review`, `git-workflow`, `testing`, `security`, `react`) |
 
 See the [init command docs](./commands/init.md) for available templates and full examples.
 
@@ -315,7 +316,7 @@ No arguments. Checks all installed skills for newer versions.
 
 ### `rolecraft ci`
 
-Re-install all skills and MCP servers from lockfiles. Use `--yes` in CI.
+Re-install all skills and MCP servers from lockfiles. Non-interactive by design — no flags needed.
 
 ### `rolecraft verify`
 

--- a/scripts/benchmark-visual.js
+++ b/scripts/benchmark-visual.js
@@ -45,7 +45,7 @@ const DEFAULT = {
     githubRatio: 6.94,
   },
   packageSize: {
-    rolecraft: '107.3 kB',
+    rolecraft: '432.8 kB',
     vercel: '~465 KB',
     agentskill: '~84 KB',
   },

--- a/src/agents/manifest.js
+++ b/src/agents/manifest.js
@@ -43,8 +43,9 @@ const MANIFEST_DATA = {
   opencode: {
     skillInstallScope: 'global ~/.agents/skills',
     mcpSupport: {
-      supported: false,
-      format: null,
+      supported: true,
+      format: MCP_CONFIG_FORMATS.STANDARD,
+      configPath: '~/.agents/mcp.json',
     },
     instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
     supportLevel: SUPPORT_LEVELS.VERIFIED,
@@ -92,8 +93,9 @@ const MANIFEST_DATA = {
   devin: {
     skillInstallScope: 'project ./.devin/skills',
     mcpSupport: {
-      supported: false,
-      format: null,
+      supported: true,
+      format: MCP_CONFIG_FORMATS.STANDARD,
+      configPath: './.devin/mcp.json',
     },
     instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
     supportLevel: SUPPORT_LEVELS.VERIFIED,
@@ -119,8 +121,9 @@ const MANIFEST_DATA = {
   copilot: {
     skillInstallScope: 'project ./.github/skills',
     mcpSupport: {
-      supported: false,
-      format: null,
+      supported: true,
+      format: MCP_CONFIG_FORMATS.COPILOT,
+      configPath: './.github/copilot/.mcp.json',
     },
     instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
     supportLevel: SUPPORT_LEVELS.VERIFIED,

--- a/src/agents/manifest.test.js
+++ b/src/agents/manifest.test.js
@@ -38,7 +38,7 @@ describe('agent manifest', () => {
     const opencode = manifest.find((a) => a.name === 'opencode')
     assert.ok(opencode)
     assert.equal(opencode.supportLevel, SUPPORT_LEVELS.VERIFIED)
-    assert.equal(opencode.mcpSupport.supported, false)
+    assert.equal(opencode.mcpSupport.supported, true)
   })
 
   it('includes claude-code as verified with MCP', () => {

--- a/src/commands/completions.js
+++ b/src/commands/completions.js
@@ -288,7 +288,7 @@ _rolecraft() {
             '--codeep[Also install to ~/.codeep/skills/]' \\
             '--kimi-code[Also install to ~/.kimi-code/skills/]' \\
              '--zcode[Also install to ~/.zcode/skills/]' \\
-             '--droid[Also install to ~/.factory/skills/]' \\
+             '--droid[Also install to ~/.droid/skills/]' \\
              '--chatgpt[Also install to ~/.agents/skills/]' \\
              '--codearts-agent[Also install to ~/.codeartsdoer/skills/]' \\
              '--universal[Also install to ~/.config/agents/skills/]' \\
@@ -437,7 +437,7 @@ for cmd in install bundle use setup upgrade check
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l codeep          -d 'Install to ~/.codeep/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l kimi-code       -d 'Install to ~/.kimi-code/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l zcode           -d 'Install to ~/.zcode/skills/'
-  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l droid           -d 'Install to ~/.factory/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l droid           -d 'Install to ~/.droid/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l chatgpt         -d 'Install to ~/.agents/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l codearts-agent  -d 'Install to ~/.codeartsdoer/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l universal       -d 'Install to ~/.config/agents/skills/'

--- a/src/commands/rollback.js
+++ b/src/commands/rollback.js
@@ -15,7 +15,6 @@ Restore a skill to its previous version. Requires a history entry
 Options:
   --list              Show available rollback versions
   --dry-run           Preview what would be restored without making changes
-  --yes, -y           Skip confirmation prompt
   --help, -h          Show this help
 
 Examples:


### PR DESCRIPTION
Fixes 18 documentation and CLI consistency issues found in a full repo audit: stale package size, wrong agent counts/paths, unimplemented flags documented, stale example outputs, MCP manifest alignment, missing commands in tables, duplicate help flags.