### PR TITLE
feat: add oh-my-pi (omp) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <b>The Security-First Skill Manager for AI Agents</b><br>
-   Every install runs a security scan · Skills & MCP Servers across 86 Agents (26 Verified)<br>
+   Every install runs a security scan · Skills & MCP Servers across 87 Agents (27 Verified)<br>
   Zero-dependency CLI · No signup · Offline-first
 </p>
 
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  Works with <b>86 AI agents</b>. See the <a href="docs/agents.md">full agent table →</a>
+  Works with <b>87 AI agents</b>. See the <a href="docs/agents.md">full agent table →</a>
 </p>
 
 <p align="center">
@@ -98,7 +98,7 @@ rolecraft convert ./my-skill
 rolecraft convert --help
 ```
 
-**Requirements:** Node.js >= 20 · 432.8 kB · zero dependencies · 86 agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
+**Requirements:** Node.js >= 20 · 432.8 kB · zero dependencies · 87 agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
 
 > **Why zero dependencies?** Every dependency is a supply-chain risk. rolecraft uses only Node.js built-ins (`fs`, `path`, `crypto`, `https`) — no `node_modules` surprises.
 
@@ -154,7 +154,7 @@ No other CLI combines both. npx skills has no MCP support. ags has a separate MC
 - **Zero dependencies** — 432.8 kB, only Node.js built-ins
 - **MCP + Skills in one command** — install skills and their MCP servers together
 - **Any source** — local folder, GitHub/GitLab/SSH URL, npm package
-- **86 agents** — opencode, claude-code, cursor, copilot, aider, and more
+- **87 agents** — opencode, claude-code, cursor, copilot, aider, oh-my-pi (omp), and more
 - **No registry required** — works fully without a marketplace; community-driven [registry](https://github.com/rolecraft-sh/registry) optional
 - **Security scoring** — static analysis on every install: detects prompt injection, command injection, obfuscated code, credential harvesting. Scores 0–100. Blocks dangerous skills (use `--yes` to override). 341 malicious skills were found on community hubs in Feb 2026 — rolecraft scans every skill before it touches your machine
 - **CI-ready** — lockfile-based re-install (`rolecraft ci`), `--yes` flag, `--dry-run`
@@ -294,7 +294,7 @@ All API functions return plain objects (no side-effects). Available exports:
 | GitLab / SSH git URL                 | ✅               | ✅              | ❌                  |
 | npm package source                   | ✅               | ✅              | ❌                  |
 | **MCP server management**            | ✅               | ❌              | ❌                  |
-| Agent targets                        | **86**           | 72              | 15+                 |
+| Agent targets                        | **87**           | 72              | 15+                 |
 | **Registry / marketplace**           | ✅               | ✅ (skills.sh)  | ⚠️ (registry only)  |
 | Bundle install + create              | ✅               | ❌              | ✅ (skillset only)  |
 | Interactive TUI search + install     | ✅               | ✅              | ❌                  |
@@ -374,13 +374,13 @@ rolecraft install ./my-skill --cursor --devin --copilot --gemini --cody
 A: No. No account, no API key, no marketplace. Point rolecraft at any folder or repo and it works.
 
 **Q: Can I use rolecraft with multiple AI agents?**
-A: Yes. 86 agents supported. Use `--cursor`, `--claude`, `--devin` flags or `--all` for every agent.
+A: Yes. 87 agents supported. Use `--cursor`, `--claude`, `--devin` flags or `--all` for every agent.
 
 **Q: Does rolecraft send telemetry?**
 A: No. Zero data leaves your machine. The security scan runs locally. No phone home.
 
 **Q: How is this different from `npx skills` (Vercel)?**
-A: rolecraft has zero dependencies, MCP server management, 86 agents (vs 72), `doctor`, `watch`, `bundle`, `agents-xml`, and shell completions. [Full comparison →](docs/comparison.md)
+A: rolecraft has zero dependencies, MCP server management, 87 agents (vs 72), `doctor`, `watch`, `bundle`, `agents-xml`, and shell completions. [Full comparison →](docs/comparison.md)
 
 **Q: Can I use it in CI/CD?**
 A: Yes. `rolecraft ci --yes` re-installs all skills from lockfile, non-interactive. Perfect for pipelines.

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,12 +2,12 @@
 name: rolecraft
 description: >-
   Install AI agent skills as roles & behaviors from any source — local folder,
-  GitHub, GitLab, SSH git URL. Zero-dependency CLI with 86 agent targets (26 verified).
+  GitHub, GitLab, SSH git URL. Zero-dependency CLI with 87 agent targets (27 verified).
 ---
 
 # rolecraft
 
-Install and manage AI agent skills across 86 agents (26 verified) with a single command. Zero dependencies. No registry required.
+Install and manage AI agent skills across 87 agents (27 verified) with a single command. Zero dependencies. No registry required.
 
 ## When to use
 
@@ -83,9 +83,9 @@ npx rolecraft convert ./my-skill
 | `--symlink` | Symlink instead of copy |
 | `--global` / `--project` | Scope selection |
 
-## Supported agents (86 total · 26 verified)
+## Supported agents (87 total · 27 verified)
 
-`opencode`, `claude-code`, `cursor`, `windsurf`, `devin`, `codex`, `copilot`, `aider`, `cline`, `gemini-cli`, `cody`, `continue`, `warp`, `codeium`, `fabric`, `goose`, `tabnine`, `supermaven`, `pr-pilot`, `loom`, `roo`, `trae`, `hermes`, `kiro`, `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, `cortex`, `mistral-vibe`, `qwen-code`, `openclaw`, `codebuddy`, `mux`, `pi`, `autohand-code`, `rovo-dev`, `firebender`, `ibm-bob`, `aider-desk`, and 44 more.
+`opencode`, `claude-code`, `cursor`, `windsurf`, `devin`, `codex`, `copilot`, `aider`, `cline`, `gemini-cli`, `cody`, `continue`, `warp`, `codeium`, `fabric`, `goose`, `tabnine`, `supermaven`, `pr-pilot`, `loom`, `roo`, `trae`, `hermes`, `kiro`, `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, `cortex`, `mistral-vibe`, `qwen-code`, `openclaw`, `codebuddy`, `mux`, `pi`, `omp (oh-my-pi)`, `autohand-code`, `rovo-dev`, `firebender`, `ibm-bob`, `aider-desk`, and 45 more.
 
 ## Examples
 

--- a/apps.json
+++ b/apps.json
@@ -15,8 +15,8 @@
       "id": "rolecraft",
       "name": "RoleCraft",
       "subtitle": "The package manager for AI agents",
-      "description": "Install, test, publish, and manage skills & MCP servers across 86+ agents. Zero-dependency CLI.",
-      "longDescription": "RoleCraft is a zero-dependency Node.js CLI that serves as the package manager for AI agent skills. Install skills from any source, test them, publish to a central registry, and manage MCP servers — all from a single tool. Compatible with 86+ AI coding agents including Claude Code, Cursor, Codex, OpenCode, Windsurf, and more.",
+      "description": "Install, test, publish, and manage skills & MCP servers across 87 agents. Zero-dependency CLI.",
+      "longDescription": "RoleCraft is a zero-dependency Node.js CLI that serves as the package manager for AI agent skills. Install skills from any source, test them, publish to a central registry, and manage MCP servers — all from a single tool. Compatible with 87 AI coding agents including Claude Code, Cursor, Codex, OpenCode, Windsurf, Oh My Pi, and more.",
       "icon": "https://raw.githubusercontent.com/rolecraft-sh/rolecraft/main/assets/rolecraft_logo.png",
       "iconEmoji": "📦",
       "iconStyle": {
@@ -37,7 +37,7 @@
         "Install skills from GitHub, URLs, or local paths",
         "Central skill registry with schema validation",
         "MCP server management — install, verify, and run",
-        "Compatible with 86+ AI agents (Claude Code, Cursor, Codex, OpenCode...)",
+        "Compatible with 87 AI agents (Claude Code, Cursor, Codex, OpenCode, Oh My Pi...)",
         "GitHub Action for CI/CD integration",
         "Skill testing and verification built-in",
         "Profile system for team collaboration"

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -41,6 +41,7 @@ rolecraft knows where each AI agent looks for skills. When you use a flag like `
 | codebuddy | `~/.codebuddy/skills/` | experimental | - |
 | mux | `~/.mux/skills/` | experimental | - |
 | pi | `~/.pi/agent/skills/` | experimental | - |
