### PR TITLE
refactor: share bundle loading and installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ git clone https://github.com/rolecraft-sh/rolecraft.git
 cd rolecraft
 npm install              # also installs the pre-commit hook automatically
 npm link                 # now `rolecraft` runs from your local checkout
-npm test                 # 1007+ tests should pass
+npm test                 # 1012+ tests should pass
 ```
 
 **Requirements:** Node.js >= 20. Dev dependencies (Biome, VitePress) install locally but never ship to users — the runtime stays zero-dependency.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ git clone https://github.com/rolecraft-sh/rolecraft.git
 cd rolecraft
 npm install              # also installs the pre-commit hook automatically
 npm link                 # now `rolecraft` runs from your local checkout
-npm test                 # 1004+ tests should pass
+npm test                 # 1007+ tests should pass
 ```
 
 **Requirements:** Node.js >= 20. Dev dependencies (Biome, VitePress) install locally but never ship to users — the runtime stays zero-dependency.

--- a/MANIFEST-MATRIX.md
+++ b/MANIFEST-MATRIX.md
@@ -36,8 +36,8 @@ manifest and run the script — it updates every location automatically.
 | agent_count | apps.json:18 | 87 |
 | agent_count | apps.json:19 | 87 |
 | agent_count | apps.json:40 | 87 |
-| unpacked_size | benchmark/RESULTS.md:42 | 397.4 kB |
-| test_count | CONTRIBUTING.md:12 | 1004 |
+| unpacked_size | benchmark/RESULTS.md:42 | 396.0 kB |
+| test_count | CONTRIBUTING.md:12 | 1007 |
 | agent_count | docs/agents.md:99 | 87 |
 | agent_count | docs/commands/agents.md:47 | 87 |
 | agent_count | docs/commands/agents.md:71 | 87 |
@@ -45,27 +45,27 @@ manifest and run the script — it updates every location automatically.
 | agent_count | docs/commands/doctor.md:25 | 87 |
 | agent_count | docs/commands/doctor.md:60 | 87 |
 | agent_count | docs/commands/doctor.md:77 | 87 |
-| unpacked_size | docs/comparison.md:10 | 397.4 kB |
+| unpacked_size | docs/comparison.md:10 | 396.0 kB |
 | agent_count | docs/comparison.md:11 | 87 |
 | agent_count | docs/guides/getting-started.md:18 | 87 |
 | verified_count | docs/guides/getting-started.md:18 | 27 |
 | agent_count | docs/index.md:7 | 87 |
 | verified_count | docs/index.md:7 | 27 |
-| unpacked_size | docs/index.md:26 | 397.4 kB |
+| unpacked_size | docs/index.md:26 | 396.0 kB |
 | agent_count | docs/index.md:38 | 87 |
 | verified_count | docs/index.md:38 | 27 |
-| unpacked_size | docs/migration-from-skills.md:10 | 397.4 kB |
+| unpacked_size | docs/migration-from-skills.md:10 | 396.0 kB |
 | agent_count | docs/migration-from-skills.md:11 | 87 |
 | agent_count | docs/migration-from-skills.md:55 | 87 |
 | agent_count | docs/reference.md:161 | 87 |
 | agent_count | package.json:4 | 87 |
 | agent_count | README.md:9 | 87 |
 | verified_count | README.md:9 | 27 |
-| unpacked_size | README.md:54 | 397.4 kB |
+| unpacked_size | README.md:54 | 396.0 kB |
 | verified_count | README.md:54 | 27 |
-| unpacked_size | README.md:88 | 397.4 kB |
+| unpacked_size | README.md:88 | 396.0 kB |
 | agent_count | README.md:90 | 87 |
-| test_count | README.md:162 | 1004 |
+| test_count | README.md:162 | 1007 |
 | agent_count | SKILL.md:5 | 87 |
 | verified_count | SKILL.md:5 | 27 |
 | agent_count | SKILL.md:10 | 87 |

