### PR TITLE
refactor: merge agent manifest registry

### DIFF
--- a/MANIFEST-MATRIX.md
+++ b/MANIFEST-MATRIX.md
@@ -32,37 +32,37 @@ manifest and run the script — it updates every location automatically.
 
 | token | path | current_value |
 | --- | --- | --- |
-| unpacked_size | benchmark/RESULTS.md:42 | 418.7 kB |
+| unpacked_size | benchmark/RESULTS.md:42 | 413.7 kB |
 | agent_count | docs/commands/agents.md:47 | 87 |
 | agent_count | docs/commands/agents.md:71 | 87 |
 | agent_count | docs/commands/agents.md:79 | 87 |
 | agent_count | docs/commands/doctor.md:25 | 87 |
 | agent_count | docs/commands/doctor.md:60 | 87 |
 | agent_count | docs/commands/doctor.md:77 | 87 |
-| unpacked_size | docs/comparison.md:10 | 418.7 kB |
+| unpacked_size | docs/comparison.md:10 | 413.7 kB |
 | agent_count | docs/comparison.md:11 | 87 |
 | agent_count | docs/guides/getting-started.md:18 | 87 |
 | verified_count | docs/guides/getting-started.md:18 | 27 |
 | agent_count | docs/index.md:7 | 87 |
 | verified_count | docs/index.md:7 | 27 |
-| unpacked_size | docs/index.md:26 | 418.7 kB |
+| unpacked_size | docs/index.md:26 | 413.7 kB |
 | agent_count | docs/index.md:38 | 87 |
 | verified_count | docs/index.md:38 | 27 |
-| unpacked_size | docs/migration-from-skills.md:10 | 418.7 kB |
+| unpacked_size | docs/migration-from-skills.md:10 | 413.7 kB |
 | agent_count | docs/migration-from-skills.md:11 | 87 |
 | agent_count | docs/migration-from-skills.md:55 | 87 |
 | agent_count | docs/reference.md:161 | 87 |
 | agent_count | README.md:9 | 87 |
 | verified_count | README.md:9 | 27 |
 | agent_count | README.md:34 | 87 |
-| unpacked_size | README.md:54 | 418.7 kB |
+| unpacked_size | README.md:54 | 413.7 kB |
 | verified_count | README.md:54 | 27 |
-| unpacked_size | README.md:101 | 418.7 kB |
+| unpacked_size | README.md:101 | 413.7 kB |
 | agent_count | README.md:101 | 87 |
-| unpacked_size | README.md:154 | 418.7 kB |
+| unpacked_size | README.md:154 | 413.7 kB |
 | agent_count | README.md:157 | 87 |
 | agent_count | README.md:297 | 87 |
-| unpacked_size | README.md:314 | 418.7 kB |
+| unpacked_size | README.md:314 | 413.7 kB |
 | agent_count | README.md:377 | 87 |
 | agent_count | README.md:383 | 87 |
 | agent_count | SKILL.md:5 | 87 |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ---
 
 <p align="center">
-  <b>⚡ Zero dependencies</b> · <b>📦 418.7 kB</b> · <b>🤖 27 verified agents</b> · <b>🔌 Skills + MCP</b> · <b>🔒 Security scoring</b> · <b>📝 Skill testing</b> · <b>🔧 Init templates</b> · <b>🌐 Offline-first</b>
+  <b>⚡ Zero dependencies</b> · <b>📦 413.7 kB</b> · <b>🤖 27 verified agents</b> · <b>🔌 Skills + MCP</b> · <b>🔒 Security scoring</b> · <b>📝 Skill testing</b> · <b>🔧 Init templates</b> · <b>🌐 Offline-first</b>
 </p>
 
 <p align="center">