+| oh-my-pi | `~/.omp/agent/skills/` | verified | mcpServers |
 | autohand-code | `~/.autohand/skills/` | experimental | - |
 | rovo-dev | `~/.rovodev/skills/` | experimental | - |
 | firebender | `~/.firebender/skills/` | experimental | - |
@@ -93,9 +94,9 @@ rolecraft knows where each AI agent looks for skills. When you use a flag like `
 
 > **Support levels:** `verified` — actively tested and maintained; `community` — community-contributed, maintained on best-effort; `legacy` — previous generation, no active development; `experimental` — known to exist, not formally tested.
 
-> **MCP support:** 7 agent(s) support MCP server configuration. Format: `mcpServers`, `servers`, `experimental.mcpServers`
+> **MCP support:** 8 agent(s) support MCP server configuration. Format: `mcpServers`, `servers`, `experimental.mcpServers`
 
-> **Agent count:** 86 total — 26 verified, 0 community, 0 legacy, 60 experimental.
+> **Agent count:** 87 total — 27 verified, 0 community, 0 legacy, 60 experimental.
 
 ## Notes
 
@@ -119,6 +120,7 @@ rolecraft knows where each AI agent looks for skills. When you use a flag like `
 - **openhands:** Also reads project .agents/skills; legacy .openhands/skills and .openhands/microagents still supported
 - **junie:** Also reads project .junie/skills; auto-imports .cursor/.claude/.codex skill folders
 - **qwen-code:** Also reads project .qwen/skills