--- a/MANIFEST-MATRIX.md
+++ b/MANIFEST-MATRIX.md
@@ -37,7 +37,7 @@ manifest and run the script — it updates every location automatically.
 | agent_count | apps.json:19 | 87 |
 | agent_count | apps.json:40 | 87 |
 | unpacked_size | benchmark/RESULTS.md:42 | 396.0 kB |
-| test_count | CONTRIBUTING.md:12 | 1007 |
+| test_count | CONTRIBUTING.md:12 | 1012 |
 | agent_count | docs/agents.md:99 | 87 |
 | agent_count | docs/commands/agents.md:47 | 87 |
 | agent_count | docs/commands/agents.md:71 | 87 |
@@ -65,7 +65,7 @@ manifest and run the script — it updates every location automatically.
 | verified_count | README.md:54 | 27 |
 | unpacked_size | README.md:88 | 396.0 kB |
 | agent_count | README.md:90 | 87 |
-| test_count | README.md:162 | 1007 |
+| test_count | README.md:162 | 1012 |
 | agent_count | SKILL.md:5 | 87 |
 | verified_count | SKILL.md:5 | 27 |
 | agent_count | SKILL.md:10 | 87 |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 
 <p align="center">
-  <b>⚡ Zero dependencies</b> · <b>📦 397.4 kB</b> · <b>🤖 27 verified agents</b> · <b>🔌 Skills + MCP</b> · <b>🔒 Security scoring</b> · <b>📝 Skill testing</b> · <b>🔧 Init templates</b> · <b>🌐 Offline-first</b>
+  <b>⚡ Zero dependencies</b> · <b>📦 396.0 kB</b> · <b>🤖 27 verified agents</b> · <b>🔌 Skills + MCP</b> · <b>🔒 Security scoring</b> · <b>📝 Skill testing</b> · <b>🔧 Init templates</b> · <b>🌐 Offline-first</b>
 </p>
 
 ---
@@ -85,7 +85,7 @@ rolecraft setup user/repo
 
 ## Features
 
