### PR TITLE
feat: add skipped and errored counters to check command summary

### DIFF
--- a/MANIFEST-MATRIX.md
+++ b/MANIFEST-MATRIX.md
@@ -32,37 +32,37 @@ manifest and run the script — it updates every location automatically.
 
 | token | path | current_value |
 | --- | --- | --- |
-| unpacked_size | benchmark/RESULTS.md:42 | 413.7 kB |
+| unpacked_size | benchmark/RESULTS.md:42 | 414.0 kB |
 | agent_count | docs/commands/agents.md:47 | 87 |
 | agent_count | docs/commands/agents.md:71 | 87 |
 | agent_count | docs/commands/agents.md:79 | 87 |
 | agent_count | docs/commands/doctor.md:25 | 87 |
 | agent_count | docs/commands/doctor.md:60 | 87 |
 | agent_count | docs/commands/doctor.md:77 | 87 |
-| unpacked_size | docs/comparison.md:10 | 413.7 kB |
+| unpacked_size | docs/comparison.md:10 | 414.0 kB |
 | agent_count | docs/comparison.md:11 | 87 |
 | agent_count | docs/guides/getting-started.md:18 | 87 |
 | verified_count | docs/guides/getting-started.md:18 | 27 |
 | agent_count | docs/index.md:7 | 87 |
 | verified_count | docs/index.md:7 | 27 |
-| unpacked_size | docs/index.md:26 | 413.7 kB |
+| unpacked_size | docs/index.md:26 | 414.0 kB |
 | agent_count | docs/index.md:38 | 87 |
 | verified_count | docs/index.md:38 | 27 |
-| unpacked_size | docs/migration-from-skills.md:10 | 413.7 kB |
+| unpacked_size | docs/migration-from-skills.md:10 | 414.0 kB |
 | agent_count | docs/migration-from-skills.md:11 | 87 |
 | agent_count | docs/migration-from-skills.md:55 | 87 |
 | agent_count | docs/reference.md:161 | 87 |
 | agent_count | README.md:9 | 87 |
 | verified_count | README.md:9 | 27 |
 | agent_count | README.md:34 | 87 |
-| unpacked_size | README.md:54 | 413.7 kB |
+| unpacked_size | README.md:54 | 414.0 kB |
 | verified_count | README.md:54 | 27 |
-| unpacked_size | README.md:101 | 413.7 kB |
+| unpacked_size | README.md:101 | 414.0 kB |
 | agent_count | README.md:101 | 87 |
-| unpacked_size | README.md:154 | 413.7 kB |
+| unpacked_size | README.md:154 | 414.0 kB |
 | agent_count | README.md:157 | 87 |
 | agent_count | README.md:297 | 87 |
-| unpacked_size | README.md:314 | 413.7 kB |
+| unpacked_size | README.md:314 | 414.0 kB |
 | agent_count | README.md:377 | 87 |
 | agent_count | README.md:383 | 87 |
 | agent_count | SKILL.md:5 | 87 |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ---
 
 <p align="center">
-  <b>⚡ Zero dependencies</b> · <b>📦 413.7 kB</b> · <b>🤖 27 verified agents</b> · <b>🔌 Skills + MCP</b> · <b>🔒 Security scoring</b> · <b>📝 Skill testing</b> · <b>🔧 Init templates</b> · <b>🌐 Offline-first</b>
+  <b>⚡ Zero dependencies</b> · <b>📦 414.0 kB</b> · <b>🤖 27 verified agents</b> · <b>🔌 Skills + MCP</b> · <b>🔒 Security scoring</b> · <b>📝 Skill testing</b> · <b>🔧 Init templates</b> · <b>🌐 Offline-first</b>
 </p>
 
 <p align="center">
