### PR TITLE
fix: remove skills from recorded agent directories

### DIFF
--- a/src/api/remove.js
+++ b/src/api/remove.js
@@ -8,6 +8,7 @@ import {
   normalizeSlug,
 } from '../utils/lockfile.js'
 import { assertSafeSlug } from '../utils/installer.js'
+import agents, { getAgentByFlag } from '../agents.js'
 
 function findActualSlug(slug, lock) {
   if (lock.skills[slug]) return slug
@@ -20,6 +21,39 @@ function findActualSlug(slug, lock) {
     const namePart = k.split('/').pop()
     return namePart === slug || normalizeSlug(namePart) === normalized
   })
+}
+
+function getTargetBaseDir(target, cwd) {
+  if (target === 'project') {
+    return join(cwd, '.agents', 'skills')
+  }
+
+  const agent =
+    getAgentByFlag(target) ||
+    agents.find((candidate) => candidate.name === target)
+
+  return agent ? agent.getDir() : getAgentsDir()
+}
+
+function resolveRemovalDirs(slug, entry, scope, cwd, seenDirs) {
+  const fallbackTarget = scope === 'project' ? 'project' : 'agents'
+  const targets =
+    Array.isArray(entry?.agents) && entry.agents.length > 0
+      ? entry.agents
+      : [fallbackTarget]
+  const dirs = []
+
+  for (const target of targets) {
+    const baseDir = getTargetBaseDir(target, cwd)
+    const dir = join(baseDir, normalizeSlug(slug))
+    assertSafeSlug(slug, baseDir, dir)
+
+    if (seenDirs.has(dir)) continue
+    seenDirs.add(dir)
+    dirs.push({ scope, path: dir })
+  }
+
+  return dirs
 }
 
 export async function apiRemove(slug, cwd = process.cwd(), options = {}) {
@@ -35,38 +69,47 @@ export async function apiRemove(slug, cwd = process.cwd(), options = {}) {
   }
 
   const actualSlug = globalFound || projectFound
-  const removed = []
+  const seenDirs = new Set()
+  const dirs = []
+
+  if (globalFound) {
+    dirs.push(
+      ...resolveRemovalDirs(
+        actualSlug,
+        globalLock.skills[globalFound],
+        'global',
+        cwd,
+        seenDirs,
+      ),
+    )
+  }
+  if (projectFound) {
+    dirs.push(
+      ...resolveRemovalDirs(
+        actualSlug,
+        projectLock.skills[projectFound],
+        'project',
+        cwd,
+        seenDirs,
+      ),
+    )
+  }
 
   if (options.dryRun) {
-    const dirs = []
-    if (globalFound) {
-      const dir = join(getAgentsDir(), normalizeSlug(actualSlug))
-      assertSafeSlug(actualSlug, getAgentsDir(), dir)
-      dirs.push({ scope: 'global', path: dir })
-    }
-    if (projectFound) {
-      const dir = join(cwd, '.agents', 'skills', normalizeSlug(actualSlug))
-      assertSafeSlug(actualSlug, join(cwd, '.agents', 'skills'), dir)
-      dirs.push({ scope: 'project', path: dir })
-    }
     return { dryRun: true, slug: actualSlug, dirs }
   }
 
+  for (const { path } of dirs) {
+    await rm(path, { recursive: true, force: true })
+  }
+
   if (globalFound) {
-    const dir = join(getAgentsDir(), normalizeSlug(actualSlug))
-    assertSafeSlug(actualSlug, getAgentsDir(), dir)
-    await rm(dir, { recursive: true, force: true })
     await removeSkillFromLock(actualSlug)
-    removed.push({ scope: 'global', path: dir })
   }
 
   if (projectFound) {
-    const projectDir = join(cwd, '.agents', 'skills', normalizeSlug(actualSlug))
-    assertSafeSlug(actualSlug, join(cwd, '.agents', 'skills'), projectDir)
-    await rm(projectDir, { recursive: true, force: true })
     await removeSkillFromLock(actualSlug, projectLockPath)
-    removed.push({ scope: 'project', path: projectDir })
   }
 
-  return { slug: actualSlug, removed }
+  return { slug: actualSlug, removed: dirs }
 }

--- a/src/api/remove.js
+++ b/src/api/remove.js
@@ -1,5 +1,5 @@
 import { rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { isAbsolute, join, relative } from 'node:path'
 import {
   readLock,
   removeSkillFromLock,
@@ -23,6 +23,16 @@ function findActualSlug(slug, lock) {
   })
 }
 