+- **oh-my-pi:** pi fork by can1357; native skills at ~/.omp/agent/skills (user) and .omp/skills (project); also reads ~/.claude/skills, ~/.agents/skills and .github/skills; MCP via standard mcpServers format
 - **forge:** ForgeCode by tailcallhq; also reads ~/forge/skills and ~/.agents/skills; project dir has highest precedence
 - **jazz:** jazz-ai (lvndry/jazz, not an AWS product); also reads project ./skills
 - **lingma:** Also reads project .lingma/skills; renamed to Qoder CN on 2026-05-20

--- a/docs/commands/agents.md
+++ b/docs/commands/agents.md
@@ -44,7 +44,7 @@ $ rolecraft agents
 
 🔍 Agent Capability Manifest
 
-Total agents: 86
+Total agents: 87
 
 ## VERIFIED
 
@@ -68,7 +68,7 @@ These agents have built-in MCP configuration support:
 ## Validation
 
 Manifest valid: ✅ Yes
-Agent count: 86
+Agent count: 87
 ```
 
 ```bash
@@ -76,7 +76,7 @@ $ rolecraft agents --json
 
 {
   "version": 1,
-  "agentCount": 86,
+  "agentCount": 87,
   "agents": [
     {
       "flag": "claude",

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -22,7 +22,7 @@ Scans your system and reports on:
 - **Lockfile schema** — validates global lockfile format
 - **Global & project lockfiles** — skill count per scope
 - **Disk usage** — total size of installed skills
-- **Agent detection** — finds installed agents among 86 supported, per-agent skill count and directory permissions
+- **Agent detection** — finds installed agents among 87 supported, per-agent skill count and directory permissions
 - **Orphaned skill dirs** — directories not tracked in any lockfile
 - **Skill integrity** — verifies skill directories exist, content hashes match, and checks for broken symlinks
 - **MCP servers** — counts configured MCP servers across detected agents
@@ -57,7 +57,7 @@ $ rolecraft doctor
    ✅ Global lockfile                        3 skill(s) tracked
    ⚠️  Project lockfile                       no project skills
    ✅ Disk usage                             3 skill(s), 12.5 KB total
-   ✅ Agent detection                        14/86 supported agents detected
+   ✅ Agent detection                        14/87 supported agents detected
      ✅  └ opencode                          2 skill(s) [rwx]
      ✅  └ claude-code                       1 skill(s) [rwx]
    ✅ Orphaned skill dirs                    none
@@ -74,7 +74,7 @@ $ rolecraft doctor --json
   "status": "degraded",
   "checks": {
     "Node.js version": { "status": "pass", "detail": "v22.0.0" },
-    "Agent detection": { "status": "pass", "detail": "14/86 supported agents detected" },
+    "Agent detection": { "status": "pass", "detail": "14/87 supported agents detected" },
     "Skill integrity": { "status": "warn", "detail": "3 checked, 1 missing director(ies)" },
     "MCP servers": { "status": "warn", "detail": "none configured" }
   },

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | **Runtime** | Zero-dep Node ESM | 1 dep (Node) | 2 deps (TypeScript) |
 | **File size** | 432.8 kB | ~465 KB | ~84 KB |
-| **Agent targets** | **86** | 72 | 15+ |
+| **Agent targets** | **87** | 72 | 15+ |
 | **Skill marketplace** | rolecraft registry | skills.sh (90K+) | agentskill.sh (100K+) |
 | **Publish your own** | ✅ | ❌ | ❌ |
 | **MCP management** | ✅ | ❌ | ❌ |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -15,7 +15,7 @@ A skill is a reusable capability for your AI coding agent. Think of it as a plug
 - **Team conventions** — one command sets up every agent on every developer's machine
 - **MCP servers** — skills can declare and install MCP servers alongside themselves
 
-rolecraft manages all of this across **86 AI agents** (26 verified) with a single CLI and **zero runtime dependencies**.
+rolecraft manages all of this across **87 AI agents** (27 verified) with a single CLI and **zero runtime dependencies**.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "RoleCraft"
   text: "The Security-First Skill Manager for AI Agents"
-  tagline: Every install runs a security scan · Skills & MCP Servers across 86 Agents (26 Verified)
+  tagline: Every install runs a security scan · Skills & MCP Servers across 87 Agents (27 Verified)
   image:
     src: /rolecraft-demo.gif
     alt: RoleCraft Demo
@@ -35,4 +35,4 @@ features:
   - title: Init Templates
     details: "rolecraft init --template scaffolds production-ready skills from pre-built templates. Start fast, ship faster."
   - title: Parallel Install
-    details: Install skills and MCP servers across all 86 agents (26 verified) simultaneously. Blazing fast, built for scale.
+    details: Install skills and MCP servers across all 87 agents (27 verified) simultaneously. Blazing fast, built for scale.

--- a/docs/migration-from-skills.md
+++ b/docs/migration-from-skills.md
@@ -8,7 +8,7 @@ If you're using [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) a
 |---|---|---|
 | Dependencies | **0** (zero-dep) | 1 (`supports-color`) |
 | Package size | **432.8 kB** | ~465 KB |
-| Agent targets | **86** | 72 |
+| Agent targets | **87** | 72 |
 | Telemetry | **None** | Anonymous telemetry |
 | Offline installs | **Fully supported** | Requires network |
 | Shell completions | bash, zsh, fish | Not available |
@@ -52,7 +52,7 @@ rm ~/.skills-lock.json
 ## What rolecraft does differently
 
 ### More agent targets
-rolecraft supports **86 agents** vs Vercel's 72. This includes newer agents like `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, and more.
+rolecraft supports **87 agents** vs Vercel's 72. This includes newer agents like `augment`, `kilo`, `openhands`, `junie`, `factory`, `command-code`, `oh-my-pi (omp)`, and more.
 
 ### Any source, not just GitHub
 Install from local folders, GitLab, Bitbucket, SSH URLs, or even npm packages — not just GitHub repos.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -158,7 +158,7 @@ Pass any of these to `install`, `setup`, or `profile` to target specific agents:
 | `--tiny-cloud` | tiny-cloud | `~/.tinycloud/skills/` |
 | `--zencoder` | zencoder | `~/.zencoder/skills/` |
 | `--codebuddy` | codebuddy | `~/.codebuddy/skills/` |
-| *(see [full list](agents) for all 86 agents)* | | |
+| *(see [full list](agents) for all 87 agents)* | | |
 
 Combine multiple flags in one command:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rolecraft",
   "version": "2.3.2",
-  "description": "The package manager for AI agents — install, test, publish, and manage skills & MCP servers across 86+ agents. Zero-dependency CLI for claude-code, cursor, opencode, and more.",
+  "description": "The package manager for AI agents — install, test, publish, and manage skills & MCP servers across 87 agents. Zero-dependency CLI for claude-code, cursor, opencode, omp, and more.",
   "type": "module",
   "bin": {
     "rolecraft": "bin/rolecraft.js"

--- a/src/agents.js
+++ b/src/agents.js
@@ -240,6 +240,12 @@ const AGENTS_DATA = [
     label: '~/.pi/agent/skills/',
   },
   {
+    flag: 'omp',
+    name: 'oh-my-pi',
+    getDir: () => home('.omp', 'agent', 'skills'),
+    label: '~/.omp/agent/skills/',
+  },
+  {
     flag: 'autohand-code',
     name: 'autohand-code',
     getDir: () => home('.autohand', 'skills'),
@@ -543,6 +549,7 @@ const MCP_SUPPORTED = [
   'devin',
   'copilot',
   'continue',
+  'omp',
 ]
 
 const MCP_PATHS = {

--- a/src/agents/manifest.js
+++ b/src/agents/manifest.js
@@ -147,6 +147,20 @@ const MANIFEST_DATA = {
     notes:
       'Confirmed from source code loaders; also reads workspace .claude/skills',
   },
+  'oh-my-pi': {
+    skillInstallScope: 'global ~/.omp/agent/skills',
+    mcpSupport: {
+      supported: true,
+      format: MCP_CONFIG_FORMATS.STANDARD,
+      configPath: '~/.omp/agent/mcp.json',
+    },
+    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
+    supportLevel: SUPPORT_LEVELS.VERIFIED,
+    docUrl: 'https://omp.sh/docs/skills',
+    lastVerified: '2026-08-24',
+    notes:
+      'pi fork by can1357; native skills at ~/.omp/agent/skills (user) and .omp/skills (project); also reads ~/.claude/skills, ~/.agents/skills and .github/skills; MCP via standard mcpServers format',
+  },
   // Agents sharing .agents/skills directory
   'gemini-cli': {
     skillInstallScope: 'global ~/.gemini/skills',

--- a/src/agents/manifest.test.js
+++ b/src/agents/manifest.test.js
@@ -50,6 +50,20 @@ describe('agent manifest', () => {
     assert.ok(cc.docUrl)
   })
 
+  it('includes oh-my-pi as verified with MCP and native paths', () => {
+    const manifest = getAgentManifest()
+    const omp = manifest.find((a) => a.name === 'oh-my-pi')
+    assert.ok(omp)
+    assert.equal(omp.flag, 'omp')
+    assert.equal(omp.supportLevel, SUPPORT_LEVELS.VERIFIED)
+    assert.equal(omp.skillInstallScope, 'global ~/.omp/agent/skills')
+    assert.equal(omp.mcpSupport.supported, true)
+    assert.equal(omp.mcpSupport.format, 'mcpServers')
+    assert.equal(omp.instructionFormat, 'skill-md')
+    assert.ok(omp.docUrl)
+    assert.ok(omp.lastVerified)
+  })
+
   it('flags shared-directory agents with aliasFor', () => {
     const shared = getAgentManifest().filter((a) => a.aliasFor)
     assert.ok(shared.length > 0)

--- a/src/commands/completions.js
+++ b/src/commands/completions.js
@@ -284,7 +284,8 @@ _rolecraft() {
              '--openclaw[Also install to ~/.openclaw/skills/]' \\
              '--codebuddy[Also install to ~/.codebuddy/skills/]' \\
              '--mux[Also install to ~/.mux/skills/]' \\
-             '--pi[Also install to ~/.pi/agent/skills/]' \\
+              '--pi[Also install to ~/.pi/agent/skills/]' \\
+              '--omp[Also install to ~/.omp/agent/skills/]' \\
              '--autohand-code[Also install to ~/.autohand/skills/]' \\
              '--rovo[Also install to ~/.rovodev/skills/]' \\
              '--firebender[Also install to ~/.firebender/skills/]' \\
@@ -435,7 +436,8 @@ for cmd in install bundle use setup upgrade check
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l openclaw        -d 'Install to ~/.openclaw/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l codebuddy       -d 'Install to ~/.codebuddy/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l mux             -d 'Install to ~/.mux/skills/'
-  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l pi              -d 'Install to ~/.pi/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l pi              -d 'Install to ~/.pi/agent/skills/'
+  complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l omp             -d 'Install to ~/.omp/agent/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l autohand-code   -d 'Install to ~/.autohand/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l rovo            -d 'Install to ~/.rovodev/skills/'
   complete -f -c rolecraft -n "__fish_rolecraft_using_command $cmd" -l firebender      -d 'Install to ~/.firebender/skills/'

--- a/src/utils/installer.test.js
+++ b/src/utils/installer.test.js
@@ -404,6 +404,20 @@ describe('installer', () => {
     assert.ok(existsSync(join(skillDir, 'SKILL.md')))
   })
 
+  it('installs skill to omp directory', async () => {
+    const results = await installerModule.installSkill(resolvedSkill, ['omp'])
+    assert.equal(results.length, 1)
+    assert.equal(results[0].target, 'omp')
+    const skillDir = join(
+      process.env.HOME,
+      '.omp',
+      'agent',
+      'skills',
+      'test-my-skill',
+    )
+    assert.ok(existsSync(join(skillDir, 'SKILL.md')))
+  })
+
   it('installs skill to autohand-code directory', async () => {
     const results = await installerModule.installSkill(resolvedSkill, [
       'autohand-code',

--- a/src/utils/mcp.test.js
+++ b/src/utils/mcp.test.js
@@ -45,6 +45,7 @@ describe('mcp', () => {
         'devin',
         'copilot',
         'continue',
+        'omp',
       ]
       assert.equal(agents.length, supported.length)
       for (const flag of supported) {


### PR DESCRIPTION
Adds oh-my-pi (omp) as a verified install target with native skill path (~/.omp/agent/skills), standard mcpServers MCP support, shell completions, tests, and updated docs/counts.