### PR TITLE
refactor: extract shared security score helper

### DIFF
--- a/src/utils/security.js
+++ b/src/utils/security.js
@@ -159,6 +159,20 @@ const PATTERNS = [
   },
 ]
 
+export function computeScore(issues) {
+  const deductions = {}
+  for (const issue of issues) {
+    deductions[issue.severity] = (deductions[issue.severity] || 0) + 1
+  }
+
+  let score = 100
+  for (const [severity, count] of Object.entries(deductions)) {
+    score -= count * (WEIGHTS[severity] || 0)
+  }
+
+  return Math.max(0, score)
+}
+
 export function scanSkill(resolved) {
   const issues = []
   const seen = new Set()
@@ -209,17 +223,7 @@ export function scanSkill(resolved) {
     })
   }
 
-  const deductions = {}
-  for (const issue of issues) {
-    deductions[issue.severity] = (deductions[issue.severity] || 0) + 1
-  }
-
-  let score = 100
-  for (const [severity, count] of Object.entries(deductions)) {
-    score -= count * (WEIGHTS[severity] || 0)
-  }
-
-  return { score: Math.max(0, score), issues }
+  return { score: computeScore(issues), issues }
 }
 
 export function classifyScore(score, issues = []) {
@@ -281,17 +285,7 @@ export function scanMcpServer(resolved) {
     })
   }
 
-  const deductions = {}
-  for (const issue of issues) {
-    deductions[issue.severity] = (deductions[issue.severity] || 0) + 1
-  }
-
-  let score = 100
-  for (const [severity, count] of Object.entries(deductions)) {
-    score -= count * (WEIGHTS[severity] || 0)
-  }
-
-  return { score: Math.max(0, score), issues }
+  return { score: computeScore(issues), issues }
 }
 
 export function formatSecurityReport({ score, issues }, skillName) {

--- a/src/utils/security.test.js
+++ b/src/utils/security.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  computeScore,
   scanSkill,
   scanMcpServer,
   classifyScore,
@@ -36,6 +37,30 @@ describe('security', () => {
     it('returns danger for below 70', () => {
       assert.equal(classifyScore(69), 'danger')
       assert.equal(classifyScore(0), 'danger')
+    })
+  })
+
+  describe('computeScore', () => {
+    it('deducts weights for mixed issue severities', () => {
+      const issues = [
+        { severity: 'critical' },
+        { severity: 'high' },
+        { severity: 'medium' },
+        { severity: 'medium' },
+        { severity: 'low' },
+        { severity: 'low' },
+        { severity: 'low' },
+      ]
+
+      assert.equal(computeScore(issues), 61)
+    })
+
+    it('clamps scores at zero', () => {
+      const issues = Array.from({ length: 6 }, () => ({
+        severity: 'critical',
+      }))
+
+      assert.equal(computeScore(issues), 0)
     })
   })
 


### PR DESCRIPTION
Extracts a shared security scoring helper for skill and MCP scans and adds focused mixed-severity and clamping tests; closes #237.