+function rebaseToCwd(dir, cwd) {
+  const rel = relative(process.cwd(), dir)
+
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+    return dir
+  }
+
+  return join(cwd, rel)
+}
+
 function getTargetBaseDir(target, cwd) {
   if (target === 'project') {
     return join(cwd, '.agents', 'skills')
@@ -32,7 +42,9 @@ function getTargetBaseDir(target, cwd) {
     getAgentByFlag(target) ||
     agents.find((candidate) => candidate.name === target)
 
-  return agent ? agent.getDir() : getAgentsDir()
+  const baseDir = agent ? agent.getDir() : getAgentsDir()
+
+  return rebaseToCwd(baseDir, cwd)
 }
 
 function resolveRemovalDirs(slug, entry, scope, cwd, seenDirs) {

--- a/src/api/remove.test.js
+++ b/src/api/remove.test.js
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync } from 'node:fs'
+import { existsSync, mkdtempSync } from 'node:fs'
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -77,5 +77,100 @@ describe('api remove', () => {
     const result = await apiRemove('test/exact', tempDir)
     assert.equal(result.slug, 'test/exact')
     assert.ok(result.removed.length >= 1)
+  })
+
+  it('removes a skill from a recorded per-agent target', async () => {
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'test/per-agent': { agents: ['pi'] },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      }),
+    )
+    const skillDir = join(tempDir, '.pi', 'agent', 'skills', 'test-per-agent')
+    await mkdir(skillDir, { recursive: true })
+
+    const result = await apiRemove('test/per-agent', tempDir)
+
+    assert.equal(existsSync(skillDir), false)
+    assert.deepEqual(result.removed, [{ scope: 'global', path: skillDir }])
+  })
+
+  it('removes a skill from every recorded agent target', async () => {
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'test/multi-agent': { agents: ['claude', 'omp'] },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      }),
+    )
+    const claudeDir = join(tempDir, '.claude', 'skills', 'test-multi-agent')
+    const ompDir = join(tempDir, '.omp', 'agent', 'skills', 'test-multi-agent')
+    await mkdir(claudeDir, { recursive: true })
+    await mkdir(ompDir, { recursive: true })
+
+    const result = await apiRemove('test/multi-agent', tempDir)
+
+    assert.equal(existsSync(claudeDir), false)
+    assert.equal(existsSync(ompDir), false)
+    assert.deepEqual(result.removed, [
+      { scope: 'global', path: claudeDir },
+      { scope: 'global', path: ompDir },
+    ])
+  })
+
+  it('deduplicates shared agent directories in dry-run output', async () => {
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'test/shared-dir': { agents: ['codex', 'warp', 'pi'] },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      }),
+    )
+    const sharedDir = join(tempDir, '.agents', 'skills', 'test-shared-dir')
+    const piDir = join(tempDir, '.pi', 'agent', 'skills', 'test-shared-dir')
+    await mkdir(sharedDir, { recursive: true })
+    await mkdir(piDir, { recursive: true })
+
+    const result = await apiRemove('test/shared-dir', tempDir, { dryRun: true })
+
+    assert.deepEqual(result.dirs, [
+      { scope: 'global', path: sharedDir },
+      { scope: 'global', path: piDir },
+    ])
+    assert.equal(existsSync(sharedDir), true)
+    assert.equal(existsSync(piDir), true)
+  })
+
+  it('supports agent names written by current installer versions', async () => {
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'test/agent-name': { agents: ['oh-my-pi'] },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      }),
+    )
+    const skillDir = join(tempDir, '.omp', 'agent', 'skills', 'test-agent-name')
+    await mkdir(skillDir, { recursive: true })
+
+    await apiRemove('test/agent-name', tempDir)
+
+    assert.equal(existsSync(skillDir), false)
   })
 })

--- a/src/api/remove.test.js
+++ b/src/api/remove.test.js
@@ -173,4 +173,25 @@ describe('api remove', () => {
 
     assert.equal(existsSync(skillDir), false)
   })
+
+  it('resolves project-relative agents against the given cwd', async () => {
+    await writeFile(
+      join(tempDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'test/proj-agent': { agents: ['devin'] },
+        },
+        dismissed: {},
+        lastSelectedAgents: [],
+      }),
+    )
+    const skillDir = join(tempDir, '.devin', 'skills', 'test-proj-agent')
+    await mkdir(skillDir, { recursive: true })
+
+    const result = await apiRemove('test/proj-agent', tempDir)
+
+    assert.equal(existsSync(skillDir), false)
+    assert.deepEqual(result.removed, [{ scope: 'global', path: skillDir }])
+  })
 })


### PR DESCRIPTION
Removes skills from every recorded agent directory, deduplicates shared paths, preserves safe-slug checks, and updates dry-run coverage; fixes #252.