-- **Zero dependencies** — 397.4 kB, only Node.js built-ins
+- **Zero dependencies** — 396.0 kB, only Node.js built-ins
 - **Any source** — local folder, GitHub/GitLab/SSH URL, npm package
 - **87 agents** — opencode, claude-code, cursor, copilot, aider, oh-my-pi, and more
 - **No registry required** — works fully without a marketplace; community-driven [registry](https://github.com/rolecraft-sh/registry) optional
@@ -159,7 +159,7 @@ git clone https://github.com/rolecraft-sh/rolecraft.git && cd rolecraft
 npm install                # sets up the pre-commit hook automatically
 npm link                   # rolecraft CLI runs from local checkout
 npm run lint               # syntax + Biome checks
-npm test                   # 1004+ tests, 0 fails expected
+npm test                   # 1007+ tests, 0 fails expected
 ```
 
 A `pre-commit` hook runs lint automatically on every commit. Zero-runtime-dependency policy is preserved — Biome and VitePress are devDependencies only.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ git clone https://github.com/rolecraft-sh/rolecraft.git && cd rolecraft
 npm install                # sets up the pre-commit hook automatically
 npm link                   # rolecraft CLI runs from local checkout
 npm run lint               # syntax + Biome checks
-npm test                   # 1007+ tests, 0 fails expected
+npm test                   # 1012+ tests, 0 fails expected
 ```
 
 A `pre-commit` hook runs lint automatically on every commit. Zero-runtime-dependency policy is preserved — Biome and VitePress are devDependencies only.

--- a/benchmark/RESULTS.md
+++ b/benchmark/RESULTS.md
@@ -39,4 +39,4 @@
 | Local skill install  | ✅ **10.23 ms**   | ✅ 3894 ms (381x slower)  | ❌ not supported   |
 | GitHub skill install | ✅ **1.6 s**      | ✅ 10.9 s (6.9x slower)   | ❌ fails (bug)     |
 | Zero dependencies    | ✅ **0**          | ❌ 1 dep                  | ❌ 2 deps          |
-| Package size         | **397.4 kB**      | ~465 KB                   | ~84 KB             |
+| Package size         | **396.0 kB**      | ~465 KB                   | ~84 KB             |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -7,7 +7,7 @@
 | | rolecraft | skills (Vercel) | @agentskill.sh/cli |
 |---|---|---|---|
 | **Runtime** | Zero-dep Node ESM | 1 dep (Node) | 2 deps (TypeScript) |
-| **File size** | 397.4 kB | ~465 KB | ~84 KB |
+| **File size** | 396.0 kB | ~465 KB | ~84 KB |
 | **Agent targets** | **87** | 72 | 15+ |
 | **Skill marketplace** | rolecraft registry | skills.sh (90K+) | agentskill.sh (100K+) |
 | **Publish your own** | ✅ | ❌ | ❌ |

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
   - title: One-Command Onboarding
     details: "rolecraft setup <source> detects all AI agents and installs skills + MCP servers to every one of them."
   - title: Zero Dependencies
-    details: 397.4 kB, no bloat. Only Node.js built-ins.
+    details: 396.0 kB, no bloat. Only Node.js built-ins.
   - title: MCP + Skills in One Command
     details: Install skills and their MCP servers together. No other CLI tool combines both.
   - title: Rollback

--- a/docs/migration-from-skills.md
+++ b/docs/migration-from-skills.md
@@ -7,7 +7,7 @@ If you're using [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) a
 | Reason | rolecraft | Vercel skills |
 |---|---|---|
 | Dependencies | **0** (zero-dep) | 1 (`supports-color`) |
-| Package size | **397.4 kB** | ~465 KB |
+| Package size | **396.0 kB** | ~465 KB |
 | Agent targets | **87** | 72 |
 | Telemetry | **None** | Anonymous telemetry |
 | Offline installs | **Fully supported** | Requires network |

--- a/src/api/bundle-internal.js
+++ b/src/api/bundle-internal.js
@@ -72,8 +72,8 @@ export async function installBundleSources(
   const results = []
   const installOpts = {
     scope: { global: true, project: true },
-    yes: options.yes || false,
-    noMcp: options.noMcp || false,
+    yes: options.yes ?? false,
+    noMcp: options.noMcp ?? false,
   }
   let installed = 0
   let failed = 0

--- a/src/api/bundle-internal.js
+++ b/src/api/bundle-internal.js
@@ -1,0 +1,93 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { apiInstallSkills } from './install.js'
+import { expandTilde } from '../utils/paths.js'
+
+function parseSources(raw, filePath) {
+  if (filePath.endsWith('.json')) {
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) return parsed
+    if (parsed.skills && Array.isArray(parsed.skills)) return parsed.skills
+    throw new Error(
+      'JSON bundle must be an array of sources or an object with a "skills" array',
+    )
+  }
+
+  return raw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#'))
+}
+
+async function resolveBundleFile(arg) {
+  const isFilePath =
+    arg.endsWith('.json') ||
+    arg.endsWith('.txt') ||
+    arg.startsWith('./') ||
+    arg.startsWith('../') ||
+    arg.startsWith('/') ||
+    arg.startsWith('~')
+  if (isFilePath) {
+    const resolvedPath = expandTilde(arg, process.env.HOME || '/tmp')
+    for (const candidate of [resolvedPath, join(process.cwd(), arg)]) {
+      try {
+        await readFile(candidate, 'utf-8')
+        return candidate
+      } catch {}
+    }
+    throw new Error(`Bundle file not found: ${arg}`)
+  }
+
+  const candidates = [
+    arg,
+    join(process.cwd(), arg),
+    `${arg}.json`,
+    `${arg}.txt`,
+    join(process.cwd(), `${arg}.json`),
+    join(process.cwd(), `${arg}.txt`),
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      await readFile(candidate, 'utf-8')
+      return candidate
+    } catch {}
+  }
+  return null
+}
+
+export async function loadBundleSources(sources) {
+  if (typeof sources !== 'string') return { sources, filePath: null }
+  const filePath = await resolveBundleFile(sources)
+  if (!filePath) return { sources: [sources], filePath: null }
+  const raw = await readFile(filePath, 'utf-8')
+  return { sources: parseSources(raw, filePath), filePath }
+}
+
+export async function installBundleSources(
+  sources,
+  options = {},
+  callbacks = {},
+) {
+  const results = []
+  const installOpts = {
+    scope: { global: true, project: true },
+    yes: options.yes || false,
+    noMcp: options.noMcp || false,
+  }
+  let installed = 0
+  let failed = 0
+  for (const [index, source] of sources.entries()) {
+    callbacks.onStart?.(source, index)
+    try {
+      const details = await apiInstallSkills(source, installOpts)
+      installed++
+      results.push({ source, status: 'ok', details })
+    } catch (error) {
+      failed++
+      results.push({ source, status: 'failed', error: error?.message })
+      callbacks.onError?.(source, error)
+    }
+  }
+  return { installed, failed, results }
+}