@@ -98,7 +98,7 @@ rolecraft convert ./my-skill
 rolecraft convert --help
 ```
 
-**Requirements:** Node.js >= 20 · 418.7 kB · zero dependencies · 87 agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
+**Requirements:** Node.js >= 20 · 413.7 kB · zero dependencies · 87 agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
 
 > **Why zero dependencies?** Every dependency is a supply-chain risk. rolecraft uses only Node.js built-ins (`fs`, `path`, `crypto`, `https`) — no `node_modules` surprises.
 
@@ -151,7 +151,7 @@ No other CLI combines both. npx skills has no MCP support. ags has a separate MC
 
 ## Features
 
-- **Zero dependencies** — 418.7 kB, only Node.js built-ins
+- **Zero dependencies** — 413.7 kB, only Node.js built-ins
 - **MCP + Skills in one command** — install skills and their MCP servers together
 - **Any source** — local folder, GitHub/GitLab/SSH URL, npm package
 - **87 agents** — opencode, claude-code, cursor, copilot, aider, oh-my-pi (omp), and more
@@ -311,7 +311,7 @@ All API functions return plain objects (no side-effects). Available exports:
 | AGENTS.md XML generation             | ✅               | ❌              | ❌                  |
 | Self-upgrade command                 | ✅               | ❌              | ❌                  |
 | **Publish to registry**              | ✅               | ❌              | ❌                  |
-| File size                            | 418.7 kB         | ~465 KB         | ~84 KB              |
+| File size                            | 413.7 kB         | ~465 KB         | ~84 KB              |
 
 [See full table →](docs/comparison.md)
 

--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -39,4 +39,4 @@
 | Local skill install  | ✅ **10.23 ms**   | ✅ 3894 ms (381x slower)  | ❌ not supported   |
 | GitHub skill install | ✅ **1.6 s**      | ✅ 10.9 s (6.9x slower)   | ❌ fails (bug)     |
 | Zero dependencies    | ✅ **0**          | ❌ 1 dep                  | ❌ 2 deps          |
-| Package size         | **418.7 kB**      | ~465 KB                   | ~84 KB             |
+| Package size         | **413.7 kB**      | ~465 KB                   | ~84 KB             |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -7,7 +7,7 @@
 | | rolecraft | skills (Vercel) | @agentskill.sh/cli |
 |---|---|---|---|
 | **Runtime** | Zero-dep Node ESM | 1 dep (Node) | 2 deps (TypeScript) |
-| **File size** | 418.7 kB | ~465 KB | ~84 KB |
+| **File size** | 413.7 kB | ~465 KB | ~84 KB |
 | **Agent targets** | **87** | 72 | 15+ |
 | **Skill marketplace** | rolecraft registry | skills.sh (90K+) | agentskill.sh (100K+) |
 | **Publish your own** | ✅ | ❌ | ❌ |

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
   - title: One-Command Onboarding
     details: "rolecraft setup <source> detects all AI agents and installs skills + MCP servers to every one of them."
   - title: Zero Dependencies
-    details: 418.7 kB, no bloat. Only Node.js built-ins.
+    details: 413.7 kB, no bloat. Only Node.js built-ins.
   - title: MCP + Skills in One Command
     details: Install skills and their MCP servers together. No other CLI tool combines both.
   - title: Rollback

--- a/docs/migration-from-skills.md
+++ b/docs/migration-from-skills.md
@@ -7,7 +7,7 @@ If you're using [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) a
 | Reason | rolecraft | Vercel skills |
 |---|---|---|
 | Dependencies | **0** (zero-dep) | 1 (`supports-color`) |
-| Package size | **418.7 kB** | ~465 KB |
+| Package size | **413.7 kB** | ~465 KB |
 | Agent targets | **87** | 72 |
 | Telemetry | **None** | Anonymous telemetry |
 | Offline installs | **Fully supported** | Requires network |

--- a/src/agents.js
+++ b/src/agents.js
@@ -22,78 +22,192 @@ const AGENTS_DATA = [
     name: 'opencode',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    mcpSupport: {
+      supported: true,
+      format: 'mcpServers',
+      configPath: '~/.agents/mcp.json',
+    },
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://opencode.ai/docs',
+    lastVerified: '2026-07-20',
   },
   {
     flag: 'claude',
     name: 'claude-code',
     getDir: () => home('.claude', 'skills'),
     label: '~/.claude/skills/',
+    skillInstallScope: 'global ~/.claude/skills',
+    mcpSupport: {
+      supported: true,
+      format: 'mcpServers',
+      configPath: '~/.claude.json',
+    },
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.anthropic.com/en/docs/claude-code',
+    lastVerified: '2026-07-27',
   },
   {
     flag: 'cursor',
     name: 'cursor',
     getDir: () => home('.cursor', 'skills'),
     label: '~/.cursor/skills/',
+    skillInstallScope: 'global ~/.cursor/skills',
+    mcpSupport: {
+      supported: true,
+      format: 'mcpServers',
+      configPath: '~/.cursor/mcp_config.json',
+    },
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://cursor.com/docs',
+    lastVerified: '2026-07-22',
+    mcpPath: '~/.cursor/mcp.json',
   },
   {
     flag: 'windsurf',
     name: 'windsurf',
     getDir: () => home('.codeium', 'windsurf', 'skills'),
     label: '~/.codeium/windsurf/skills/',
+    skillInstallScope: 'global ~/.codeium/windsurf/skills',
+    mcpSupport: {
+      supported: true,
+      format: 'mcpServers',
+      configPath: '~/.windsurf/mcp_config.json',
+    },
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.windsurf.com/windsurf/cascade/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Rebranded to Devin Desktop; global skills live at ~/.codeium/windsurf/skills, workspace at .windsurf/skills',
   },
   {
     flag: 'devin',
     name: 'devin',
     getDir: () => proj('.devin', 'skills'),
     label: './.devin/skills/',
+    skillInstallScope: 'project ./.devin/skills',
+    mcpSupport: {
+      supported: true,
+      format: 'mcpServers',
+      configPath: './.devin/mcp.json',
+    },
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.devin.ai/product-guides/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Devin scans repo-committed skill paths (.agents/skills recommended, .devin/skills among them); no user-global skills dir',
   },
   {
     flag: 'codex',
     name: 'codex',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://developers.openai.com/codex/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Reads ~/.agents/skills (user) and .agents/skills (repo, up to repo root); admin /etc/codex/skills',
+    aliasFor: 'opencode',
   },
   {
     flag: 'copilot',
     name: 'copilot',
     getDir: () => proj('.github', 'skills'),
     label: './.github/skills/',
+    skillInstallScope: 'project ./.github/skills',
+    mcpSupport: {
+      supported: true,
+      format: 'servers',
+      configPath: './.github/copilot/.mcp.json',
+    },
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl:
+      'https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Project skills at .github/skills (also reads .claude/skills and .agents/skills); personal skills at ~/.copilot/skills or ~/.agents/skills',
   },
   {
     flag: 'aider',
     name: 'aider',
     getDir: () => home('.aider', 'skills'),
     label: '~/.aider/skills/',
+    docUrl: 'https://aider.chat/docs/usage/conventions.html',
+    notes:
+      'No skills concept; conventions are markdown files loaded via .aider.conf.yml read: directives',
   },
   {
     flag: 'cline',
     name: 'cline',
     getDir: () => home('.cline', 'skills'),
     label: '~/.cline/skills/',
+    skillInstallScope: 'global ~/.cline/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.cline.bot/customization/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Also reads project .cline/skills, .clinerules/skills and .claude/skills',
   },
   {
     flag: 'gemini',
     name: 'gemini-cli',
     getDir: () => home('.gemini', 'skills'),
     label: '~/.gemini/skills/',
+    skillInstallScope: 'global ~/.gemini/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://geminicli.com/docs/cli/skills/',
+    lastVerified: '2026-08-17',
+    notes: 'Also reads ~/.agents/skills alias and project .gemini/skills',
   },
   {
     flag: 'cody',
     name: 'cody',
     getDir: () => home('.cody', 'skills'),
     label: '~/.cody/skills/',
+    docUrl: 'https://sourcegraph.com/docs/cody',
+    notes:
+      'No official skills support documented; Sourcegraph agentic product is now Amp (ampcode.com)',
   },
   {
     flag: 'continue',
     name: 'continue',
     getDir: () => home('.continue', 'skills'),
     label: '~/.continue/skills/',
+    skillInstallScope: 'global ~/.continue/skills',
+    mcpSupport: {
+      supported: true,
+      format: 'experimental.mcpServers',
+      configPath: '~/.continue/config.json',
+    },
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://github.com/continuedev/continue',
+    lastVerified: '2026-08-17',
+    notes:
+      'Confirmed from source code loaders; also reads workspace .claude/skills',
   },
   {
     flag: 'warp',
     name: 'warp',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.warp.dev/agents/capabilities/skills/',
+    lastVerified: '2026-08-17',
+    notes:
+      'Discovers a broad list of provider dirs; ~/.agents/skills is the recommended global path',
   },
   {
     flag: 'codeium',
@@ -112,18 +226,36 @@ const AGENTS_DATA = [
     name: 'goose',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl:
+      'https://goose-docs.ai/docs/guides/context-engineering/using-skills/',
+    lastVerified: '2026-08-17',
+    notes:
+      'Legacy .goose/skills and .claude/skills paths still discovered for backward compatibility',
   },
   {
     flag: 'tabnine',
     name: 'tabnine',
     getDir: () => home('.tabnine', 'agent', 'skills'),
     label: '~/.tabnine/agent/skills/',
+    skillInstallScope: 'global ~/.tabnine/agent/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl:
+      'https://docs.tabnine.com/main/getting-started/tabnine-cli/features/agent-skills',
+    lastVerified: '2026-08-17',
+    notes: '~/.agents/skills works as an alias scope',
   },
   {
     flag: 'supermaven',
     name: 'supermaven',
     getDir: () => home('.supermaven', 'skills'),
     label: '~/.supermaven/skills/',
+    docUrl: 'https://supermaven.com',
+    notes:
+      'Autocomplete tool (Anysphere/Cursor since Nov 2024); no agent skills feature documented',
   },
   {
     flag: 'pr-pilot',
@@ -136,18 +268,35 @@ const AGENTS_DATA = [
     name: 'loom',
     getDir: () => home('.loom', 'skills'),
     label: '~/.loom/skills/',
+    docUrl: 'https://github.com/awslabs/loom/',
+    notes:
+      'Loom for AWS (awslabs/loom) is an agent deployment platform with no local skills directory; not installable via rolecraft',
   },
   {
     flag: 'roo',
     name: 'roo',
     getDir: () => home('.roo', 'skills'),
     label: '~/.roo/skills/',
+    skillInstallScope: 'global ~/.roo/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.roocode.com/advanced-usage/available-tools/skill',
+    lastVerified: '2026-08-17',
+    notes:
+      'Also reads project .roo/skills, ~/.agents/skills and .agents/skills',
   },
   {
     flag: 'trae',
     name: 'trae',
     getDir: () => home('.trae', 'skills'),
     label: '~/.trae/skills/',
+    skillInstallScope: 'global ~/.trae/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.trae.ai/ide/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Also reads project .trae/skills; optional .agents/skills support behind a setting toggle',
   },
   {
     flag: 'hermes',
@@ -160,6 +309,12 @@ const AGENTS_DATA = [
     name: 'kiro',
     getDir: () => home('.kiro', 'skills'),
     label: '~/.kiro/skills/',
+    skillInstallScope: 'global ~/.kiro/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://kiro.dev/docs/skills/',
+    lastVerified: '2026-08-17',
+    notes: 'Also reads project .kiro/skills; no cross-agent aliases',
   },
   {
     flag: 'augment',
@@ -178,12 +333,26 @@ const AGENTS_DATA = [
     name: 'openhands',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.openhands.dev/overview/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Also reads project .agents/skills; legacy .openhands/skills and .openhands/microagents still supported',
   },
   {
     flag: 'junie',
     name: 'junie',
     getDir: () => home('.junie', 'skills'),
     label: '~/.junie/skills/',
+    skillInstallScope: 'global ~/.junie/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://junie.jetbrains.com/docs/agent-skills.html',
+    lastVerified: '2026-08-17',
+    notes:
+      'Also reads project .junie/skills; auto-imports .cursor/.claude/.codex skill folders',
   },
   {
     flag: 'factory',
@@ -214,6 +383,12 @@ const AGENTS_DATA = [
     name: 'qwen-code',
     getDir: () => home('.qwen', 'skills'),
     label: '~/.qwen/skills/',
+    skillInstallScope: 'global ~/.qwen/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/',
+    lastVerified: '2026-08-17',
+    notes: 'Also reads project .qwen/skills',
   },
   {
     flag: 'openclaw',
@@ -244,6 +419,18 @@ const AGENTS_DATA = [
     name: 'oh-my-pi',
     getDir: () => home('.omp', 'agent', 'skills'),
     label: '~/.omp/agent/skills/',
+    skillInstallScope: 'global ~/.omp/agent/skills',
+    mcpSupport: {
+      supported: true,
+      format: 'mcpServers',
+      configPath: '~/.omp/agent/mcp.json',
+    },
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://omp.sh/docs/skills',
+    lastVerified: '2026-08-24',
+    notes:
+      'pi fork by can1357; native skills at ~/.omp/agent/skills (user) and .omp/skills (project); also reads ~/.claude/skills, ~/.agents/skills and .github/skills; MCP via standard mcpServers format',
   },
   {
     flag: 'autohand-code',
@@ -310,6 +497,13 @@ const AGENTS_DATA = [
     name: 'forge',
     getDir: () => proj('.forge', 'skills'),
     label: './.forge/skills/',
+    skillInstallScope: 'project ./.forge/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://forgecode.dev/docs/skills/',
+    lastVerified: '2026-08-17',
+    notes:
+      'ForgeCode by tailcallhq; also reads ~/forge/skills and ~/.agents/skills; project dir has highest precedence',
   },
   {
     flag: 'inference-sh',
@@ -322,6 +516,13 @@ const AGENTS_DATA = [
     name: 'jazz',
     getDir: () => home('.jazz', 'skills'),
     label: '~/.jazz/skills/',
+    skillInstallScope: 'global ~/.jazz/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://www.mintlify.com/lvndry/jazz/guides/using-skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'jazz-ai (lvndry/jazz, not an AWS product); also reads project ./skills',
   },
   {
     flag: 'iflow',
@@ -346,6 +547,13 @@ const AGENTS_DATA = [
     name: 'lingma',
     getDir: () => home('.lingma', 'skills'),
     label: '~/.lingma/skills/',
+    skillInstallScope: 'global ~/.lingma/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://help.aliyun.com/en/lingma/qoder-cn/user-guide/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Also reads project .lingma/skills; renamed to Qoder CN on 2026-05-20',
   },
   {
     flag: 'mcp-jam',
@@ -472,6 +680,14 @@ const AGENTS_DATA = [
     name: 'chatgpt',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://developers.openai.com/codex/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'ChatGPT/Codex share the .agents skills locations; symlinked skill folders honored',
+    aliasFor: 'opencode',
   },
   {
     flag: 'codearts-agent',
@@ -490,48 +706,94 @@ const AGENTS_DATA = [
     name: 'amp',
     getDir: () => home('.config', 'agents', 'skills'),
     label: '~/.config/agents/skills/',
+    skillInstallScope: 'global ~/.config/agents/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://ampcode.com/manual#agent-skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'amp skill add --global installs to ~/.config/agents/skills; also reads ~/.agents/skills',
   },
   {
     flag: 'antigravity',
     name: 'antigravity',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    docUrl: 'https://github.com/daniel-e/agents',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
   },
   {
     flag: 'antigravity-cli',
     name: 'antigravity-cli',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    docUrl: 'https://github.com/daniel-e/agents',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
   },
   {
     flag: 'deepagents',
     name: 'deep-agents',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    docUrl: 'https://github.com/daniel-e/deep-agents',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
   },
   {
     flag: 'dexto',
     name: 'dexto',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    docUrl: 'https://dexto.ai',
+    lastVerified: '2026-07-26',
+    aliasFor: 'opencode',
   },
   {
     flag: 'loaf',
     name: 'loaf',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    docUrl: 'https://github.com/loaf-ai/loaf',
+    lastVerified: '2026-07-25',
+    aliasFor: 'opencode',
   },
   {
     flag: 'replit',
     name: 'replit',
     getDir: () => proj('.agents', 'skills'),
     label: './.agents/skills/',
+    skillInstallScope: 'project ./.agents/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://docs.replit.com/features/agent/skills',
+    lastVerified: '2026-08-17',
+    notes: 'Project-committed .agents/skills only; no user-global skills dir',
   },
   {
     flag: 'zed',
     name: 'zed',
     getDir: () => home('.agents', 'skills'),
     label: '~/.agents/skills/',
+    skillInstallScope: 'global ~/.agents/skills',
+    instructionFormat: 'skill-md',
+    supportLevel: 'verified',
+    docUrl: 'https://zed.dev/docs/ai/skills',
+    lastVerified: '2026-08-17',
+    notes:
+      'Flat layout only: skills must be direct children of ~/.agents/skills',
+    aliasFor: 'opencode',
   },
   {
     flag: 'promptscript',
@@ -541,33 +803,24 @@ const AGENTS_DATA = [
   },
 ]
 
-const MCP_SUPPORTED = [
-  'agents',
-  'claude',
-  'cursor',
-  'windsurf',
-  'devin',
-  'copilot',
-  'continue',
-  'omp',
-]
-
-const MCP_PATHS = {
-  claude: () => home('.claude.json'),
-  windsurf: () => home('.windsurf', 'mcp_config.json'),
-  copilot: () => proj('.github', 'copilot', '.mcp.json'),
-  continue: () => home('.continue', 'config.json'),
+function expandConfigPath(configPath) {
+  if (!configPath) return null
+  if (configPath.startsWith('~/'))
+    return home(...configPath.slice(2).split('/'))
+  if (configPath.startsWith('./'))
+    return proj(...configPath.slice(2).split('/'))
+  return configPath
 }
 
 for (const a of AGENTS_DATA) {
-  if (!MCP_SUPPORTED.includes(a.flag)) {
+  if (!a.mcpSupport?.supported) {
     a.mcp = null
     continue
   }
-  if (MCP_PATHS[a.flag]) {
-    a.mcp = { getPath: MCP_PATHS[a.flag] }
-  } else {
-    a.mcp = { getPath: mcpFromSkillDir(a.getDir) }
+  a.mcp = {
+    getPath: () =>
+      expandConfigPath(a.mcpPath || a.mcpSupport.configPath) ||
+      mcpFromSkillDir(a.getDir)(),
   }
 }
 

--- a/src/agents.js
+++ b/src/agents.js
@@ -58,13 +58,12 @@ const AGENTS_DATA = [
     mcpSupport: {
       supported: true,
       format: 'mcpServers',
-      configPath: '~/.cursor/mcp_config.json',
+      configPath: '~/.cursor/mcp.json',
     },
     instructionFormat: 'skill-md',
     supportLevel: 'verified',
     docUrl: 'https://cursor.com/docs',
     lastVerified: '2026-07-22',
-    mcpPath: '~/.cursor/mcp.json',
   },
   {
     flag: 'windsurf',

--- a/src/agents/manifest.js
+++ b/src/agents/manifest.js
@@ -29,550 +29,45 @@ export const MCP_CONFIG_FORMATS = {
   COPILOT: 'servers', // GitHub Copilot format
 }
 
-/**
- * Agent capability manifest data
- * Each agent has structured metadata including:
- * - skillInstallScope: where skills are installed
- * - mcpSupport: MCP configuration support and format
- * - instructionFormat: skill instruction format support
- * - supportLevel: verified/community/legacy/experimental
- * - docUrl: official documentation URL
- * - lastVerified: last verification date (ISO date string)
- */
-const MANIFEST_DATA = {
-  opencode: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: true,
-      format: MCP_CONFIG_FORMATS.STANDARD,
-      configPath: '~/.agents/mcp.json',
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://opencode.ai/docs',
-    lastVerified: '2026-07-20',
-  },
-  'claude-code': {
-    skillInstallScope: 'global ~/.claude/skills',
-    mcpSupport: {
-      supported: true,
-      format: MCP_CONFIG_FORMATS.STANDARD,
-      configPath: '~/.claude.json',
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.anthropic.com/en/docs/claude-code',
-    lastVerified: '2026-07-27',
-  },
-  cursor: {
-    skillInstallScope: 'global ~/.cursor/skills',
-    mcpSupport: {
-      supported: true,
-      format: MCP_CONFIG_FORMATS.STANDARD,
-      configPath: '~/.cursor/mcp_config.json',
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://cursor.com/docs',
-    lastVerified: '2026-07-22',
-  },
-  windsurf: {
-    skillInstallScope: 'global ~/.codeium/windsurf/skills',
-    mcpSupport: {
-      supported: true,
-      format: MCP_CONFIG_FORMATS.STANDARD,
-      configPath: '~/.windsurf/mcp_config.json',
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.windsurf.com/windsurf/cascade/skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'Rebranded to Devin Desktop; global skills live at ~/.codeium/windsurf/skills, workspace at .windsurf/skills',
-  },
-  devin: {
-    skillInstallScope: 'project ./.devin/skills',
-    mcpSupport: {
-      supported: true,
-      format: MCP_CONFIG_FORMATS.STANDARD,
-      configPath: './.devin/mcp.json',
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.devin.ai/product-guides/skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'Devin scans repo-committed skill paths (.agents/skills recommended, .devin/skills among them); no user-global skills dir',
-  },
-  codex: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
+function toManifestAgent(agent) {
+  return {
+    flag: agent.flag,
+    name: agent.name,
+    label: agent.label,
+    skillInstallScope: agent.skillInstallScope || 'unknown',
+    mcpSupport: agent.mcpSupport || {
       supported: false,
       format: null,
     },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://developers.openai.com/codex/skills',
-    lastVerified: '2026-08-17',
-    aliasFor: 'opencode',
-    notes:
-      'Reads ~/.agents/skills (user) and .agents/skills (repo, up to repo root); admin /etc/codex/skills',
-  },
-  copilot: {
-    skillInstallScope: 'project ./.github/skills',
-    mcpSupport: {
-      supported: true,
-      format: MCP_CONFIG_FORMATS.COPILOT,
-      configPath: './.github/copilot/.mcp.json',
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl:
-      'https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'Project skills at .github/skills (also reads .claude/skills and .agents/skills); personal skills at ~/.copilot/skills or ~/.agents/skills',
-  },
-  continue: {
-    skillInstallScope: 'global ~/.continue/skills',
-    mcpSupport: {
-      supported: true,
-      format: MCP_CONFIG_FORMATS.CONTINUE,
-      configPath: '~/.continue/config.json',
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://github.com/continuedev/continue',
-    lastVerified: '2026-08-17',
-    notes:
-      'Confirmed from source code loaders; also reads workspace .claude/skills',
-  },
-  'oh-my-pi': {
-    skillInstallScope: 'global ~/.omp/agent/skills',
-    mcpSupport: {
-      supported: true,
-      format: MCP_CONFIG_FORMATS.STANDARD,
-      configPath: '~/.omp/agent/mcp.json',
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://omp.sh/docs/skills',
-    lastVerified: '2026-08-24',
-    notes:
-      'pi fork by can1357; native skills at ~/.omp/agent/skills (user) and .omp/skills (project); also reads ~/.claude/skills, ~/.agents/skills and .github/skills; MCP via standard mcpServers format',
-  },
-  // Agents sharing .agents/skills directory
-  'gemini-cli': {
-    skillInstallScope: 'global ~/.gemini/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://geminicli.com/docs/cli/skills/',
-    lastVerified: '2026-08-17',
-    notes: 'Also reads ~/.agents/skills alias and project .gemini/skills',
-  },
-  'qwen-code': {
-    skillInstallScope: 'global ~/.qwen/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://qwenlm.github.io/qwen-code-docs/en/users/features/skills/',
-    lastVerified: '2026-08-17',
-    notes: 'Also reads project .qwen/skills',
-  },
-  goose: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl:
-      'https://goose-docs.ai/docs/guides/context-engineering/using-skills/',
-    lastVerified: '2026-08-17',
-    notes:
-      'Legacy .goose/skills and .claude/skills paths still discovered for backward compatibility',
-  },
-  roo: {
-    skillInstallScope: 'global ~/.roo/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.roocode.com/advanced-usage/available-tools/skill',
-    lastVerified: '2026-08-17',
-    notes:
-      'Also reads project .roo/skills, ~/.agents/skills and .agents/skills',
-  },
-  trae: {
-    skillInstallScope: 'global ~/.trae/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.trae.ai/ide/skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'Also reads project .trae/skills; optional .agents/skills support behind a setting toggle',
-  },
-  junie: {
-    skillInstallScope: 'global ~/.junie/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://junie.jetbrains.com/docs/agent-skills.html',
-    lastVerified: '2026-08-17',
-    notes:
-      'Also reads project .junie/skills; auto-imports .cursor/.claude/.codex skill folders',
-  },
-  warp: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.warp.dev/agents/capabilities/skills/',
-    lastVerified: '2026-08-17',
-    notes:
-      'Discovers a broad list of provider dirs; ~/.agents/skills is the recommended global path',
-  },
-  openhands: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.openhands.dev/overview/skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'Also reads project .agents/skills; legacy .openhands/skills and .openhands/microagents still supported',
-  },
-  tabnine: {
-    skillInstallScope: 'global ~/.tabnine/agent/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl:
-      'https://docs.tabnine.com/main/getting-started/tabnine-cli/features/agent-skills',
-    lastVerified: '2026-08-17',
-    notes: '~/.agents/skills works as an alias scope',
-  },
-  amp: {
-    skillInstallScope: 'global ~/.config/agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://ampcode.com/manual#agent-skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'amp skill add --global installs to ~/.config/agents/skills; also reads ~/.agents/skills',
-  },
-  zed: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://zed.dev/docs/ai/skills',
-    lastVerified: '2026-08-17',
-    aliasFor: 'opencode',
-    notes:
-      'Flat layout only: skills must be direct children of ~/.agents/skills',
-  },
-  replit: {
-    skillInstallScope: 'project ./.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.replit.com/features/agent/skills',
-    lastVerified: '2026-08-17',
-    notes: 'Project-committed .agents/skills only; no user-global skills dir',
-  },
-  cline: {
-    skillInstallScope: 'global ~/.cline/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://docs.cline.bot/customization/skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'Also reads project .cline/skills, .clinerules/skills and .claude/skills',
-  },
-  kiro: {
-    skillInstallScope: 'global ~/.kiro/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://kiro.dev/docs/skills/',
-    lastVerified: '2026-08-17',
-    notes: 'Also reads project .kiro/skills; no cross-agent aliases',
-  },
-  lingma: {
-    skillInstallScope: 'global ~/.lingma/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://help.aliyun.com/en/lingma/qoder-cn/user-guide/skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'Also reads project .lingma/skills; renamed to Qoder CN on 2026-05-20',
-  },
-  forge: {
-    skillInstallScope: 'project ./.forge/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://forgecode.dev/docs/skills/',
-    lastVerified: '2026-08-17',
-    notes:
-      'ForgeCode by tailcallhq; also reads ~/forge/skills and ~/.agents/skills; project dir has highest precedence',
-  },
-  jazz: {
-    skillInstallScope: 'global ~/.jazz/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://www.mintlify.com/lvndry/jazz/guides/using-skills',
-    lastVerified: '2026-08-17',
-    notes:
-      'jazz-ai (lvndry/jazz, not an AWS product); also reads project ./skills',
-  },
-  chatgpt: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.VERIFIED,
-    docUrl: 'https://developers.openai.com/codex/skills',
-    lastVerified: '2026-08-17',
-    aliasFor: 'opencode',
-    notes:
-      'ChatGPT/Codex share the .agents skills locations; symlinked skill folders honored',
-  },
-  antigravity: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://github.com/daniel-e/agents',
-    lastVerified: '2026-07-25',
-    aliasFor: 'opencode',
-  },
-  'antigravity-cli': {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://github.com/daniel-e/agents',
-    lastVerified: '2026-07-25',
-    aliasFor: 'opencode',
-  },
-  'deep-agents': {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://github.com/daniel-e/deep-agents',
-    lastVerified: '2026-07-25',
-    aliasFor: 'opencode',
-  },
-  dexto: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://dexto.ai',
-    lastVerified: '2026-07-26',
-    aliasFor: 'opencode',
-  },
-  loaf: {
-    skillInstallScope: 'global ~/.agents/skills',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.SKILL_MD,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://github.com/loaf-ai/loaf',
-    lastVerified: '2026-07-25',
-    aliasFor: 'opencode',
-  },
-  loom: {
-    skillInstallScope: 'unknown',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.CUSTOM,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://github.com/awslabs/loom/',
-    lastVerified: null,
-    notes:
-      'Loom for AWS (awslabs/loom) is an agent deployment platform with no local skills directory; not installable via rolecraft',
-  },
-  aider: {
-    skillInstallScope: 'unknown',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.CUSTOM,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://aider.chat/docs/usage/conventions.html',
-    lastVerified: null,
-    notes:
-      'No skills concept; conventions are markdown files loaded via .aider.conf.yml read: directives',
-  },
-  cody: {
-    skillInstallScope: 'unknown',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.CUSTOM,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://sourcegraph.com/docs/cody',
-    lastVerified: null,
-    notes:
-      'No official skills support documented; Sourcegraph agentic product is now Amp (ampcode.com)',
-  },
-  supermaven: {
-    skillInstallScope: 'unknown',
-    mcpSupport: {
-      supported: false,
-      format: null,
-    },
-    instructionFormat: INSTRUCTION_FORMATS.CUSTOM,
-    supportLevel: SUPPORT_LEVELS.EXPERIMENTAL,
-    docUrl: 'https://supermaven.com',
-    lastVerified: null,
-    notes:
-      'Autocomplete tool (Anysphere/Cursor since Nov 2024); no agent skills feature documented',
-  },
+    instructionFormat: agent.instructionFormat || INSTRUCTION_FORMATS.CUSTOM,
+    supportLevel: agent.supportLevel || SUPPORT_LEVELS.EXPERIMENTAL,
+    docUrl: agent.docUrl || null,
+    lastVerified: agent.lastVerified || null,
+    notes: agent.notes || null,
+    aliasFor: agent.aliasFor || null,
+  }
+}
+
+function buildAgentManifest(agentList = agents) {
+  return agentList.map(toManifestAgent)
 }
 
 /**
- * Get full agent manifest with capability data
- * Merges manifest data with AGENTS_DATA from agents.js
+ * Get full agent manifest with capability data.
  */
 export function getAgentManifest() {
-  const manifest = []
-
-  for (const agent of agents) {
-    const name = agent.name
-    const manifestEntry = MANIFEST_DATA[name] || {}
-
-    manifest.push({
-      flag: agent.flag,
-      name: agent.name,
-      label: agent.label,
-      skillInstallScope: manifestEntry.skillInstallScope || 'unknown',
-      mcpSupport: manifestEntry.mcpSupport || {
-        supported: false,
-        format: null,
-      },
-      instructionFormat:
-        manifestEntry.instructionFormat || INSTRUCTION_FORMATS.CUSTOM,
-      supportLevel: manifestEntry.supportLevel || SUPPORT_LEVELS.EXPERIMENTAL,
-      docUrl: manifestEntry.docUrl || null,
-      lastVerified: manifestEntry.lastVerified || null,
-      notes: manifestEntry.notes || null,
-      aliasFor: manifestEntry.aliasFor || null,
-    })
-  }
-
-  return manifest
+  return buildAgentManifest()
 }
 
 /**
- * Get agent by flag with full manifest data
+ * Get agent by flag with full manifest data.
  */
 export function getAgentManifestByFlag(flag) {
-  for (const agent of agents) {
-    if (agent.flag === flag) {
-      const manifestEntry = MANIFEST_DATA[agent.name] || {}
-      return {
-        flag: agent.flag,
-        name: agent.name,
-        label: agent.label,
-        skillInstallScope: manifestEntry.skillInstallScope || 'unknown',
-        mcpSupport: manifestEntry.mcpSupport || {
-          supported: false,
-          format: null,
-        },
-        instructionFormat:
-          manifestEntry.instructionFormat || INSTRUCTION_FORMATS.CUSTOM,
-        supportLevel: manifestEntry.supportLevel || SUPPORT_LEVELS.EXPERIMENTAL,
-        docUrl: manifestEntry.docUrl || null,
-        lastVerified: manifestEntry.lastVerified || null,
-        notes: manifestEntry.notes || null,
-        aliasFor: manifestEntry.aliasFor || null,
-      }
-    }
-  }
-  return null
+  return buildAgentManifest().find((agent) => agent.flag === flag) || null
 }
 
 /**
- * Get agents grouped by support level
+ * Get agents grouped by support level.
  */
 export function getAgentsBySupportLevel() {
   const groups = {
@@ -584,40 +79,65 @@ export function getAgentsBySupportLevel() {
 
   for (const agent of getAgentManifest()) {
     const level = agent.supportLevel
-    if (groups[level]) {
-      groups[level].push(agent)
-    }
+    if (groups[level]) groups[level].push(agent)
   }
 
   return groups
 }
 
 /**
- * Get agents with MCP support
+ * Get agents with MCP support.
  */
 export function getAgentsWithMcp() {
   return getAgentManifest().filter((agent) => agent.mcpSupport.supported)
 }
 
 /**
- * Validate manifest has all required fields for a consistent agent count
+ * Validate manifest has one complete registry entry per agent.
  */
-export function validateManifest() {
+export function validateManifest(agentList = agents) {
   const issues = []
-  const manifest = getAgentManifest()
+  const seenFlags = new Set()
+  const seenNames = new Set()
+  const manifest = buildAgentManifest(agentList)
 
-  for (const agent of manifest) {
+  for (const [index, agent] of manifest.entries()) {
+    const rawAgent = agentList[index]
+
+    if (!agent.flag) issues.push({ agent: agent.name, issue: 'missing flag' })
+    if (!agent.name) issues.push({ agent: agent.flag, issue: 'missing name' })
+    if (seenFlags.has(agent.flag)) {
+      issues.push({ agent: agent.name, issue: `duplicate flag ${agent.flag}` })
+    }
+    if (seenNames.has(agent.name)) {
+      issues.push({ agent: agent.name, issue: `duplicate name ${agent.name}` })
+    }
+    seenFlags.add(agent.flag)
+    seenNames.add(agent.name)
+
     if (!agent.skillInstallScope) {
       issues.push({ agent: agent.name, issue: 'missing skillInstallScope' })
     }
     if (!agent.supportLevel) {
       issues.push({ agent: agent.name, issue: 'missing supportLevel' })
     }
-    if (!agent.lastVerified && agent.supportLevel === SUPPORT_LEVELS.VERIFIED) {
-      issues.push({
-        agent: agent.name,
-        issue: 'missing lastVerified date for verified agent',
-      })
+    if (agent.supportLevel === SUPPORT_LEVELS.VERIFIED) {
+      for (const field of [
+        'skillInstallScope',
+        'instructionFormat',
+        'docUrl',
+        'lastVerified',
+      ]) {
+        if (!rawAgent[field]) {
+          issues.push({
+            agent: agent.name,
+            issue: `missing ${field} for verified agent`,
+          })
+        }
+      }
+    }
+    if (rawAgent.mcpSupport?.supported && !rawAgent.mcpSupport.format) {
+      issues.push({ agent: agent.name, issue: 'missing MCP format' })
     }
   }
 

--- a/src/agents/manifest.test.js
+++ b/src/agents/manifest.test.js
@@ -114,6 +114,62 @@ describe('agent manifest', () => {
     assert.equal(result.issues.length, 0)
   })
 
+  it('validateManifest catches duplicate registry keys', () => {
+    const [agent] = getAgentManifest()
+    const result = validateManifest([agent, { ...agent }])
+
+    assert.equal(result.valid, false)
+    assert.ok(result.issues.some((i) => i.issue.includes('duplicate flag')))
+    assert.ok(result.issues.some((i) => i.issue.includes('duplicate name')))
+  })
+
+  it('validateManifest requires verified-agent metadata', () => {
+    const result = validateManifest([
+      {
+        flag: 'example',
+        name: 'example',
+        label: '~/.example/skills/',
+        supportLevel: SUPPORT_LEVELS.VERIFIED,
+      },
+    ])
+
+    assert.equal(result.valid, false)
+    assert.ok(
+      result.issues.some((i) =>
+        i.issue.includes('missing lastVerified for verified agent'),
+      ),
+    )
+    assert.ok(
+      result.issues.some((i) =>
+        i.issue.includes('missing docUrl for verified agent'),
+      ),
+    )
+    assert.ok(
+      result.issues.some((i) =>
+        i.issue.includes('missing skillInstallScope for verified agent'),
+      ),
+    )
+    assert.ok(
+      result.issues.some((i) =>
+        i.issue.includes('missing instructionFormat for verified agent'),
+      ),
+    )
+  })
+
+  it('validateManifest requires MCP-enabled agents to declare a format', () => {
+    const result = validateManifest([
+      {
+        flag: 'example',
+        name: 'example',
+        label: '~/.example/skills/',
+        mcpSupport: { supported: true },
+      },
+    ])
+
+    assert.equal(result.valid, false)
+    assert.ok(result.issues.some((i) => i.issue.includes('missing MCP format')))
+  })
+
   it('docs/agents.md matches generated content from manifest', () => {
     const docsPath = join(__dirname, '..', '..', 'docs', 'agents.md')
     const current = readFileSync(docsPath, 'utf-8')


### PR DESCRIPTION
## Description

Moves agent capability metadata into the agent registry so manifest APIs and MCP support checks read from one source while keeping existing `rolecraft agents --json` output unchanged.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor

## Checklist

- [ ] Tests pass locally (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [x] No new dependencies added
- [x] Docs updated if needed

## Related issue

Fixes #254