### PR TITLE
refactor: centralize tilde expansion

### DIFF
--- a/src/api/bundle.js
+++ b/src/api/bundle.js
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { apiInstallSkills } from './install.js'
+import { expandTilde } from '../utils/paths.js'
 
 function parseSources(raw, filePath) {
   if (filePath.endsWith('.json')) {
@@ -27,9 +28,7 @@ async function resolveBundleFile(arg) {
     arg.startsWith('/') ||
     arg.startsWith('~')
   if (isFilePath) {
-    const resolvedPath = arg.startsWith('~')
-      ? join(process.env.HOME || '/tmp', arg.slice(1))
-      : arg
+    const resolvedPath = expandTilde(arg, process.env.HOME || '/tmp')
     for (const candidate of [resolvedPath, join(process.cwd(), arg)]) {
       try {
         await readFile(candidate, 'utf-8')

--- a/src/api/convert.js
+++ b/src/api/convert.js
@@ -1,12 +1,12 @@
 import { readFile, writeFile, readdir, mkdir } from 'node:fs/promises'
 import { join, basename } from 'node:path'
-import { homedir } from 'node:os'
 import {
   detectFormat,
   skillToMdc,
   mdcToSkill,
   parseFrontmatter,
 } from '../utils/converter.js'
+import { expandTilde } from '../utils/paths.js'
 
 function findSkillFile(dir, entries) {
   for (const e of entries) {
@@ -22,9 +22,7 @@ function findMdcFiles(dir, entries) {
 }
 
 export async function convertApi(source, options = {}) {
-  const expanded = source.startsWith('~')
-    ? join(homedir(), source.slice(1))
-    : source
+  const expanded = expandTilde(source)
   const outDir = options.output || process.cwd()
   const converted = []
 

--- a/src/api/doctor.js
+++ b/src/api/doctor.js
@@ -18,6 +18,7 @@ import {
 } from '../utils/lockfile.js'
 import { detectAgents } from '../commands/setup.js'
 import { parseFrontmatter, splitSections } from '../utils/converter.js'
+import { expandTilde } from '../utils/paths.js'
 import agents from '../agents.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -199,9 +200,7 @@ function validateMcpServers(detected) {
             arg.startsWith('./') ||
             arg.startsWith('~')
           ) {
-            const resolvedPath = arg.startsWith('~')
-              ? join(homedir(), arg.slice(1))
-              : arg
+            const resolvedPath = expandTilde(arg)
             try {
               accessSync(resolvedPath, constants.F_OK)
             } catch {

--- a/src/api/watch.js
+++ b/src/api/watch.js
@@ -1,9 +1,9 @@
 import { watch } from 'node:fs'
-import { homedir } from 'node:os'
 import { readLock, getProjectLockPath } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import { createDebouncer, WATCH_DEBOUNCE_MS } from '../utils/debounce.js'
+import { expandTilde } from '../utils/paths.js'
 import agents from '../agents.js'
 
 const agentNameToTarget = Object.fromEntries(
@@ -64,7 +64,7 @@ export async function watchApi(slug, cwd = process.cwd(), options = {}) {
     const entry = mergedSkills[s]
     if (entry.sourceType !== 'local') continue
 
-    const sourcePath = entry.source.replace(/^~/, homedir())
+    const sourcePath = expandTilde(entry.source)
 
     const handler = (_eventType, filename) => {
       if (!filename || filename.startsWith('.')) return

--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { createInterface } from 'node:readline'
 import { stdin as input, stdout as output } from 'node:process'
 import { apiInstallSkills } from '../api/install.js'
+import { expandTilde } from '../utils/paths.js'
 
 function askQuestion(query) {
   const rl = createInterface({ input, output })
@@ -39,9 +40,7 @@ async function resolveBundleFile(arg) {
     arg.startsWith('/') ||
     arg.startsWith('~')
   if (isFilePath) {
-    const resolvedPath = arg.startsWith('~')
-      ? join(process.env.HOME || '/tmp', arg.slice(1))
-      : arg
+    const resolvedPath = expandTilde(arg, process.env.HOME || '/tmp')
     for (const candidate of [resolvedPath, join(process.cwd(), arg)]) {
       try {
         await readFile(candidate, 'utf-8')

--- a/src/commands/bundle.test.js
+++ b/src/commands/bundle.test.js
@@ -245,6 +245,10 @@ describe('bundle command', () => {
       `import { apiInstallSkills } from '${join(__dirname, '../api/install.js')}'`,
     )
     modSrc = modSrc.replace(
+      `import { expandTilde } from '../utils/paths.js'`,
+      `import { expandTilde } from '${join(__dirname, '../utils/paths.js')}'`,
+    )
+    modSrc = modSrc.replace(
       `import { createInterface } from 'node:readline'`,
       [
         `const _bAns = ['my-test-bundle', '']`,
@@ -277,6 +281,10 @@ describe('bundle command', () => {
     modSrc = modSrc.replace(
       `import { apiInstallSkills } from '../api/install.js'`,
       `import { apiInstallSkills } from '${join(__dirname, '../api/install.js')}'`,
+    )
+    modSrc = modSrc.replace(
+      `import { expandTilde } from '../utils/paths.js'`,
+      `import { expandTilde } from '${join(__dirname, '../utils/paths.js')}'`,
     )
     modSrc = modSrc.replace(
       `import { createInterface } from 'node:readline'`,

--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -1,12 +1,12 @@
 import { readFile, writeFile, readdir, mkdir } from 'node:fs/promises'
 import { join, basename } from 'node:path'
-import { homedir } from 'node:os'
 import {
   detectFormat,
   skillToMdc,
   mdcToSkill,
   parseFrontmatter,
 } from '../utils/converter.js'
+import { expandTilde } from '../utils/paths.js'
 
 function findSkillFile(dir, entries) {
   for (const e of entries) {
@@ -22,9 +22,7 @@ function findMdcFiles(dir, entries) {
 }
 
 export async function convertCommand(source, options = {}) {
-  const expanded = source.startsWith('~')
-    ? join(homedir(), source.slice(1))
-    : source
+  const expanded = expandTilde(source)
   const outDir = options.output || process.cwd()
 
   const entries = await readdir(expanded, { withFileTypes: true }).catch(

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -1,9 +1,9 @@
 import { watch } from 'node:fs'
-import { homedir } from 'node:os'
 import { readLock, getProjectLockPath } from '../utils/lockfile.js'
 import { resolveSource } from '../utils/resolver.js'
 import { installSkill } from '../utils/installer.js'
 import { createDebouncer, WATCH_DEBOUNCE_MS } from '../utils/debounce.js'
+import { expandTilde } from '../utils/paths.js'
 import agents from '../agents.js'
 
 const agentNameToTarget = Object.fromEntries(
@@ -60,7 +60,7 @@ export async function watchCommand(slug, cwd = process.cwd(), options = {}) {
     console.log(`\n📋 [dry-run] Would watch ${watchSlugs.length} skill(s):\n`)
     for (const s of watchSlugs) {
       const entry = mergedSkills[s]
-      const sourcePath = entry.source.replace(/^~/, homedir())
+      const sourcePath = expandTilde(entry.source)
       console.log(`   • ${s} → ${sourcePath}`)
     }
     console.log()
@@ -94,7 +94,7 @@ export async function watchCommand(slug, cwd = process.cwd(), options = {}) {
       continue
     }
 
-    const sourcePath = entry.source.replace(/^~/, homedir())
+    const sourcePath = expandTilde(entry.source)
 
     const handler = (_eventType, filename) => {
       if (!filename || filename.startsWith('.')) return

--- a/src/utils/mcp.js
+++ b/src/utils/mcp.js
@@ -7,7 +7,7 @@ import {
   readdir,
 } from 'node:fs/promises'
 import { join, dirname, relative } from 'node:path'
-import { homedir, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import {
   execSync as defaultExecSync,
   spawnSync as defaultSpawnSync,
@@ -16,6 +16,7 @@ import agents from '../agents.js'
 import { addServerToMcpLock, removeServerFromMcpLock } from './mcp-lock.js'
 import { parseFrontmatter } from './converter.js'
 import { UserError } from './errors.js'
+import { expandTilde } from './paths.js'
 
 let _runExec = defaultExecSync
 let runSpawnSync = defaultSpawnSync
@@ -347,9 +348,7 @@ export async function resolveMcpSource(source) {
     source.startsWith('.') ||
     source.startsWith('~')
   ) {
-    const resolvedPath = source.startsWith('~')
-      ? join(homedir(), source.slice(1))
-      : source
+    const resolvedPath = expandTilde(source)
     return {
       command: 'node',
       args: [resolvedPath],

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -4,3 +4,7 @@ import { join } from 'node:path'
 export function home(...parts) {
   return join(homedir(), ...parts)
 }
+
+export function expandTilde(path, homeDirectory = homedir()) {
+  return path.startsWith('~') ? join(homeDirectory, path.slice(1)) : path
+}

--- a/src/utils/paths.test.js
+++ b/src/utils/paths.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+import { expandTilde } from './paths.js'
+
+describe('expandTilde', () => {
+  it('expands a tilde-prefixed path from the home directory', () => {
+    assert.equal(
+      expandTilde('~/skills/example'),
+      join(homedir(), 'skills/example'),
+    )
+  })
+
+  it('expands a bare tilde to the home directory', () => {
+    assert.equal(expandTilde('~'), homedir())
+  })
+
+  it('supports an explicit home directory', () => {
+    assert.equal(
+      expandTilde('~/fixture.json', '/tmp'),
+      join('/tmp', 'fixture.json'),
+    )
+  })
+
+  it('leaves non-tilde paths unchanged', () => {
+    assert.equal(expandTilde('/tmp/example'), '/tmp/example')
+    assert.equal(expandTilde('./example'), './example')
+  })
+})

--- a/src/utils/resolver.js
+++ b/src/utils/resolver.js
@@ -2,13 +2,14 @@ import { readFile, readdir, stat, rm } from 'node:fs/promises'
 import { createWriteStream } from 'node:fs'
 import { Writable } from 'node:stream'
 import { join, dirname, basename } from 'node:path'
-import { tmpdir, homedir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { execSync as defaultExecSync, spawnSync } from 'node:child_process'
 import { mkdtempSync } from 'node:fs'
 import { get as defaultHttpsGet } from 'node:https'
 import { computeContentHash } from './lockfile.js'
 import { parseFrontmatter } from './converter.js'
 import { UserError } from './errors.js'
+import { expandTilde } from './paths.js'
 
 const SCAN_MAX_DEPTH = 3
 
@@ -217,7 +218,7 @@ async function scanForSkill(dir, maxDepth = SCAN_MAX_DEPTH) {
 }
 
 async function resolveLocalInternal(source) {
-  const expanded = source.replace(/^~/, homedir())
+  const expanded = expandTilde(source)
 
   let skillDir
   try {


### PR DESCRIPTION
Centralizes the ten live leading-tilde expansion sites in `expandTilde` with focused behavior-preservation tests, closing #240.