--- a/src/api/bundle-internal.test.js
+++ b/src/api/bundle-internal.test.js
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadBundleSources, installBundleSources } from './bundle-internal.js'
+
+describe('installBundleSources', () => {
+  it('calls onStart callback for each source', async () => {
+    const sources = ['owner/one', 'owner/two', 'owner/three']
+    const started = []
+
+    await installBundleSources(
+      sources,
+      {},
+      {
+        onStart: (source, index) => started.push({ source, index }),
+      },
+    )
+
+    assert.equal(started.length, 3)
+    assert.deepEqual(started[0], { source: 'owner/one', index: 0 })
+    assert.deepEqual(started[1], { source: 'owner/two', index: 1 })
+    assert.deepEqual(started[2], { source: 'owner/three', index: 2 })
+  })
+
+  it('calls onError callback when install fails', async () => {
+    const sources = ['owner/fail1', 'owner/fail2']
+    const errors = []
+
+    const result = await installBundleSources(
+      sources,
+      {},
+      {
+        onError: (source, error) => errors.push({ source, error }),
+      },
+    )
+
+    assert.equal(result.installed, 0)
+    assert.equal(result.failed, 2)
+    assert.equal(errors.length, 2)
+    assert.equal(errors[0].source, 'owner/fail1')
+    assert.ok(errors[0].error instanceof Error)
+    assert.equal(errors[1].source, 'owner/fail2')
+  })
+
+  it('passes yes and noMcp options to install', async () => {
+    const sources = ['owner/fail']
+
+    const result = await installBundleSources(
+      sources,
+      { yes: true, noMcp: true },
+      {},
+    )
+
+    assert.equal(result.results.length, 1)
+    assert.equal(result.results[0].status, 'failed')
+  })
+})
+
+describe('loadBundleSources', () => {
+  it('returns array sources directly', async () => {
+    const result = await loadBundleSources(['owner/one', 'owner/two'])
+    assert.deepEqual(result, {
+      sources: ['owner/one', 'owner/two'],
+      filePath: null,
+    })
+  })
+
+  it('wraps bare string as single-element array', async () => {
+    const result = await loadBundleSources('owner/one')
+    assert.deepEqual(result, {
+      sources: ['owner/one'],
+      filePath: null,
+    })
+  })
+})