@@ -98,7 +98,7 @@ rolecraft convert ./my-skill
 rolecraft convert --help
 ```
 
-**Requirements:** Node.js >= 20 · 413.7 kB · zero dependencies · 87 agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
+**Requirements:** Node.js >= 20 · 414.0 kB · zero dependencies · 87 agents · [Getting Started →](docs/guides/getting-started.md) · [Full install guide →](docs/install.md)
 
 > **Why zero dependencies?** Every dependency is a supply-chain risk. rolecraft uses only Node.js built-ins (`fs`, `path`, `crypto`, `https`) — no `node_modules` surprises.
 
@@ -151,7 +151,7 @@ No other CLI combines both. npx skills has no MCP support. ags has a separate MC
 
 ## Features
 
-- **Zero dependencies** — 413.7 kB, only Node.js built-ins
+- **Zero dependencies** — 414.0 kB, only Node.js built-ins
 - **MCP + Skills in one command** — install skills and their MCP servers together
 - **Any source** — local folder, GitHub/GitLab/SSH URL, npm package
 - **87 agents** — opencode, claude-code, cursor, copilot, aider, oh-my-pi (omp), and more
@@ -311,7 +311,7 @@ All API functions return plain objects (no side-effects). Available exports:
 | AGENTS.md XML generation             | ✅               | ❌              | ❌                  |
 | Self-upgrade command                 | ✅               | ❌              | ❌                  |
 | **Publish to registry**              | ✅               | ❌              | ❌                  |
-| File size                            | 413.7 kB         | ~465 KB         | ~84 KB              |
+| File size                            | 414.0 kB         | ~465 KB         | ~84 KB              |
 
 [See full table →](docs/comparison.md)
 

--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -39,4 +39,4 @@
 | Local skill install  | ✅ **10.23 ms**   | ✅ 3894 ms (381x slower)  | ❌ not supported   |
 | GitHub skill install | ✅ **1.6 s**      | ✅ 10.9 s (6.9x slower)   | ❌ fails (bug)     |
 | Zero dependencies    | ✅ **0**          | ❌ 1 dep                  | ❌ 2 deps          |
-| Package size         | **413.7 kB**      | ~465 KB                   | ~84 KB             |
+| Package size         | **414.0 kB**      | ~465 KB                   | ~84 KB             |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -7,7 +7,7 @@
 | | rolecraft | skills (Vercel) | @agentskill.sh/cli |
 |---|---|---|---|
 | **Runtime** | Zero-dep Node ESM | 1 dep (Node) | 2 deps (TypeScript) |
-| **File size** | 413.7 kB | ~465 KB | ~84 KB |
+| **File size** | 414.0 kB | ~465 KB | ~84 KB |
 | **Agent targets** | **87** | 72 | 15+ |
 | **Skill marketplace** | rolecraft registry | skills.sh (90K+) | agentskill.sh (100K+) |
 | **Publish your own** | ✅ | ❌ | ❌ |

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
   - title: One-Command Onboarding
     details: "rolecraft setup <source> detects all AI agents and installs skills + MCP servers to every one of them."
   - title: Zero Dependencies
-    details: 413.7 kB, no bloat. Only Node.js built-ins.
+    details: 414.0 kB, no bloat. Only Node.js built-ins.
   - title: MCP + Skills in One Command
     details: Install skills and their MCP servers together. No other CLI tool combines both.
   - title: Rollback

--- a/docs/migration-from-skills.md
+++ b/docs/migration-from-skills.md
@@ -7,7 +7,7 @@ If you're using [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) a
 | Reason | rolecraft | Vercel skills |
 |---|---|---|
 | Dependencies | **0** (zero-dep) | 1 (`supports-color`) |
-| Package size | **413.7 kB** | ~465 KB |
+| Package size | **414.0 kB** | ~465 KB |
 | Agent targets | **87** | 72 |
 | Telemetry | **None** | Anonymous telemetry |
 | Offline installs | **Fully supported** | Requires network |

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -10,6 +10,10 @@ export async function checkCommand() {
     return
   }
 
+  // Count statuses for summary
+  const skippedCount = skills.filter((s) => s.status === 'skipped').length
+  const erroredCount = skills.filter((s) => s.status === 'error').length
+
   console.log(`\nChecking ${skills.length} skill(s) for updates:\n`)
 
   const rows = []
@@ -35,5 +39,8 @@ export async function checkCommand() {
     updatesAvailable > 0
       ? `\n${updatesAvailable} update(s) available — run \`rolecraft update <slug>\`\n`
       : '\nAll skills are up to date.\n',
+  )
+  console.log(
+    `Checked ${skills.length} skill(s): ${updatesAvailable} update(s) available, ${skippedCount} skipped (no source), ${erroredCount} could not be checked.`,
   )
 }

--- a/src/commands/check.test.js
+++ b/src/commands/check.test.js
@@ -110,13 +110,26 @@ describe('check command', () => {
     assert.ok(logs.some((l) => l.includes('up to date')))
   })
 
-  it('reports update available when hash differs', async () => {
+  it('shows skipped/errors counters correctly', async () => {
+    const { logs, restore } = capture()
+    try {
+      await checkModule.checkCommand()
+    } finally {
+      restore()
+    }
+    assert.ok(logs.some((l) => l.includes('skipped (no source)')))
+    assert.ok(logs.some((l) => l.includes('could not be checked')))
+  })
+
+  it('reports skill with update available from local hash diff', async () => {
     const skillDir = join(tempDir, 'update-skill')
     mkdirSync(skillDir, { recursive: true })
-    writeFileSync(
-      join(skillDir, 'SKILL.md'),
-      '# slug: test/update\nname: update-skill\nNewer content',
-    )
+    const skillContent = '# slug: test/update\nname: update-skill\nSome content'
+    writeFileSync(join(skillDir, 'SKILL.md'), skillContent)
+
+    const { computeContentHash } = await import('../utils/lockfile.js')
+    const fileContents = { 'SKILL.md': skillContent }
+    computeContentHash(fileContents)
 
     await writeFile(
       join(tempDir, '.agents', '.skill-lock.json'),
@@ -127,7 +140,7 @@ describe('check command', () => {
             slug: 'test/update',
             source: skillDir,
             sourceType: 'local',
-            contentSha: 'oldhashthatdoesnotmatch',
+            contentSha: 'old-hash-that-does-not-match',
           },
         },
         dismissed: {},


### PR DESCRIPTION
Fixes #109 by implementing the missing summary counters in the check command.

The api/check.js already returned status: 'skipped' and status: 'error' per skill, but the command layer wasn't counting these for the final summary line.

Now the check command outputs:

