### PR TITLE
fix: track all published agent counts

### DIFF
--- a/MANIFEST-MATRIX.md
+++ b/MANIFEST-MATRIX.md
@@ -36,6 +36,7 @@ manifest and run the script — it updates every location automatically.
 | agent_count | apps.json:19 | 87 |
 | agent_count | apps.json:40 | 87 |
 | unpacked_size | benchmark/RESULTS.md:42 | 414.8 kB |
+| agent_count | docs/agents.md:99 | 87 |
 | agent_count | docs/commands/agents.md:47 | 87 |
 | agent_count | docs/commands/agents.md:71 | 87 |
 | agent_count | docs/commands/agents.md:79 | 87 |

--- a/MANIFEST-MATRIX.md
+++ b/MANIFEST-MATRIX.md
@@ -32,6 +32,9 @@ manifest and run the script — it updates every location automatically.
 
 | token | path | current_value |
 | --- | --- | --- |
+| agent_count | apps.json:18 | 87 |
+| agent_count | apps.json:19 | 87 |
+| agent_count | apps.json:40 | 87 |
 | unpacked_size | benchmark/RESULTS.md:42 | 414.8 kB |
 | agent_count | docs/commands/agents.md:47 | 87 |
 | agent_count | docs/commands/agents.md:71 | 87 |
@@ -52,6 +55,7 @@ manifest and run the script — it updates every location automatically.
 | agent_count | docs/migration-from-skills.md:11 | 87 |
 | agent_count | docs/migration-from-skills.md:55 | 87 |
 | agent_count | docs/reference.md:161 | 87 |
+| agent_count | package.json:4 | 87 |
 | agent_count | README.md:9 | 87 |
 | verified_count | README.md:9 | 27 |
 | agent_count | README.md:34 | 87 |

--- a/src/agents/manifest.test.js
+++ b/src/agents/manifest.test.js
@@ -267,6 +267,7 @@ describe('agent manifest', () => {
       'docs/commands/agents.md',
       'docs/commands/doctor.md',
       'docs/comparison.md',
+      'docs/agents.md',
     ]
     const value = getTokenValues().agent_count
     const pattern = new RegExp(`(?<!\\w)${value}(?!\\w)`)

--- a/src/agents/manifest.test.js
+++ b/src/agents/manifest.test.js
@@ -247,6 +247,42 @@ describe('agent manifest', () => {
     }
   })
 
+  it('tracks every published agent-count claim in the manifest matrix', () => {
+    const matrixPath = join(__dirname, '..', '..', 'MANIFEST-MATRIX.md')
+    const rows = parseMatrix(readFileSync(matrixPath, 'utf-8'))
+    const tracked = new Set(
+      rows
+        .filter((row) => row.token === 'agent_count')
+        .map((row) => `${row.file}:${row.line}`),
+    )
+    const files = [
+      'README.md',
+      'SKILL.md',
+      'apps.json',
+      'package.json',
+      'docs/index.md',
+      'docs/reference.md',
+      'docs/guides/getting-started.md',
+      'docs/migration-from-skills.md',
+      'docs/commands/agents.md',
+      'docs/commands/doctor.md',
+      'docs/comparison.md',
+    ]
+    const value = getTokenValues().agent_count
+    const pattern = new RegExp(`(?<!\\w)${value}(?!\\w)`)
+
+    for (const file of files) {
+      const content = readFileSync(join(__dirname, '..', '..', file), 'utf-8')
+      for (const [index, line] of content.split('\n').entries()) {
+        if (!pattern.test(line)) continue
+        assert.ok(
+          tracked.has(`${file}:${index + 1}`),
+          `untracked agent count in ${file}:${index + 1}`,
+        )
+      }
+    }
+  })
+
   it('applying the matrix while in sync is a no-op', () => {
     const matrixPath = join(__dirname, '..', '..', 'MANIFEST-MATRIX.md')
     const md = readFileSync(matrixPath, 'utf-8')


### PR DESCRIPTION
Tracks package and app metadata agent-count claims in the manifest matrix and adds regression coverage for untracked public count literals, fixing #256.