--- a/src/api/bundle.js
+++ b/src/api/bundle.js
@@ -1,106 +1,12 @@
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import { apiInstallSkills } from './install.js'
-import { expandTilde } from '../utils/paths.js'
-
-function parseSources(raw, filePath) {
-  if (filePath.endsWith('.json')) {
-    const parsed = JSON.parse(raw)
-    if (Array.isArray(parsed)) return parsed
-    if (parsed.skills && Array.isArray(parsed.skills)) return parsed.skills
-    throw new Error(
-      'JSON bundle must be an array of sources or an object with a "skills" array',
-    )
-  }
-
-  return raw
-    .split('\n')
-    .map((l) => l.trim())
-    .filter((l) => l && !l.startsWith('#'))
-}
-
-async function resolveBundleFile(arg) {
-  const isFilePath =
-    arg.endsWith('.json') ||
-    arg.endsWith('.txt') ||
-    arg.startsWith('./') ||
-    arg.startsWith('../') ||
-    arg.startsWith('/') ||
-    arg.startsWith('~')
-  if (isFilePath) {
-    const resolvedPath = expandTilde(arg, process.env.HOME || '/tmp')
-    for (const candidate of [resolvedPath, join(process.cwd(), arg)]) {
-      try {
-        await readFile(candidate, 'utf-8')
-        return candidate
-      } catch {}
-    }
-    throw new Error(`Bundle file not found: ${arg}`)
-  }
-
-  const candidates = [
-    arg,
-    join(process.cwd(), arg),
-    `${arg}.json`,
-    `${arg}.txt`,
-    join(process.cwd(), `${arg}.json`),
-    join(process.cwd(), `${arg}.txt`),
-  ]
-
-  for (const candidate of candidates) {
-    try {
-      await readFile(candidate, 'utf-8')
-      return candidate
-    } catch {}
-  }
-  return null
-}
+import { loadBundleSources, installBundleSources } from './bundle-internal.js'
 
 export async function bundleApi(sources, options = {}) {
-  let skillSources
-
-  if (typeof sources === 'string') {
-    const filePath = await resolveBundleFile(sources)
-    if (filePath) {
-      const raw = await readFile(filePath, 'utf-8')
-      skillSources = parseSources(raw, filePath)
-    } else {
-      skillSources = [sources]
-    }
-  } else {
-    skillSources = sources
-  }
-
+  const { sources: skillSources } = await loadBundleSources(sources)
   if (skillSources.length === 0) {
     return { installed: 0, failed: 0, results: [] }
   }
-
-  const dryRun = options.dryRun || false
-
-  if (dryRun) {
+  if (options.dryRun) {
     return { dryRun: true, skills: skillSources }
   }
-
-  const results = []
-  let successCount = 0
-  let failCount = 0
-
-  const installOpts = {
-    scope: { global: true, project: true },
-    yes: options.yes || false,
-    noMcp: options.noMcp || false,
-  }
-
-  for (const source of skillSources) {
-    try {
-      const result = await apiInstallSkills(source, installOpts)
-      successCount++
-      results.push({ source, status: 'ok', details: result })
-    } catch (err) {
-      failCount++
-      results.push({ source, status: 'failed', error: err.message })
-    }
-  }
-
-  return { installed: successCount, failed: failCount, results }
+  return installBundleSources(skillSources, options)
 }

--- a/src/api/bundle.test.js
+++ b/src/api/bundle.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { bundleApi } from './bundle.js'
+
+// Dry runs exercise the API's input formats without installing any skills.
+describe('bundle API', () => {
+  it('preserves dry-run results for inline sources', async () => {
+    assert.deepEqual(
+      await bundleApi(['owner/one', 'owner/two'], { dryRun: true }),
+      {
+        dryRun: true,
+        skills: ['owner/one', 'owner/two'],
+      },
+    )
+    assert.deepEqual(await bundleApi('owner/one', { dryRun: true }), {
+      dryRun: true,
+      skills: ['owner/one'],
+    })
+    assert.deepEqual(await bundleApi([], { dryRun: true }), {
+      installed: 0,
+      failed: 0,
+      results: [],
+    })
+  })
+
+  it('accepts JSON arrays, JSON objects, and commented text bundles', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'rolecraft-bundle-api-'))
+    try {
+      for (const [name, content] of [
+        ['array.json', '["owner/one","owner/two"]'],
+        ['object.json', '{"skills":["owner/one","owner/two"]}'],
+        ['list.txt', '# comment\n owner/one \n\nowner/two\n'],
+      ]) {
+        const file = join(directory, name)
+        await writeFile(file, content)
+        assert.deepEqual(await bundleApi(file, { dryRun: true }), {
+          dryRun: true,
+          skills: ['owner/one', 'owner/two'],
+        })
+      }
+      const invalidFile = join(directory, 'invalid.json')
+      await writeFile(invalidFile, '{"name":"missing skills"}')
+      await assert.rejects(bundleApi(invalidFile), /JSON bundle must/)
+      await assert.rejects(
+        bundleApi(join(directory, 'missing.json')),
+        /Bundle file not found/,
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -1,9 +1,11 @@
-import { readFile, writeFile } from 'node:fs/promises'
+import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { createInterface } from 'node:readline'
 import { stdin as input, stdout as output } from 'node:process'
-import { apiInstallSkills } from '../api/install.js'
-import { expandTilde } from '../utils/paths.js'
+import {
+  loadBundleSources,
+  installBundleSources,
+} from '../api/bundle-internal.js'
 
 function askQuestion(query) {
   const rl = createInterface({ input, output })
@@ -13,59 +15,6 @@ function askQuestion(query) {
       resolve(answer.trim())
     })
   })
-}
-
-function parseSources(raw, filePath) {
-  if (filePath.endsWith('.json')) {
-    const parsed = JSON.parse(raw)
-    if (Array.isArray(parsed)) return parsed
-    if (parsed.skills && Array.isArray(parsed.skills)) return parsed.skills
-    throw new Error(
-      'JSON bundle must be an array of sources or an object with a "skills" array',
-    )
-  }
-
-  return raw
-    .split('\n')
-    .map((l) => l.trim())
-    .filter((l) => l && !l.startsWith('#'))
-}
-
-async function resolveBundleFile(arg) {
-  const isFilePath =
-    arg.endsWith('.json') ||
-    arg.endsWith('.txt') ||
-    arg.startsWith('./') ||
-    arg.startsWith('../') ||
-    arg.startsWith('/') ||
-    arg.startsWith('~')
-  if (isFilePath) {
-    const resolvedPath = expandTilde(arg, process.env.HOME || '/tmp')
-    for (const candidate of [resolvedPath, join(process.cwd(), arg)]) {
-      try {
-        await readFile(candidate, 'utf-8')
-        return candidate
-      } catch {}
-    }
-    throw new Error(`Bundle file not found: ${arg}`)
-  }
-
-  const candidates = [
-    arg,
-    join(process.cwd(), arg),
-    `${arg}.json`,
-    `${arg}.txt`,
-    join(process.cwd(), `${arg}.json`),
-    join(process.cwd(), `${arg}.txt`),
-  ]
-
-  for (const candidate of candidates) {
-    try {
-      await readFile(candidate, 'utf-8')
-      return candidate
-    } catch {}
-  }
-  return null
 }
 
 async function installSources(sources, label, options, noMcp = false) {
@@ -78,36 +27,23 @@ async function installSources(sources, label, options, noMcp = false) {
     `\n📦 Installing ${sources.length} skill(s)${label}:${label ? '\n' : ''}`,
   )
 
-  let successCount = 0
-  let failCount = 0
-
-  for (let i = 0; i < sources.length; i++) {
-    const source = sources[i]
-
-    if (options.dryRun) {
-      console.log(`   • ${source}`)
-      continue
-    }
-
-    console.log('   [%s/%s] %s', i + 1, sources.length, source)
-
-    try {
-      await apiInstallSkills(source, {
-        scope: { global: true, project: true },
-        yes: true,
-        noMcp: noMcp,
-      })
-      successCount++
-    } catch (err) {
-      console.error('   ❌ %s: %s', source, err?.message)
-      failCount++
-    }
-  }
-
   if (options.dryRun) {
+    for (const source of sources) console.log(`   • ${source}`)
     console.log(`\n📋 [dry-run] Would install ${sources.length} skill(s).\n`)
     return
   }
+
+  const { installed: successCount, failed: failCount } =
+    await installBundleSources(
+      sources,
+      { yes: true, noMcp },
+      {
+        onStart: (source, index) =>
+          console.log('   [%s/%s] %s', index + 1, sources.length, source),
+        onError: (source, error) =>
+          console.error('   ❌ %s: %s', source, error?.message),
+      },
+    )
 
   console.log()
 
@@ -159,17 +95,11 @@ export async function bundleCreateCommand(name) {
 }
 
 export async function bundleCommand(sources, options = {}) {
-  if (typeof sources === 'string') {
-    const filePath = await resolveBundleFile(sources)
-    if (filePath) {
-      const raw = await readFile(filePath, 'utf-8')
-      const parsed = parseSources(raw, filePath)
-      await installSources(parsed, ` from ${filePath}`, options, options.noMcp)
-      return
-    }
-    await installSources([sources], '', options, options.noMcp)
-    return
-  }
-
-  await installSources(sources, '', options, options.noMcp)
+  const { sources: parsed, filePath } = await loadBundleSources(sources)
+  await installSources(
+    parsed,
+    filePath ? ` from ${filePath}` : '',
+    options,
+    options.noMcp,
+  )
 }

--- a/src/commands/bundle.test.js
+++ b/src/commands/bundle.test.js
@@ -184,6 +184,28 @@ describe('bundle command', () => {
     )
   })
 
+  it('preserves failure counts and frozen-lockfile exit behavior', async () => {
+    const sources = [join(tempDir, 'missing-one'), join(tempDir, 'missing-two')]
+    const origError = console.error
+    const errors = []
+    console.error = (...args) => errors.push(format(...args))
+    capture()
+    try {
+      await bundleModule.bundleCommand(sources)
+      assert.ok(logs.some((line) => line.includes('0 installed, 2 failed.')))
+      assert.equal(errors.length, 2)
+      assert.ok(errors[0].includes(sources[0]))
+      assert.ok(errors[1].includes(sources[1]))
+      await assert.rejects(
+        bundleModule.bundleCommand(sources, { frozenLockfile: true }),
+        /Some skills failed to install/,
+      )
+    } finally {
+      restoreLog()
+      console.error = origError
+    }
+  })
+
   it('creates a bundle file with a given name', async () => {
     capture()
     await bundleModule.bundleCreateCommand('test-collection')
@@ -241,12 +263,8 @@ describe('bundle command', () => {
     const copyPath = join(tempDir, 'bundle-interactive.mjs')
     let modSrc = readFileSync(join(__dirname, 'bundle.js'), 'utf-8')
     modSrc = modSrc.replace(
-      `import { apiInstallSkills } from '../api/install.js'`,
-      `import { apiInstallSkills } from '${join(__dirname, '../api/install.js')}'`,
-    )
-    modSrc = modSrc.replace(
-      `import { expandTilde } from '../utils/paths.js'`,
-      `import { expandTilde } from '${join(__dirname, '../utils/paths.js')}'`,
+      "'../api/bundle-internal.js'",
+      JSON.stringify(join(__dirname, '../api/bundle-internal.js')),
     )
     modSrc = modSrc.replace(
       `import { createInterface } from 'node:readline'`,
@@ -279,12 +297,8 @@ describe('bundle command', () => {
     const copyPath = join(tempDir, 'bundle-overwrite.mjs')
     let modSrc = readFileSync(join(__dirname, 'bundle.js'), 'utf-8')
     modSrc = modSrc.replace(
-      `import { apiInstallSkills } from '../api/install.js'`,
-      `import { apiInstallSkills } from '${join(__dirname, '../api/install.js')}'`,
-    )
-    modSrc = modSrc.replace(
-      `import { expandTilde } from '../utils/paths.js'`,
-      `import { expandTilde } from '${join(__dirname, '../utils/paths.js')}'`,
+      "'../api/bundle-internal.js'",
+      JSON.stringify(join(__dirname, '../api/bundle-internal.js')),
     )
     modSrc = modSrc.replace(
       `import { createInterface } from 'node:readline'`,
@@ -296,9 +310,8 @@ describe('bundle command', () => {
       ].join('\n'),
     )
     modSrc = modSrc.replace(
-      `import { readFile, writeFile } from 'node:fs/promises'`,
+      `import { writeFile } from 'node:fs/promises'`,
       [
-        `import { readFile } from 'node:fs/promises'`,
         `import { writeFile as _bOrigWf } from 'node:fs/promises'`,
         `let _bWfCalls = 0`,
         `const writeFile = async (...args) => {`,


### PR DESCRIPTION
I shared bundle loading and installation between the API and CLI while preserving their output and return values, with 1,079 tests, lint and a CLI create/dry-run check passing (closes #238).
