### PR TITLE
feat: add agents and rollback shell completions

### DIFF
--- a/src/api/completions.js
+++ b/src/api/completions.js
@@ -11,9 +11,11 @@ const COMMANDS = [
   'verify',
   'ci',
   'completions',
+  'agents',
   'agents-xml',
   'doctor',
   'upgrade',
+  'rollback',
   'check',
   'watch',
   'convert',
@@ -159,7 +161,9 @@ _rolecraft() {
       ;;
     list) COMPREPLY=($(compgen -W "--json" -- "$cur")) ;;
     remove|update|watch|convert) COMPREPLY=($(compgen -W "--dry-run" -- "$cur")) ;;
+    rollback) COMPREPLY=($(compgen -W "--list --dry-run" -- "$cur")) ;;
     init|verify|ci|help|version) COMPREPLY=() ;;
+    agents) COMPREPLY=($(compgen -W "--json" -- "$cur")) ;;
     agents-xml) COMPREPLY=($(compgen -W "--write" -- "$cur")) ;;
     doctor) COMPREPLY=($(compgen -W "--json --network --deep" -- "$cur")) ;;
     diff) COMPREPLY=($(compgen -W "--json --brief --context --no-color" -- "$cur")) ;;
@@ -201,7 +205,9 @@ _rolecraft() {
     'verify:Verify skill integrity'
     'ci:CI mode install'
     'completions:Generate completions'
+    'agents:Show agent capability manifest'
     'upgrade:Upgrade rolecraft'
+    'rollback:Restore a skill to previous version'
     'check:Check for updates'
     'watch:Watch skills'
     'convert:Convert skill format'
@@ -259,6 +265,8 @@ for cmd in install bundle use setup upgrade check
 end
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a install -d 'Install a skill'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a list -d 'List installed skills'
+complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a agents -d 'Show agent capability manifest'
+complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a rollback -d 'Restore a skill to previous version'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a help -d 'Show help'
 `
 }

--- a/src/commands/completions.js
+++ b/src/commands/completions.js
@@ -11,9 +11,11 @@ const COMMANDS = [
   'verify',
   'ci',
   'completions',
+  'agents',
   'agents-xml',
   'doctor',
   'upgrade',
+  'rollback',
   'check',
   'watch',
   'convert',
@@ -160,7 +162,9 @@ _rolecraft() {
       ;;
     list) COMPREPLY=($(compgen -W "--json" -- "$cur")) ;;
     remove|update|watch|convert) COMPREPLY=($(compgen -W "--dry-run" -- "$cur")) ;;
+    rollback) COMPREPLY=($(compgen -W "--list --dry-run" -- "$cur")) ;;
     init|verify|ci|help|version) COMPREPLY=() ;;
+    agents) COMPREPLY=($(compgen -W "--json" -- "$cur")) ;;
     agents-xml) COMPREPLY=($(compgen -W "--write" -- "$cur")) ;;
     doctor) COMPREPLY=($(compgen -W "--json --network --deep" -- "$cur")) ;;
     diff) COMPREPLY=($(compgen -W "--json --brief --context --no-color" -- "$cur")) ;;
@@ -210,7 +214,9 @@ _rolecraft() {
     'verify:Verify installed skill integrity'
     'ci:Install all skills from lockfile'
     'completions:Generate shell completion scripts'
+    'agents:Show agent capability manifest'
     'upgrade:Upgrade rolecraft to latest version'
+    'rollback:Restore a skill to previous version'
     'check:Check for available skill updates'
     'watch:Watch skills and auto-sync changes'
     'convert:Convert another skill format to SKILL.md'
@@ -373,7 +379,9 @@ complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a search    -d 'Se
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a verify    -d 'Verify skill integrity'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a ci        -d 'CI mode install'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a completions -d 'Generate completions'
+complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a agents   -d 'Show agent capability manifest'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a upgrade    -d 'Upgrade to latest version'
+complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a rollback -d 'Restore a skill to previous version'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a check      -d 'Check for skill updates'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a watch      -d 'Watch skills and auto-sync'
 complete -f -c rolecraft -n '__fish_rolecraft_needs_command' -a convert    -d 'Convert a skill format'

--- a/src/commands/completions.test.js
+++ b/src/commands/completions.test.js
@@ -4,6 +4,8 @@ import assert from 'node:assert/strict'
 let completionsModule
 
 const addedCommands = [
+  'agents',
+  'rollback',
   'check',
   'watch',
   'convert',


### PR DESCRIPTION
## Summary

- add `agents` and `rollback` to bash, zsh, and fish completions
- add bash option completions for `agents` and `rollback`
- update completion tests

## Testing

- `npm run lint`
- `node --test src/commands/completions.test.js`
- manually verified bash, zsh, and fish completion output

Closes #232